### PR TITLE
feat: add scraper plugin system with entry-point discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to PyScrappy are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [1.3.0] - 2026-07-28
+
+### Added
+- **Plugin system.** Scrapers can now be registered and discovered dynamically:
+  - `@register_scraper("name")` decorator and `register(name, cls)` for in-process registration.
+  - `get_scraper(name)` and `list_scrapers()` to resolve and enumerate scrapers.
+  - Automatic discovery of third-party scrapers via the `pyscrappy.scrapers` entry-point group, so an installed `pyscrappy-<name>` package registers itself with no change to PyScrappy core.
+  - `BaseScraper` is now exported from the top-level package.
+- **Plugin scrapers are agent-ready automatically.** The MCP server exposes two new tools, `list_available_scrapers` and `scrape_with(name, args)`, so any registered scraper (built-in or plugin) is callable by an AI agent and by `pyscrappy chat` without dedicated MCP glue.
+- A copyable [`plugin-template/`](plugin-template/) starting point and a plugin authoring guide.
+
+### Changed
+- Built-in scrapers are now registered in the shared registry, so the Python API, MCP server, and agent all resolve scrapers through one path.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,45 @@ Every scraper that works without a proxy is also exposed as an [MCP tool](#mcp-s
 | `ZomatoScraper` | Restaurant listings by city | Recommended | `scrape_zomato` |
 | `UberEatsScraper` | Restaurants by city + full menus (any Uber Eats country) | No | `search_ubereats`, `get_ubereats_menu` |
 
+## Plugins
+
+PyScrappy is extensible: you can add your own scrapers, and third parties can
+ship them as standalone `pyscrappy-<name>` packages. A registered scraper works
+everywhere a built-in does, including the MCP server and the `pyscrappy chat`
+agent, with no change to PyScrappy core.
+
+**In your own code** — register with the decorator:
+
+```python
+from pyscrappy import BaseScraper, register_scraper, get_scraper
+from pyscrappy.core.models import ScrapeResult, ScrapeMetadata
+
+@register_scraper("reddit")
+class RedditScraper(BaseScraper):
+    def scrape(self, subreddit: str, **kwargs) -> ScrapeResult:
+        data = self.fetch_and_parse(f"https://old.reddit.com/r/{subreddit}/.json")
+        # ... build a list of dicts ...
+        return ScrapeResult(data=[...], metadata=ScrapeMetadata(scraper="reddit"))
+
+get_scraper("reddit")().scrape(subreddit="python")
+```
+
+**As a distributable package** — advertise an entry point in your
+`pyproject.toml`, and PyScrappy discovers it once your package is installed:
+
+```toml
+[project.entry-points."pyscrappy.scrapers"]
+reddit = "pyscrappy_reddit:RedditScraper"
+```
+
+After `pip install pyscrappy-reddit`, the scraper shows up in
+`list_scrapers()`, and an AI agent can call it via the `scrape_with` MCP tool —
+no core change required.
+
+See the [plugin template](plugin-template/) for a complete, copyable starting
+point, and the [plugin guide](https://pyscrappy.vercel.app/docs/plugins/) for
+the full walkthrough.
+
 ## Quick start
 
 ### Scrape any URL → clean, LLM-ready Markdown

--- a/plugin-template/README.md
+++ b/plugin-template/README.md
@@ -1,0 +1,53 @@
+# PyScrappy plugin template
+
+A minimal, copyable starting point for a PyScrappy scraper plugin. Once
+installed, your scraper is available through PyScrappy's Python API, its MCP
+server, and the `pyscrappy chat` agent — with no change to PyScrappy core.
+
+## Use it
+
+1. Copy this directory and rename it to your plugin, e.g. `pyscrappy-reddit`.
+2. Rename the package folder `pyscrappy_example/` → `pyscrappy_reddit/`.
+3. In `pyproject.toml`, update `name`, the `[tool.hatch.build...]` package, and
+   the entry point:
+
+   ```toml
+   [project.entry-points."pyscrappy.scrapers"]
+   reddit = "pyscrappy_reddit:RedditScraper"
+   ```
+
+4. Implement your scraper in the package's `__init__.py` (subclass
+   `BaseScraper`, set `name`, implement `scrape`).
+5. Install and test:
+
+   ```bash
+   pip install -e .
+   pytest
+   ```
+
+## How discovery works
+
+The `[project.entry-points."pyscrappy.scrapers"]` table is what PyScrappy reads.
+The key (`example`) is the name used with `get_scraper("example")` and the
+`scrape_with` MCP tool; the value points at your class. Nothing else is needed —
+PyScrappy discovers installed plugins automatically.
+
+## Using your scraper
+
+```python
+from pyscrappy import get_scraper
+
+with get_scraper("example")() as s:
+    result = s.scrape(url="https://example.com")
+    print(result.to_markdown())
+```
+
+From an AI agent (once PyScrappy's MCP server is running): the agent calls
+`list_available_scrapers`, sees `example`, and runs it via
+`scrape_with(name="example", args={"url": "..."})`.
+
+## Publishing
+
+Build and publish like any Python package (`uv build` / `python -m build`, then
+`twine upload`). Name it `pyscrappy-<thing>` so users can find it. Once it's on
+PyPI, `pip install pyscrappy-<thing>` is all anyone needs.

--- a/plugin-template/pyproject.toml
+++ b/plugin-template/pyproject.toml
@@ -1,0 +1,32 @@
+# PyScrappy plugin template.
+#
+# Copy this directory, rename it, and change:
+#   1. `name` below (PyPI package name, conventionally `pyscrappy-<thing>`)
+#   2. the package directory `pyscrappy_example/` -> `pyscrappy_<thing>/`
+#   3. the entry point at the bottom to point at your scraper class
+#
+# Then `pip install -e .` and your scraper is discoverable by PyScrappy.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyscrappy-example"
+version = "0.1.0"
+description = "An example PyScrappy scraper plugin"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+dependencies = [
+    "pyscrappy>=1.3.0",
+]
+
+# This is what makes PyScrappy discover your scraper. The key ("example") is the
+# name used with `get_scraper(...)` and the `scrape_with` MCP tool; the value is
+# `<import path>:<ClassName>`.
+[project.entry-points."pyscrappy.scrapers"]
+example = "pyscrappy_example:ExampleScraper"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pyscrappy_example"]

--- a/plugin-template/pyscrappy_example/__init__.py
+++ b/plugin-template/pyscrappy_example/__init__.py
@@ -1,0 +1,39 @@
+"""An example PyScrappy scraper plugin.
+
+Rename this package to `pyscrappy_<thing>` and adapt `ExampleScraper` to your
+source. Everything a built-in scraper can do is available here via `BaseScraper`:
+``self.fetch_html``, ``self.fetch_and_parse``, ``self.http``, ``self.browser``,
+retries, rate limiting, proxies, and caching (all driven by ``self.config``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyscrappy import BaseScraper
+from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+
+
+class ExampleScraper(BaseScraper):
+    """Scrape example.com and return its title and first paragraph.
+
+    Replace this with your own logic. The only contract is: implement
+    ``scrape`` and return a ``ScrapeResult`` whose ``data`` is a list of dicts.
+    """
+
+    name = "example"
+
+    def scrape(self, url: str = "https://example.com", **kwargs: Any) -> ScrapeResult:
+        soup = self.fetch_and_parse(url)
+
+        title = soup.title.string.strip() if soup.title and soup.title.string else ""
+        first_p = soup.find("p")
+        paragraph = first_p.get_text(strip=True) if first_p else ""
+
+        return ScrapeResult(
+            data=[{"url": url, "title": title, "paragraph": paragraph}],
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+        )
+
+
+__all__ = ["ExampleScraper"]

--- a/plugin-template/tests/test_example.py
+++ b/plugin-template/tests/test_example.py
@@ -1,0 +1,21 @@
+"""Test that the plugin is registered and usable through PyScrappy.
+
+Run with `pytest` after `pip install -e .`.
+"""
+
+from pyscrappy import get_scraper, list_scrapers
+
+from pyscrappy_example import ExampleScraper
+
+
+def test_plugin_is_discovered():
+    # After install, PyScrappy finds the scraper via the entry point.
+    assert "example" in list_scrapers()
+    assert get_scraper("example") is ExampleScraper
+
+
+def test_scrape_returns_result():
+    result = ExampleScraper().scrape()
+    assert result.data
+    assert "title" in result.data[0]
+    assert result.metadata.scraper == "example"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.2.2"
+version = "1.3.0"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.2.2",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -36,7 +36,14 @@ from pyscrappy.core.exceptions import (
     ScraperTimeoutError,
     SelectorError,
 )
+from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.models import ScrapeResult
+from pyscrappy.registry import (
+    get_scraper,
+    list_scrapers,
+    register,
+    register_scraper,
+)
 from pyscrappy.generic.scraper import GenericScraper
 from pyscrappy.scrapers.amazon import AmazonScraper
 from pyscrappy.scrapers.crypto import CryptoScraper
@@ -62,7 +69,39 @@ from pyscrappy.scrapers.wikipedia import WikipediaScraper
 from pyscrappy.scrapers.youtube import YouTubeScraper
 from pyscrappy.scrapers.zomato import ZomatoScraper
 
-__version__ = "1.2.2"
+# Register built-in scrapers so they sit in the same registry as plugins and are
+# exposed uniformly to the API, MCP server, and agent. Keyed by each class's
+# `name` attribute.
+for _cls in (
+    GenericScraper,
+    AmazonScraper,
+    CryptoScraper,
+    CurrencyScraper,
+    DictionaryScraper,
+    GitHubScraper,
+    HackerNewsScraper,
+    IKEAScraper,
+    ImageSearchScraper,
+    IMDBScraper,
+    InstagramScraper,
+    LinkedInJobsScraper,
+    NeweggScraper,
+    NewsScraper,
+    OpenLibraryScraper,
+    SoundCloudScraper,
+    SpotifyScraper,
+    StockScraper,
+    UberEatsScraper,
+    TwitterScraper,
+    WeatherScraper,
+    WikipediaScraper,
+    YouTubeScraper,
+    ZomatoScraper,
+):
+    register(_cls.name, _cls)
+del _cls
+
+__version__ = "1.3.0"
 
 __all__ = [
     # Core
@@ -109,6 +148,12 @@ __all__ = [
     "scrape",
     "scrape_many",
     "scrape_all",
+    # Plugins / registry
+    "BaseScraper",
+    "register_scraper",
+    "register",
+    "get_scraper",
+    "list_scrapers",
 ]
 
 

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -470,6 +470,41 @@ async def scrape_zomato(
         )
 
 
+@mcp.tool()
+async def list_available_scrapers() -> dict[str, list[str]]:
+    """List every scraper available to this server, including installed plugins.
+
+    Third-party `pyscrappy-*` plugin packages register scrapers that show up here
+    automatically. Use a returned name with `scrape_with`.
+    """
+    from pyscrappy import list_scrapers
+
+    return {"scrapers": sorted(list_scrapers())}
+
+
+@mcp.tool()
+async def scrape_with(name: str, args: dict[str, Any] | None = None) -> ScrapeToolResult:
+    """Run any registered scraper by name, including plugins, with arbitrary args.
+
+    This is the generic entry point for scrapers that don't have a dedicated tool
+    of their own — notably third-party plugins. Call `list_available_scrapers`
+    first to see valid names.
+
+    Args:
+        name: A scraper name from `list_available_scrapers`, e.g. "wikipedia".
+        args: Keyword arguments passed to that scraper's `scrape()` method.
+    """
+    from pyscrappy import get_scraper
+
+    try:
+        scraper_cls = get_scraper(name)
+    except KeyError as exc:
+        raise ValueError(str(exc)) from None
+
+    with scraper_cls(_config()) as scraper:
+        return await _run(scraper.scrape, **(args or {}))
+
+
 def main() -> None:
     """Console-script entry point.
 

--- a/src/pyscrappy/registry.py
+++ b/src/pyscrappy/registry.py
@@ -1,0 +1,111 @@
+"""Scraper registry and plugin discovery.
+
+PyScrappy scrapers can come from three places, all landing in one registry:
+
+1. Built-in scrapers shipped in this package.
+2. Third-party packages that declare a ``pyscrappy.scrapers`` entry point.
+3. In-process registration via the :func:`register_scraper` decorator.
+
+External packages register a scraper by adding to their ``pyproject.toml``::
+
+    [project.entry-points."pyscrappy.scrapers"]
+    reddit = "pyscrappy_reddit:RedditScraper"
+
+Once the package is installed, ``get_scraper("reddit")`` resolves it and the MCP
+server / ``pyscrappy chat`` agent expose it as a tool automatically — no change
+to PyScrappy core required.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+if TYPE_CHECKING:
+    from pyscrappy.core.base import BaseScraper
+
+ENTRY_POINT_GROUP = "pyscrappy.scrapers"
+
+_S = TypeVar("_S", bound="type[BaseScraper]")
+
+# name -> scraper class. Populated lazily: entry points are discovered on first
+# access so importing pyscrappy stays fast.
+_registry: dict[str, type[BaseScraper]] = {}
+_entry_points_loaded = False
+
+
+def register_scraper(name: str) -> Callable[[_S], _S]:
+    """Register a scraper class under ``name``.
+
+    Usage::
+
+        from pyscrappy import BaseScraper, register_scraper
+
+        @register_scraper("reddit")
+        class RedditScraper(BaseScraper):
+            name = "reddit"
+            def scrape(self, **kwargs): ...
+
+    The decorator sets ``cls.name`` if it isn't already set, so the class attr
+    and the registry key stay in sync.
+    """
+
+    def decorator(cls: _S) -> _S:
+        if not getattr(cls, "name", None) or cls.name == "base":
+            cls.name = name
+        _registry[name] = cls
+        return cls
+
+    return decorator
+
+
+def register(name: str, cls: type[BaseScraper]) -> None:
+    """Register a scraper class imperatively (non-decorator form)."""
+    _registry[name] = cls
+
+
+def _load_entry_points() -> None:
+    """Discover scrapers advertised by installed packages via entry points."""
+    global _entry_points_loaded
+    if _entry_points_loaded:
+        return
+    _entry_points_loaded = True
+
+    from importlib import metadata
+
+    # The entry_points() API changed in 3.10; support both.
+    if sys.version_info >= (3, 10):
+        eps = metadata.entry_points(group=ENTRY_POINT_GROUP)
+    else:  # pragma: no cover - exercised only on 3.9
+        eps = metadata.entry_points().get(ENTRY_POINT_GROUP, [])
+
+    for ep in eps:
+        # A broken third-party plugin must not take down the whole registry.
+        try:
+            cls = ep.load()
+        except Exception:  # noqa: BLE001 - defensive: skip unloadable plugins
+            continue
+        # Don't let a plugin clobber a name already registered in-process.
+        _registry.setdefault(ep.name, cls)
+
+
+def get_scraper(name: str) -> type[BaseScraper]:
+    """Return the scraper class registered under ``name``.
+
+    Raises:
+        KeyError: if no scraper is registered under that name.
+    """
+    _load_entry_points()
+    try:
+        return _registry[name]
+    except KeyError:
+        raise KeyError(
+            f"No scraper registered under {name!r}. "
+            f"Available: {', '.join(sorted(_registry)) or '(none)'}"
+        ) from None
+
+
+def list_scrapers() -> dict[str, type[BaseScraper]]:
+    """Return a copy of the full registry (built-ins + plugins), name -> class."""
+    _load_entry_points()
+    return dict(_registry)

--- a/tests/test_mcp/test_agent.py
+++ b/tests/test_mcp/test_agent.py
@@ -15,7 +15,8 @@ from pyscrappy.mcp import agent
 @pytest.mark.anyio
 async def test_tool_specs_wrap_mcp_tools():
     specs = await agent._tool_specs()
-    assert len(specs) == 22
+    # At least the core scraper tools plus the generic plugin dispatch tools.
+    assert len(specs) >= 22
     spec = specs[0]
     assert spec["type"] == "function"
     fn = spec["function"]
@@ -24,6 +25,8 @@ async def test_tool_specs_wrap_mcp_tools():
     assert "parameters" in fn and fn["parameters"]["type"] == "object"
     names = {s["function"]["name"] for s in specs}
     assert {"scrape_url", "scrape_stock", "define_word"} <= names
+    # Plugin-aware dispatch tools are exposed to the agent too.
+    assert {"scrape_with", "list_available_scrapers"} <= names
 
 
 def _mock_ollama(monkeypatch, responses):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,112 @@
+"""Tests for the scraper registry and plugin discovery."""
+
+import pytest
+
+import pyscrappy
+from pyscrappy import BaseScraper, get_scraper, list_scrapers, register, register_scraper
+from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+from pyscrappy import registry
+
+
+class _Dummy(BaseScraper):
+    name = "dummy"
+
+    def scrape(self, **kwargs):
+        return ScrapeResult(data=[{"ok": True}], metadata=ScrapeMetadata(scraper="dummy"))
+
+
+def test_builtins_are_registered():
+    scrapers = list_scrapers()
+    # A representative sample of built-ins should be present.
+    for name in ("wikipedia", "github", "generic", "stock"):
+        assert name in scrapers
+    assert get_scraper("wikipedia").__name__ == "WikipediaScraper"
+
+
+def test_register_imperative():
+    register("dummy_imperative", _Dummy)
+    assert get_scraper("dummy_imperative") is _Dummy
+
+
+def test_register_decorator_sets_name():
+    @register_scraper("decorated")
+    class Decorated(BaseScraper):
+        def scrape(self, **kwargs):
+            return ScrapeResult(data=[])
+
+    assert get_scraper("decorated") is Decorated
+    # decorator fills in .name when not explicitly set
+    assert Decorated.name == "decorated"
+
+
+def test_decorator_keeps_explicit_name():
+    @register_scraper("regkey")
+    class Explicit(BaseScraper):
+        name = "explicit-name"
+
+        def scrape(self, **kwargs):
+            return ScrapeResult(data=[])
+
+    # registry key is the decorator arg; class keeps its own name
+    assert get_scraper("regkey") is Explicit
+    assert Explicit.name == "explicit-name"
+
+
+def test_unknown_scraper_raises_with_available_names():
+    with pytest.raises(KeyError) as exc:
+        get_scraper("no-such-scraper")
+    assert "no-such-scraper" in str(exc.value)
+    assert "Available" in str(exc.value)
+
+
+def test_entry_point_discovery(monkeypatch):
+    """A scraper advertised via an entry point is discovered lazily."""
+
+    class FakeEP:
+        name = "fakeplugin"
+
+        def load(self):
+            return _Dummy
+
+    # Force rediscovery and inject a fake entry point.
+    monkeypatch.setattr(registry, "_entry_points_loaded", False)
+    monkeypatch.setattr(registry, "_load_entry_points", _make_loader([FakeEP()]))
+
+    assert get_scraper("fakeplugin") is _Dummy
+
+
+def test_broken_plugin_is_skipped(monkeypatch):
+    """A plugin that fails to load must not break discovery of others."""
+
+    class GoodEP:
+        name = "goodplugin"
+
+        def load(self):
+            return _Dummy
+
+    class BadEP:
+        name = "badplugin"
+
+        def load(self):
+            raise ImportError("boom")
+
+    monkeypatch.setattr(registry, "_entry_points_loaded", False)
+    monkeypatch.setattr(registry, "_load_entry_points", _make_loader([BadEP(), GoodEP()]))
+
+    scrapers = list_scrapers()
+    assert "goodplugin" in scrapers
+    assert "badplugin" not in scrapers
+
+
+def _make_loader(eps):
+    """Build a replacement _load_entry_points that registers the given eps."""
+
+    def loader():
+        for ep in eps:
+            try:
+                cls = ep.load()
+            except Exception:
+                continue
+            registry._registry.setdefault(ep.name, cls)
+
+    return loader


### PR DESCRIPTION
Scrapers can now be registered dynamically and shipped as standalone
pyscrappy-* packages, discovered via the `pyscrappy.scrapers` entry-point
group. Plugins work everywhere built-ins do, including the MCP server and
the pyscrappy chat agent, via the new generic `scrape_with` and
`list_available_scrapers` tools.

- Add registry: register_scraper, register, get_scraper, list_scrapers
- Export BaseScraper; register built-ins through the shared registry
- Add plugin-template/ and a plugin authoring guide
- Bump to 1.3.0, add CHANGELOG