### PR TITLE
chore: add ruff formatting, pre-commit, and fix existing lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check src/
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Auto-fix lint + format on commit. One-time setup:  pre-commit install
+# Then `git commit` runs ruff on staged files, fixing what it can automatically.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff          # lint, auto-fixing what's safe
+        args: [--fix]
+      - id: ruff-format   # format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.1"
+version = "1.3.2"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"
@@ -73,6 +73,9 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+# The formatter owns line width; E501 only fires on lines it can't split
+# (long string literals), so enforcing it adds noise, not value.
+ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -27,6 +27,7 @@ Quick start::
 """
 
 from pyscrappy.concurrent import scrape_all, scrape_many
+from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import (
     BrowserNotInstalledError,
@@ -36,15 +37,14 @@ from pyscrappy.core.exceptions import (
     ScraperTimeoutError,
     SelectorError,
 )
-from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.models import ScrapeResult
+from pyscrappy.generic.scraper import GenericScraper
 from pyscrappy.registry import (
     get_scraper,
     list_scrapers,
     register,
     register_scraper,
 )
-from pyscrappy.generic.scraper import GenericScraper
 from pyscrappy.scrapers.amazon import AmazonScraper
 from pyscrappy.scrapers.crypto import CryptoScraper
 from pyscrappy.scrapers.currency import CurrencyScraper
@@ -62,8 +62,8 @@ from pyscrappy.scrapers.openlibrary import OpenLibraryScraper
 from pyscrappy.scrapers.soundcloud import SoundCloudScraper
 from pyscrappy.scrapers.spotify import SpotifyScraper
 from pyscrappy.scrapers.stock import StockScraper
-from pyscrappy.scrapers.ubereats import UberEatsScraper
 from pyscrappy.scrapers.twitter import TwitterScraper
+from pyscrappy.scrapers.ubereats import UberEatsScraper
 from pyscrappy.scrapers.weather import WeatherScraper
 from pyscrappy.scrapers.wikipedia import WikipediaScraper
 from pyscrappy.scrapers.youtube import YouTubeScraper
@@ -101,7 +101,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/concurrent.py
+++ b/src/pyscrappy/concurrent.py
@@ -55,6 +55,7 @@ def scrape_many(
     Returns:
         A list of ``ScrapeResult`` in the same order as ``calls``.
     """
+
     def _one(call: dict[str, Any]) -> ScrapeResult:
         with scraper_cls(config) as scraper:
             return scraper.scrape(**call)

--- a/src/pyscrappy/core/browser.py
+++ b/src/pyscrappy/core/browser.py
@@ -106,8 +106,7 @@ class BrowserManager:
         context = self._browser.new_context()
         page = context.new_page()
         try:
-            page.goto(url, wait_until="networkidle",
-                       timeout=int(self.config.timeout * 1000))
+            page.goto(url, wait_until="networkidle", timeout=int(self.config.timeout * 1000))
             page.screenshot(path=path, full_page=full_page)
         finally:
             page.close()

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -12,8 +12,7 @@ _DEFAULT_USER_AGENTS = [
     " (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
     " (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0)"
-    " Gecko/20100101 Firefox/125.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15"
     " (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
 ]

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -78,9 +78,7 @@ class HttpClient:
             if caller_params:
                 sep = "&" if "?" in url else "?"
                 url = url + sep + urlencode(caller_params)
-            endpoint, api_params = scraper_api.build_request(
-                url, self.config.scraper_api or {}
-            )
+            endpoint, api_params = scraper_api.build_request(url, self.config.scraper_api or {})
             url = endpoint
             kwargs["params"] = api_params
 
@@ -114,13 +112,16 @@ class HttpClient:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
                     delay = self.config.retry_delay * (2 ** (attempt - 1))
-                    logger.warning("Server error %s on %s, retry %d in %.1fs",
-                                   exc.response.status_code, url, attempt, delay)
+                    logger.warning(
+                        "Server error %s on %s, retry %d in %.1fs",
+                        exc.response.status_code,
+                        url,
+                        attempt,
+                        delay,
+                    )
                     time.sleep(delay)
                     continue
-                raise NetworkError(
-                    f"HTTP {exc.response.status_code} from {url}"
-                ) from exc
+                raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
 
             except httpx.RequestError as exc:
                 last_exc = exc
@@ -159,18 +160,14 @@ class HttpClient:
         for attempt in range(1, self.config.max_retries + 1):
             try:
                 headers = {"User-Agent": self._pick_ua(), **extra_headers}
-                resp = client.post(
-                    url, headers=headers, follow_redirects=True, **kwargs
-                )
+                resp = client.post(url, headers=headers, follow_redirects=True, **kwargs)
                 if resp.status_code >= 500 and attempt < self.config.max_retries:
                     time.sleep(self.config.retry_delay * (2 ** (attempt - 1)))
                     continue
                 resp.raise_for_status()
                 return resp.text
             except httpx.HTTPStatusError as exc:
-                raise NetworkError(
-                    f"HTTP {exc.response.status_code} from {url}"
-                ) from exc
+                raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -22,9 +22,7 @@ class ScrapeMetadata:
 
     source_urls: list[str] = field(default_factory=list)
     total_pages: int = 1
-    timestamp: str = field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     scraper: str = ""
 
 

--- a/src/pyscrappy/generic/extractors.py
+++ b/src/pyscrappy/generic/extractors.py
@@ -137,11 +137,13 @@ class LinkExtractor:
                 continue
             seen.add(absolute)
 
-            links.append({
-                "url": absolute,
-                "text": a.get_text(strip=True),
-                "rel": " ".join(a.get("rel", [])),
-            })
+            links.append(
+                {
+                    "url": absolute,
+                    "text": a.get_text(strip=True),
+                    "rel": " ".join(a.get("rel", [])),
+                }
+            )
 
         return links
 
@@ -157,12 +159,14 @@ class ImageExtractor:
             if not src:
                 continue
             absolute = urljoin(base_url, src) if base_url else src
-            images.append({
-                "url": absolute,
-                "alt": img.get("alt", ""),
-                "width": img.get("width", ""),
-                "height": img.get("height", ""),
-            })
+            images.append(
+                {
+                    "url": absolute,
+                    "alt": img.get("alt", ""),
+                    "width": img.get("width", ""),
+                    "height": img.get("height", ""),
+                }
+            )
 
         return images
 

--- a/src/pyscrappy/generic/scraper.py
+++ b/src/pyscrappy/generic/scraper.py
@@ -136,9 +136,7 @@ class GenericScraper(BaseScraper):
             errors=all_errors,
         )
 
-    def _fetch_with_js_detection(
-        self, url: str, render_js: bool | str, scroll_pages: int
-    ) -> str:
+    def _fetch_with_js_detection(self, url: str, render_js: bool | str, scroll_pages: int) -> str:
         """Fetch HTML, auto-detecting if JS rendering is needed."""
         if render_js is True:
             return self.browser.get_html(url, scroll_pages=scroll_pages)

--- a/src/pyscrappy/mcp/agent.py
+++ b/src/pyscrappy/mcp/agent.py
@@ -116,8 +116,12 @@ def main() -> None:
 
     chat = sub.add_parser("chat", help="Ask a local model a question it can answer with scrapers.")
     chat.add_argument("prompt", help="What to ask, in plain language.")
-    chat.add_argument("--model", default=DEFAULT_MODEL, help=f"Ollama model (default: {DEFAULT_MODEL}).")
-    chat.add_argument("--host", default=DEFAULT_HOST, help=f"Ollama host (default: {DEFAULT_HOST}).")
+    chat.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Ollama model (default: {DEFAULT_MODEL})."
+    )
+    chat.add_argument(
+        "--host", default=DEFAULT_HOST, help=f"Ollama host (default: {DEFAULT_HOST})."
+    )
     chat.add_argument("--max-steps", type=int, default=MAX_STEPS, help="Max tool-calling rounds.")
     chat.add_argument("-v", "--verbose", action="store_true", help="Print each tool call.")
 

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -89,9 +89,7 @@ def _to_result(result: ScrapeResult) -> ScrapeToolResult:
 
 async def _run(fn, /, *args, **kwargs) -> ScrapeToolResult:
     """Run a synchronous scraper off the event loop and return a typed result."""
-    result: ScrapeResult = await anyio.to_thread.run_sync(
-        lambda: fn(*args, **kwargs)
-    )
+    result: ScrapeResult = await anyio.to_thread.run_sync(lambda: fn(*args, **kwargs))
     return _to_result(result)
 
 
@@ -213,9 +211,7 @@ async def search_images(query: str, max_images: int = 20, engine: str = "bing") 
         engine: Search engine to use (default "bing").
     """
     with ImageSearchScraper(_config()) as iss:
-        return await _run(
-            iss.scrape, query=query, max_images=max_images, engine=engine
-        )
+        return await _run(iss.scrape, query=query, max_images=max_images, engine=engine)
 
 
 @mcp.tool()
@@ -242,9 +238,7 @@ async def search_linkedin_jobs(
         max_pages: Pages of results to scrape (default 1).
     """
     with LinkedInJobsScraper(_config()) as ljs:
-        return await _run(
-            ljs.scrape, query=query, location=location, max_pages=max_pages
-        )
+        return await _run(ljs.scrape, query=query, location=location, max_pages=max_pages)
 
 
 @mcp.tool()
@@ -259,9 +253,7 @@ async def get_crypto(
         vs_currency: Fiat currency for prices, e.g. "usd", "eur" (default "usd").
     """
     with CryptoScraper(_config()) as c:
-        return await _run(
-            c.scrape, query=query, max_results=max_results, vs_currency=vs_currency
-        )
+        return await _run(c.scrape, query=query, max_results=max_results, vs_currency=vs_currency)
 
 
 @mcp.tool()
@@ -465,9 +457,7 @@ async def scrape_zomato(
         max_results: Maximum number of restaurants to return (default 50).
     """
     with ZomatoScraper(_config()) as zs:
-        return await _run(
-            zs.scrape, city=city, query=query, max_results=max_results
-        )
+        return await _run(zs.scrape, city=city, query=query, max_results=max_results)
 
 
 @mcp.tool()

--- a/src/pyscrappy/scrapers/__init__.py
+++ b/src/pyscrappy/scrapers/__init__.py
@@ -15,8 +15,8 @@ from pyscrappy.scrapers.openlibrary import OpenLibraryScraper
 from pyscrappy.scrapers.soundcloud import SoundCloudScraper
 from pyscrappy.scrapers.spotify import SpotifyScraper
 from pyscrappy.scrapers.stock import StockScraper
-from pyscrappy.scrapers.ubereats import UberEatsScraper
 from pyscrappy.scrapers.twitter import TwitterScraper
+from pyscrappy.scrapers.ubereats import UberEatsScraper
 from pyscrappy.scrapers.weather import WeatherScraper
 from pyscrappy.scrapers.wikipedia import WikipediaScraper
 from pyscrappy.scrapers.youtube import YouTubeScraper

--- a/src/pyscrappy/scrapers/amazon.py
+++ b/src/pyscrappy/scrapers/amazon.py
@@ -41,8 +41,7 @@ class AmazonScraper(BaseScraper):
         "Accept-Language": "en-GB,en;q=0.9",
         "Accept-Encoding": "gzip, deflate, br",
         "Accept": (
-            "text/html,application/xhtml+xml,application/xml;q=0.9,"
-            "image/avif,image/webp,*/*;q=0.8"
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
         ),
         "Referer": "https://www.google.com/",
     }
@@ -74,10 +73,7 @@ class AmazonScraper(BaseScraper):
         visited: list[str] = []
 
         for page in range(1, max_pages + 1):
-            url = (
-                f"https://{self._domain}/s?"
-                f"k={query.replace(' ', '+')}&page={page}"
-            )
+            url = f"https://{self._domain}/s?k={query.replace(' ', '+')}&page={page}"
             visited.append(url)
 
             try:
@@ -88,10 +84,12 @@ class AmazonScraper(BaseScraper):
 
             # Check for CAPTCHA
             if soup.find("form", action=re.compile(r"validateCaptcha")):
-                errors.append(ScrapeError(
-                    url=url,
-                    message="Amazon returned a CAPTCHA page. Try using a proxy.",
-                ))
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="Amazon returned a CAPTCHA page. Try using a proxy.",
+                    )
+                )
                 break
 
             page_products = self._parse_search_results(soup, url)
@@ -104,15 +102,17 @@ class AmazonScraper(BaseScraper):
         # change rather than a genuinely empty result. Say so, so callers aren't
         # left with a silent empty result.
         if not products and not errors:
-            errors.append(ScrapeError(
-                url=visited[-1] if visited else "",
-                message=(
-                    "No products extracted. Amazon aggressively blocks "
-                    "automated traffic — this usually means the request was "
-                    "served an anti-bot page. A proxy or residential IP is "
-                    "typically required."
-                ),
-            ))
+            errors.append(
+                ScrapeError(
+                    url=visited[-1] if visited else "",
+                    message=(
+                        "No products extracted. Amazon aggressively blocks "
+                        "automated traffic — this usually means the request was "
+                        "served an anti-bot page. A proxy or residential IP is "
+                        "typically required."
+                    ),
+                )
+            )
 
         return ScrapeResult(
             data=products,
@@ -124,9 +124,7 @@ class AmazonScraper(BaseScraper):
             errors=errors,
         )
 
-    def _parse_search_results(
-        self, soup: Any, url: str
-    ) -> list[dict[str, Any]]:
+    def _parse_search_results(self, soup: Any, url: str) -> list[dict[str, Any]]:
         """Parse product cards from a search results page."""
         products: list[dict[str, Any]] = []
 

--- a/src/pyscrappy/scrapers/crypto.py
+++ b/src/pyscrappy/scrapers/crypto.py
@@ -72,10 +72,7 @@ class CryptoScraper(BaseScraper):
             return self._err(url, "Unexpected response from CoinGecko.")
 
         coins = [self._parse(c, vs_currency) for c in payload if isinstance(c, dict)]
-        errors = (
-            [] if coins
-            else [ScrapeError(url=url, message="No coins found for this query.")]
-        )
+        errors = [] if coins else [ScrapeError(url=url, message="No coins found for this query.")]
         return ScrapeResult(
             data=coins,
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),

--- a/src/pyscrappy/scrapers/currency.py
+++ b/src/pyscrappy/scrapers/currency.py
@@ -61,28 +61,25 @@ class CurrencyScraper(BaseScraper):
             return self._err(url, str(msg))
 
         rates = payload.get("rates", {})
-        wanted = (
-            {c.strip().upper() for c in to.split(",") if c.strip()} if to else None
-        )
+        wanted = {c.strip().upper() for c in to.split(",") if c.strip()} if to else None
         updated = payload.get("time_last_update_utc")
 
         rows = []
         for code, rate in rates.items():
             if wanted and code not in wanted:
                 continue
-            rows.append({
-                "base": base.upper(),
-                "currency": code,
-                "rate": rate,
-                "amount": amount,
-                "converted": round(rate * amount, 4),
-                "updated": updated,
-            })
+            rows.append(
+                {
+                    "base": base.upper(),
+                    "currency": code,
+                    "rate": rate,
+                    "amount": amount,
+                    "converted": round(rate * amount, 4),
+                    "updated": updated,
+                }
+            )
 
-        errors = (
-            [] if rows
-            else [ScrapeError(url=url, message="No matching currencies.")]
-        )
+        errors = [] if rows else [ScrapeError(url=url, message="No matching currencies.")]
         return ScrapeResult(
             data=rows,
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),

--- a/src/pyscrappy/scrapers/dictionary.py
+++ b/src/pyscrappy/scrapers/dictionary.py
@@ -69,20 +69,19 @@ class DictionaryScraper(BaseScraper):
             for meaning in entry.get("meanings", []):
                 pos = meaning.get("partOfSpeech")
                 for definition in meaning.get("definitions", []):
-                    rows.append({
-                        "word": entry.get("word") or word,
-                        "phonetic": phonetic,
-                        "part_of_speech": pos,
-                        "definition": definition.get("definition"),
-                        "example": definition.get("example"),
-                        "synonyms": definition.get("synonyms") or None,
-                    })
+                    rows.append(
+                        {
+                            "word": entry.get("word") or word,
+                            "phonetic": phonetic,
+                            "part_of_speech": pos,
+                            "definition": definition.get("definition"),
+                            "example": definition.get("example"),
+                            "synonyms": definition.get("synonyms") or None,
+                        }
+                    )
 
         rows = [{k: v for k, v in r.items() if v is not None} for r in rows]
-        errors = (
-            [] if rows
-            else [ScrapeError(url=url, message=f"No definitions for {word!r}.")]
-        )
+        errors = [] if rows else [ScrapeError(url=url, message=f"No definitions for {word!r}.")]
         return ScrapeResult(
             data=rows,
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),

--- a/src/pyscrappy/scrapers/hackernews.py
+++ b/src/pyscrappy/scrapers/hackernews.py
@@ -66,11 +66,7 @@ class HackerNewsScraper(BaseScraper):
                 errors=[ScrapeError(url=url, message=str(exc))],
             )
 
-        stories = [
-            self._parse(hit)
-            for hit in payload.get("hits", [])
-            if isinstance(hit, dict)
-        ]
+        stories = [self._parse(hit) for hit in payload.get("hits", []) if isinstance(hit, dict)]
 
         errors: list[ScrapeError] = []
         if not stories:
@@ -92,9 +88,6 @@ class HackerNewsScraper(BaseScraper):
             "author": hit.get("author"),
             "num_comments": hit.get("num_comments"),
             "created_at": hit.get("created_at"),
-            "hn_url": (
-                f"https://news.ycombinator.com/item?id={object_id}"
-                if object_id else None
-            ),
+            "hn_url": (f"https://news.ycombinator.com/item?id={object_id}" if object_id else None),
         }
         return {k: v for k, v in story.items() if v is not None}

--- a/src/pyscrappy/scrapers/ikea.py
+++ b/src/pyscrappy/scrapers/ikea.py
@@ -81,10 +81,7 @@ class IKEAScraper(BaseScraper):
             )
 
         items = (
-            payload.get("searchResultPage", {})
-            .get("products", {})
-            .get("main", {})
-            .get("items", [])
+            payload.get("searchResultPage", {}).get("products", {}).get("main", {}).get("items", [])
         )
 
         products = [
@@ -94,10 +91,12 @@ class IKEAScraper(BaseScraper):
         ]
 
         if not products:
-            errors.append(ScrapeError(
-                url=url,
-                message="No products returned for this query.",
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message="No products returned for this query.",
+                )
+            )
 
         return ScrapeResult(
             data=products,

--- a/src/pyscrappy/scrapers/image_search.py
+++ b/src/pyscrappy/scrapers/image_search.py
@@ -67,9 +67,7 @@ class ImageSearchScraper(BaseScraper):
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
         )
 
-    def _search_bing(
-        self, query: str, max_images: int
-    ) -> tuple[list[dict[str, Any]], str]:
+    def _search_bing(self, query: str, max_images: int) -> tuple[list[dict[str, Any]], str]:
         """Search Bing Images (server-rendered, no JS needed)."""
         url = f"https://www.bing.com/images/search?q={quote_plus(query)}&first=1&count={max_images}"
         soup = self.fetch_and_parse(url)
@@ -81,6 +79,7 @@ class ImageSearchScraper(BaseScraper):
             if not m_attr:
                 continue
             import json
+
             try:
                 m_data = json.loads(str(m_attr))
             except (json.JSONDecodeError, TypeError):
@@ -90,14 +89,16 @@ class ImageSearchScraper(BaseScraper):
             if not img_url:
                 continue
 
-            images.append({
-                "url": img_url,
-                "thumbnail": m_data.get("turl", ""),
-                "title": m_data.get("t", ""),
-                "source_page": m_data.get("purl", ""),
-                "width": m_data.get("mw"),
-                "height": m_data.get("mh"),
-            })
+            images.append(
+                {
+                    "url": img_url,
+                    "thumbnail": m_data.get("turl", ""),
+                    "title": m_data.get("t", ""),
+                    "source_page": m_data.get("purl", ""),
+                    "width": m_data.get("mw"),
+                    "height": m_data.get("mh"),
+                }
+            )
 
             if len(images) >= max_images:
                 break
@@ -107,18 +108,18 @@ class ImageSearchScraper(BaseScraper):
             for img in soup.find_all("img", src=True):
                 src = str(img["src"])
                 if src.startswith("http") and "bing.com/th" not in src:
-                    images.append({
-                        "url": src,
-                        "alt": img.get("alt", ""),
-                    })
+                    images.append(
+                        {
+                            "url": src,
+                            "alt": img.get("alt", ""),
+                        }
+                    )
                     if len(images) >= max_images:
                         break
 
         return images, url
 
-    def _search_google(
-        self, query: str, max_images: int
-    ) -> tuple[list[dict[str, Any]], str]:
+    def _search_google(self, query: str, max_images: int) -> tuple[list[dict[str, Any]], str]:
         """Search Google Images (basic HTML — limited results without JS)."""
         url = f"https://www.google.com/search?q={quote_plus(query)}&tbm=isch"
         soup = self.fetch_and_parse(url)
@@ -129,18 +130,18 @@ class ImageSearchScraper(BaseScraper):
             # Skip Google's tracking pixel and logo
             if not src.startswith("http") or "google.com/images" in src:
                 continue
-            images.append({
-                "url": src,
-                "alt": img.get("alt", ""),
-            })
+            images.append(
+                {
+                    "url": src,
+                    "alt": img.get("alt", ""),
+                }
+            )
             if len(images) >= max_images:
                 break
 
         return images, url
 
-    def _download_images(
-        self, images: list[dict[str, Any]], directory: str
-    ) -> None:
+    def _download_images(self, images: list[dict[str, Any]], directory: str) -> None:
         """Download images to a local directory."""
         os.makedirs(directory, exist_ok=True)
 

--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -72,15 +72,17 @@ class IMDBScraper(BaseScraper):
             return ScrapeResult(
                 data=[],
                 metadata=ScrapeMetadata(scraper=self.name),
-                errors=[ScrapeError(
-                    url=_OMDB_BASE,
-                    message=(
-                        f"{unsupported!r} browsing is not supported. IMDB data "
-                        "is served via the OMDb API, which supports title "
-                        "search and id lookup only. Use query=<title> or "
-                        "query=<imdb id, e.g. tt1375666>."
-                    ),
-                )],
+                errors=[
+                    ScrapeError(
+                        url=_OMDB_BASE,
+                        message=(
+                            f"{unsupported!r} browsing is not supported. IMDB data "
+                            "is served via the OMDb API, which supports title "
+                            "search and id lookup only. Use query=<title> or "
+                            "query=<imdb id, e.g. tt1375666>."
+                        ),
+                    )
+                ],
             )
 
         if not query:
@@ -90,14 +92,16 @@ class IMDBScraper(BaseScraper):
             return ScrapeResult(
                 data=[],
                 metadata=ScrapeMetadata(scraper=self.name),
-                errors=[ScrapeError(
-                    url=_OMDB_BASE,
-                    message=(
-                        "No OMDb API key. Set the OMDB_API_KEY environment "
-                        "variable or pass api_key=... to IMDBScraper. Get a "
-                        "free key at https://www.omdbapi.com/apikey.aspx"
-                    ),
-                )],
+                errors=[
+                    ScrapeError(
+                        url=_OMDB_BASE,
+                        message=(
+                            "No OMDb API key. Set the OMDB_API_KEY environment "
+                            "variable or pass api_key=... to IMDBScraper. Get a "
+                            "free key at https://www.omdbapi.com/apikey.aspx"
+                        ),
+                    )
+                ],
             )
 
         if _IMDB_ID_RE.match(query.strip()):
@@ -120,10 +124,12 @@ class IMDBScraper(BaseScraper):
             data = [self._normalise(payload)]
         else:
             data = []
-            errors.append(ScrapeError(
-                url=_OMDB_BASE,
-                message=f"OMDb: {payload.get('Error', 'not found')} (id={imdb_id})",
-            ))
+            errors.append(
+                ScrapeError(
+                    url=_OMDB_BASE,
+                    message=f"OMDb: {payload.get('Error', 'not found')} (id={imdb_id})",
+                )
+            )
 
         return ScrapeResult(
             data=data,
@@ -141,10 +147,12 @@ class IMDBScraper(BaseScraper):
             if payload.get("Response") != "True":
                 # OMDb returns "Movie not found!" / "Too many results." as errors.
                 if page == 1:
-                    errors.append(ScrapeError(
-                        url=_OMDB_BASE,
-                        message=f"OMDb: {payload.get('Error', 'no results')}",
-                    ))
+                    errors.append(
+                        ScrapeError(
+                            url=_OMDB_BASE,
+                            message=f"OMDb: {payload.get('Error', 'no results')}",
+                        )
+                    )
                 break
 
             results = payload.get("Search", [])
@@ -158,9 +166,9 @@ class IMDBScraper(BaseScraper):
                     movies.append(self._normalise(hit))
                     continue
                 details = self._get({"i": imdb_id})
-                movies.append(self._normalise(
-                    details if details.get("Response") == "True" else hit
-                ))
+                movies.append(
+                    self._normalise(details if details.get("Response") == "True" else hit)
+                )
 
         return ScrapeResult(
             data=movies,
@@ -174,6 +182,7 @@ class IMDBScraper(BaseScraper):
 
         OMDb uses ``"N/A"`` for missing values; convert those to ``None``.
         """
+
         def val(key: str) -> Any:
             v = item.get(key)
             return None if v in (None, "N/A", "") else v

--- a/src/pyscrappy/scrapers/instagram.py
+++ b/src/pyscrappy/scrapers/instagram.py
@@ -66,9 +66,7 @@ class InstagramScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
@@ -78,10 +76,12 @@ class InstagramScraper(BaseScraper):
         else:
             profile = self._parse_profile_html(html, username)
             if not profile.get("username"):
-                errors.append(ScrapeError(
-                    url=url,
-                    message="Could not extract profile data. Instagram may require login.",
-                ))
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="Could not extract profile data. Instagram may require login.",
+                    )
+                )
 
         return ScrapeResult(
             data=[profile] if profile else [],
@@ -96,9 +96,7 @@ class InstagramScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
@@ -110,10 +108,12 @@ class InstagramScraper(BaseScraper):
         else:
             posts = self._parse_posts_html(html, max_posts)
             if not posts:
-                errors.append(ScrapeError(
-                    url=url,
-                    message="Could not extract hashtag posts. Instagram may require login.",
-                ))
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="Could not extract hashtag posts. Instagram may require login.",
+                    )
+                )
 
         return ScrapeResult(
             data=posts,
@@ -155,9 +155,7 @@ class InstagramScraper(BaseScraper):
         profile["external_url"] = user.get("external_url", "")
 
         # Recent posts
-        edges = (
-            user.get("edge_owner_to_timeline_media", {}).get("edges", [])
-        )
+        edges = user.get("edge_owner_to_timeline_media", {}).get("edges", [])
         profile["recent_posts"] = [
             {
                 "caption": (
@@ -195,9 +193,7 @@ class InstagramScraper(BaseScraper):
 
         return profile
 
-    def _parse_hashtag_json(
-        self, data: dict[str, Any], max_posts: int
-    ) -> list[dict[str, Any]]:
+    def _parse_hashtag_json(self, data: dict[str, Any], max_posts: int) -> list[dict[str, Any]]:
         """Parse hashtag data from _sharedData JSON."""
         posts: list[dict[str, Any]] = []
 
@@ -216,22 +212,21 @@ class InstagramScraper(BaseScraper):
         for edge in edges[:max_posts]:
             node = edge.get("node", {})
             caption_edges = node.get("edge_media_to_caption", {}).get("edges", [])
-            posts.append({
-                "caption": (
-                    caption_edges[0].get("node", {}).get("text", "")
-                    if caption_edges else ""
-                ),
-                "likes": node.get("edge_liked_by", {}).get("count"),
-                "comments": node.get("edge_media_to_comment", {}).get("count"),
-                "url": f"https://www.instagram.com/p/{node.get('shortcode', '')}/",
-                "is_video": node.get("is_video", False),
-            })
+            posts.append(
+                {
+                    "caption": (
+                        caption_edges[0].get("node", {}).get("text", "") if caption_edges else ""
+                    ),
+                    "likes": node.get("edge_liked_by", {}).get("count"),
+                    "comments": node.get("edge_media_to_comment", {}).get("count"),
+                    "url": f"https://www.instagram.com/p/{node.get('shortcode', '')}/",
+                    "is_video": node.get("is_video", False),
+                }
+            )
 
         return posts
 
-    def _parse_posts_html(
-        self, html: str, max_posts: int
-    ) -> list[dict[str, Any]]:
+    def _parse_posts_html(self, html: str, max_posts: int) -> list[dict[str, Any]]:
         """Fallback: extract post links from rendered HTML."""
         soup = self.parse_html(html)
         posts: list[dict[str, Any]] = []

--- a/src/pyscrappy/scrapers/linkedin.py
+++ b/src/pyscrappy/scrapers/linkedin.py
@@ -72,10 +72,12 @@ class LinkedInJobsScraper(BaseScraper):
 
             # Check if we got an auth wall
             if soup.find("form", class_="login__form"):
-                errors.append(ScrapeError(
-                    url=url,
-                    message="LinkedIn requires authentication for this page.",
-                ))
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="LinkedIn requires authentication for this page.",
+                    )
+                )
                 break
 
             page_jobs = self._parse_job_cards(soup)
@@ -97,9 +99,7 @@ class LinkedInJobsScraper(BaseScraper):
         """Parse job cards from LinkedIn's public job search page."""
         jobs: list[dict[str, Any]] = []
 
-        for card in soup.select(
-            ".base-card, .job-search-card, .base-search-card--link"
-        ):
+        for card in soup.select(".base-card, .job-search-card, .base-search-card--link"):
             job = self._parse_single_card(card)
             if job and job.get("title"):
                 jobs.append(job)
@@ -111,16 +111,12 @@ class LinkedInJobsScraper(BaseScraper):
         job: dict[str, Any] = {}
 
         # Title
-        title_el = card.select_one(
-            ".base-search-card__title, .base-card__full-link span"
-        )
+        title_el = card.select_one(".base-search-card__title, .base-card__full-link span")
         if title_el:
             job["title"] = title_el.get_text(strip=True)
 
         # Company
-        company_el = card.select_one(
-            ".base-search-card__subtitle a, .base-search-card__subtitle"
-        )
+        company_el = card.select_one(".base-search-card__subtitle a, .base-search-card__subtitle")
         if company_el:
             job["company"] = company_el.get_text(strip=True)
 

--- a/src/pyscrappy/scrapers/newegg.py
+++ b/src/pyscrappy/scrapers/newegg.py
@@ -34,8 +34,7 @@ class NeweggScraper(BaseScraper):
         "Accept-Language": "en-US,en;q=0.9",
         "Accept-Encoding": "gzip, deflate, br",
         "Accept": (
-            "text/html,application/xhtml+xml,application/xml;q=0.9,"
-            "image/avif,image/webp,*/*;q=0.8"
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
         ),
         "Referer": "https://www.google.com/",
     }
@@ -67,10 +66,7 @@ class NeweggScraper(BaseScraper):
         visited: list[str] = []
 
         for page in range(1, max_pages + 1):
-            url = (
-                f"https://{self._domain}/p/pl?"
-                f"d={query.replace(' ', '+')}&page={page}"
-            )
+            url = f"https://{self._domain}/p/pl?d={query.replace(' ', '+')}&page={page}"
             visited.append(url)
 
             try:
@@ -85,13 +81,15 @@ class NeweggScraper(BaseScraper):
             products.extend(page_products)
 
         if not products and not errors:
-            errors.append(ScrapeError(
-                url=visited[-1] if visited else "",
-                message=(
-                    "No products extracted. Newegg may have changed its page "
-                    "layout, or the query returned no results."
-                ),
-            ))
+            errors.append(
+                ScrapeError(
+                    url=visited[-1] if visited else "",
+                    message=(
+                        "No products extracted. Newegg may have changed its page "
+                        "layout, or the query returned no results."
+                    ),
+                )
+            )
 
         return ScrapeResult(
             data=products,

--- a/src/pyscrappy/scrapers/news.py
+++ b/src/pyscrappy/scrapers/news.py
@@ -129,12 +129,14 @@ class NewsScraper(BaseScraper):
         main = soup.find("article") or soup.find("main") or soup.find(role="main")
         if main and isinstance(main, Tag):
             paragraphs = [
-                p.get_text(strip=True) for p in main.find_all("p")
+                p.get_text(strip=True)
+                for p in main.find_all("p")
                 if len(p.get_text(strip=True)) > 30
             ]
         else:
             paragraphs = [
-                p.get_text(strip=True) for p in soup.find_all("p")
+                p.get_text(strip=True)
+                for p in soup.find_all("p")
                 if len(p.get_text(strip=True)) > 50
             ]
 

--- a/src/pyscrappy/scrapers/openlibrary.py
+++ b/src/pyscrappy/scrapers/openlibrary.py
@@ -56,11 +56,7 @@ class OpenLibraryScraper(BaseScraper):
                 errors=[ScrapeError(url=url, message=str(exc))],
             )
 
-        books = [
-            self._parse(doc)
-            for doc in payload.get("docs", [])
-            if isinstance(doc, dict)
-        ]
+        books = [self._parse(doc) for doc in payload.get("docs", []) if isinstance(doc, dict)]
 
         errors: list[ScrapeError] = []
         if not books:
@@ -85,9 +81,6 @@ class OpenLibraryScraper(BaseScraper):
             "edition_count": doc.get("edition_count"),
             "languages": doc.get("language"),
             "url": f"https://openlibrary.org{key}" if key else None,
-            "cover": (
-                f"https://covers.openlibrary.org/b/id/{cover}-M.jpg"
-                if cover else None
-            ),
+            "cover": (f"https://covers.openlibrary.org/b/id/{cover}-M.jpg" if cover else None),
         }
         return {k: v for k, v in book.items() if v is not None}

--- a/src/pyscrappy/scrapers/soundcloud.py
+++ b/src/pyscrappy/scrapers/soundcloud.py
@@ -52,19 +52,19 @@ class SoundCloudScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
         tracks = self._extract_tracks(html, max_results)
 
         if not tracks:
-            errors.append(ScrapeError(
-                url=url,
-                message="No tracks extracted. SoundCloud is JS-heavy — try render_js=True.",
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message="No tracks extracted. SoundCloud is JS-heavy — try render_js=True.",
+                )
+            )
 
         return ScrapeResult(
             data=tracks,
@@ -85,25 +85,18 @@ class SoundCloudScraper(BaseScraper):
         soup = self.parse_html(html)
 
         for item in soup.select(
-            ".searchList__item, "
-            ".soundList__item, "
-            "li.searchList__item, "
-            "article"
+            ".searchList__item, .soundList__item, li.searchList__item, article"
         ):
             track: dict[str, Any] = {}
 
             # Title
-            title_el = item.select_one(
-                "a.soundTitle__title span, "
-                "a[href*='/'] span.sc-truncate"
-            )
+            title_el = item.select_one("a.soundTitle__title span, a[href*='/'] span.sc-truncate")
             if title_el:
                 track["title"] = title_el.get_text(strip=True)
 
             # Artist
             artist_el = item.select_one(
-                "a.soundTitle__username span, "
-                "a[href] span.soundTitle__usernameText"
+                "a.soundTitle__username span, a[href] span.soundTitle__usernameText"
             )
             if artist_el:
                 track["artist"] = artist_el.get_text(strip=True)
@@ -118,16 +111,14 @@ class SoundCloudScraper(BaseScraper):
 
             # Play count
             plays_el = item.select_one(
-                ".sc-ministats-plays span[aria-hidden], "
-                "[class*='playbackCount']"
+                ".sc-ministats-plays span[aria-hidden], [class*='playbackCount']"
             )
             if plays_el:
                 track["plays"] = plays_el.get_text(strip=True)
 
             # Duration
             duration_el = item.select_one(
-                ".soundTitle__duration span[aria-hidden], "
-                "[class*='duration']"
+                ".soundTitle__duration span[aria-hidden], [class*='duration']"
             )
             if duration_el:
                 track["duration"] = duration_el.get_text(strip=True)
@@ -140,15 +131,14 @@ class SoundCloudScraper(BaseScraper):
 
         return tracks
 
-    def _extract_from_hydration(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_from_hydration(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Extract data from SoundCloud's __sc_hydration JSON."""
         tracks: list[dict[str, Any]] = []
 
         match = re.search(
             r"window\.__sc_hydration\s*=\s*(\[.*?\]);\s*</script>",
-            html, re.DOTALL,
+            html,
+            re.DOTALL,
         )
         if not match:
             return tracks
@@ -177,16 +167,18 @@ class SoundCloudScraper(BaseScraper):
                 user = item.get("user") or {}
                 if not isinstance(user, dict):
                     user = {}
-                tracks.append({
-                    "title": item.get("title", ""),
-                    "artist": user.get("username", ""),
-                    "url": item.get("permalink_url", ""),
-                    "plays": item.get("playback_count"),
-                    "likes": item.get("likes_count"),
-                    "duration_ms": item.get("duration"),
-                    "genre": item.get("genre", ""),
-                    "created_at": item.get("created_at", ""),
-                })
+                tracks.append(
+                    {
+                        "title": item.get("title", ""),
+                        "artist": user.get("username", ""),
+                        "url": item.get("permalink_url", ""),
+                        "plays": item.get("playback_count"),
+                        "likes": item.get("likes_count"),
+                        "duration_ms": item.get("duration"),
+                        "genre": item.get("genre", ""),
+                        "created_at": item.get("created_at", ""),
+                    }
+                )
 
                 if len(tracks) >= max_results:
                     return tracks

--- a/src/pyscrappy/scrapers/spotify.py
+++ b/src/pyscrappy/scrapers/spotify.py
@@ -79,10 +79,12 @@ class SpotifyScraper(BaseScraper):
         items = self._extract_items(html, max_results)
 
         if not items:
-            errors.append(ScrapeError(
-                url=url,
-                message="No results extracted. Spotify requires JS rendering — use render_js=True.",
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message="No results extracted. Spotify requires JS rendering — use render_js=True.",
+                )
+            )
 
         return ScrapeResult(
             data=items,
@@ -96,19 +98,19 @@ class SpotifyScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
         tracks = self._extract_playlist_tracks(html, max_results)
 
         if not tracks:
-            errors.append(ScrapeError(
-                url=url,
-                message="No tracks extracted. Use render_js=True for playlists.",
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message="No tracks extracted. Use render_js=True for playlists.",
+                )
+            )
 
         return ScrapeResult(
             data=tracks,
@@ -129,32 +131,25 @@ class SpotifyScraper(BaseScraper):
         soup = self.parse_html(html)
 
         for card in soup.select(
-            "[data-testid='tracklist-row'], "
-            "[data-testid='search-result-item'], "
-            "div[role='row']"
+            "[data-testid='tracklist-row'], [data-testid='search-result-item'], div[role='row']"
         ):
             item: dict[str, Any] = {}
 
             # Title
             title_el = card.select_one(
-                "a[data-testid='internal-track-link'] div, "
-                "div[class*='Type__TypeElement'] a"
+                "a[data-testid='internal-track-link'] div, div[class*='Type__TypeElement'] a"
             )
             if title_el:
                 item["title"] = title_el.get_text(strip=True)
 
             # Artist
-            artist_el = card.select_one(
-                "span[data-testid='artists-names'], "
-                "a[href*='/artist/']"
-            )
+            artist_el = card.select_one("span[data-testid='artists-names'], a[href*='/artist/']")
             if artist_el:
                 item["artist"] = artist_el.get_text(strip=True)
 
             # Duration
             duration_el = card.select_one(
-                "[data-testid='tracklist-duration'], "
-                "div[class*='Duration']"
+                "[data-testid='tracklist-duration'], div[class*='Duration']"
             )
             if duration_el:
                 item["duration"] = duration_el.get_text(strip=True)
@@ -172,9 +167,7 @@ class SpotifyScraper(BaseScraper):
 
         return items
 
-    def _extract_playlist_tracks(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_playlist_tracks(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Extract tracks from a playlist page."""
         # Try resource data first
         tracks = self._extract_from_resource(html, max_results)
@@ -184,21 +177,21 @@ class SpotifyScraper(BaseScraper):
         # Fallback to generic extraction
         return self._extract_items(html, max_results)
 
-    def _extract_from_resource(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_from_resource(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Extract data from Spotify's embedded resource JSON."""
         items: list[dict[str, Any]] = []
 
         match = re.search(
             r'<script id="initial-state" type="text/plain">(.*?)</script>',
-            html, re.DOTALL,
+            html,
+            re.DOTALL,
         )
         if not match:
             return items
 
         try:
             import base64
+
             decoded = base64.b64decode(match.group(1))
             data = json.loads(decoded)
         except Exception:
@@ -218,13 +211,15 @@ class SpotifyScraper(BaseScraper):
         if isinstance(data, dict):
             if data.get("type") == "track" and data.get("name"):
                 artists = data.get("artists", [])
-                tracks.append({
-                    "title": data.get("name", ""),
-                    "artist": ", ".join(a.get("name", "") for a in artists) if artists else "",
-                    "album": data.get("album", {}).get("name", ""),
-                    "duration_ms": data.get("duration_ms"),
-                    "url": f"https://open.spotify.com/track/{data.get('id', '')}",
-                })
+                tracks.append(
+                    {
+                        "title": data.get("name", ""),
+                        "artist": ", ".join(a.get("name", "") for a in artists) if artists else "",
+                        "album": data.get("album", {}).get("name", ""),
+                        "duration_ms": data.get("duration_ms"),
+                        "url": f"https://open.spotify.com/track/{data.get('id', '')}",
+                    }
+                )
             for value in data.values():
                 tracks.extend(self._find_tracks(value))
         elif isinstance(data, list):

--- a/src/pyscrappy/scrapers/stock.py
+++ b/src/pyscrappy/scrapers/stock.py
@@ -78,32 +78,29 @@ class StockScraper(BaseScraper):
         chart = data.get("chart", {}).get("result", [])
         if chart:
             meta = chart[0].get("meta", {})
-            result_data.append({
-                "symbol": meta.get("symbol", symbol),
-                "currency": meta.get("currency", ""),
-                "exchange": meta.get("exchangeName", ""),
-                "price": meta.get("regularMarketPrice"),
-                "previous_close": meta.get("chartPreviousClose"),
-                "volume": meta.get("regularMarketVolume"),
-                "day_high": meta.get("regularMarketDayHigh"),
-                "day_low": meta.get("regularMarketDayLow"),
-                "fifty_two_week_high": meta.get("fiftyTwoWeekHigh"),
-                "fifty_two_week_low": meta.get("fiftyTwoWeekLow"),
-            })
+            result_data.append(
+                {
+                    "symbol": meta.get("symbol", symbol),
+                    "currency": meta.get("currency", ""),
+                    "exchange": meta.get("exchangeName", ""),
+                    "price": meta.get("regularMarketPrice"),
+                    "previous_close": meta.get("chartPreviousClose"),
+                    "volume": meta.get("regularMarketVolume"),
+                    "day_high": meta.get("regularMarketDayHigh"),
+                    "day_low": meta.get("regularMarketDayLow"),
+                    "fifty_two_week_high": meta.get("fiftyTwoWeekHigh"),
+                    "fifty_two_week_low": meta.get("fiftyTwoWeekLow"),
+                }
+            )
 
         return ScrapeResult(
             data=result_data,
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
         )
 
-    def _scrape_history(
-        self, symbol: str, period: str, interval: str
-    ) -> ScrapeResult:
+    def _scrape_history(self, symbol: str, period: str, interval: str) -> ScrapeResult:
         """Fetch historical OHLCV data."""
-        url = (
-            f"{_YF_BASE}/v8/finance/chart/{symbol}"
-            f"?range={period}&interval={interval}"
-        )
+        url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range={period}&interval={interval}"
         data = self._fetch_json(url)
 
         result_data: list[dict[str, Any]] = []
@@ -120,14 +117,16 @@ class StockScraper(BaseScraper):
             volumes = quotes.get("volume", [])
 
             for i, ts in enumerate(timestamps):
-                result_data.append({
-                    "date": time.strftime("%Y-%m-%d", time.gmtime(ts)),
-                    "open": opens[i] if i < len(opens) else None,
-                    "high": highs[i] if i < len(highs) else None,
-                    "low": lows[i] if i < len(lows) else None,
-                    "close": closes[i] if i < len(closes) else None,
-                    "volume": volumes[i] if i < len(volumes) else None,
-                })
+                result_data.append(
+                    {
+                        "date": time.strftime("%Y-%m-%d", time.gmtime(ts)),
+                        "open": opens[i] if i < len(opens) else None,
+                        "high": highs[i] if i < len(highs) else None,
+                        "low": lows[i] if i < len(lows) else None,
+                        "close": closes[i] if i < len(closes) else None,
+                        "volume": volumes[i] if i < len(volumes) else None,
+                    }
+                )
 
         return ScrapeResult(
             data=result_data,
@@ -143,15 +142,17 @@ class StockScraper(BaseScraper):
         chart = data.get("chart", {}).get("result", [])
         if chart:
             meta = chart[0].get("meta", {})
-            result_data.append({
-                "symbol": meta.get("symbol", symbol),
-                "name": meta.get("longName", meta.get("shortName", "")),
-                "currency": meta.get("currency", ""),
-                "exchange": meta.get("exchangeName", ""),
-                "market": meta.get("market", ""),
-                "timezone": meta.get("exchangeTimezoneName", ""),
-                "instrument_type": meta.get("instrumentType", ""),
-            })
+            result_data.append(
+                {
+                    "symbol": meta.get("symbol", symbol),
+                    "name": meta.get("longName", meta.get("shortName", "")),
+                    "currency": meta.get("currency", ""),
+                    "exchange": meta.get("exchangeName", ""),
+                    "market": meta.get("market", ""),
+                    "timezone": meta.get("exchangeTimezoneName", ""),
+                    "instrument_type": meta.get("instrumentType", ""),
+                }
+            )
 
         return ScrapeResult(
             data=result_data,
@@ -206,7 +207,7 @@ class StockScraper(BaseScraper):
 
             # Rate-limited — back off and retry
             if resp.status_code == 429:
-                delay = self.config.retry_delay * (2 ** attempt)
+                delay = self.config.retry_delay * (2**attempt)
                 self.logger.warning("Rate-limited by Yahoo Finance, retrying in %.1fs", delay)
                 time.sleep(delay)
                 continue

--- a/src/pyscrappy/scrapers/twitter.py
+++ b/src/pyscrappy/scrapers/twitter.py
@@ -71,23 +71,23 @@ class TwitterScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
         tweets = self._extract_tweets(html, max_tweets)
 
         if not tweets:
-            errors.append(ScrapeError(
-                url=url,
-                message=(
-                    "No tweets extracted. Twitter/X likely requires"
-                    " authentication. Use render_js=True with a"
-                    " logged-in browser session."
-                ),
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message=(
+                        "No tweets extracted. Twitter/X likely requires"
+                        " authentication. Use render_js=True with a"
+                        " logged-in browser session."
+                    ),
+                )
+            )
 
         return ScrapeResult(
             data=tweets,
@@ -163,12 +163,14 @@ class TwitterScraper(BaseScraper):
         for tweet_id, tweet_data in entities.items():
             if len(tweets) >= max_tweets:
                 break
-            tweets.append({
-                "id": tweet_id,
-                "text": tweet_data.get("full_text", ""),
-                "created_at": tweet_data.get("created_at", ""),
-                "retweets": tweet_data.get("retweet_count"),
-                "likes": tweet_data.get("favorite_count"),
-            })
+            tweets.append(
+                {
+                    "id": tweet_id,
+                    "text": tweet_data.get("full_text", ""),
+                    "created_at": tweet_data.get("created_at", ""),
+                    "retweets": tweet_data.get("retweet_count"),
+                    "likes": tweet_data.get("favorite_count"),
+                }
+            )
 
         return tweets

--- a/src/pyscrappy/scrapers/ubereats.py
+++ b/src/pyscrappy/scrapers/ubereats.py
@@ -93,9 +93,7 @@ class UberEatsScraper(BaseScraper):
             "type": "google_places",
             "source": "manual_auto_complete",
         }
-        self.http.set_cookie(
-            "uev2.loc", quote(json.dumps(loc)), domain=".ubereats.com"
-        )
+        self.http.set_cookie("uev2.loc", quote(json.dumps(loc)), domain=".ubereats.com")
 
         # 3. Query the feed API.
         feed_url = _FEED.format(locale=self.locale)
@@ -210,24 +208,24 @@ class UberEatsScraper(BaseScraper):
                         offers = offers[0] if offers else {}
                     name = item.get("name")
                     desc = item.get("description")
-                    menu.append({
-                        "section": section_name,
-                        "name": _html.unescape(name) if name else None,
-                        "description": _html.unescape(desc) if desc else None,
-                        "price": offers.get("price") if isinstance(offers, dict) else None,
-                        "currency": (
-                            offers.get("priceCurrency") if isinstance(offers, dict) else None
-                        ),
-                    })
+                    menu.append(
+                        {
+                            "section": section_name,
+                            "name": _html.unescape(name) if name else None,
+                            "description": _html.unescape(desc) if desc else None,
+                            "price": offers.get("price") if isinstance(offers, dict) else None,
+                            "currency": (
+                                offers.get("priceCurrency") if isinstance(offers, dict) else None
+                            ),
+                        }
+                    )
 
             record = {
                 "name": data.get("name"),
                 "cuisine": data.get("servesCuisine"),
                 "price_range": data.get("priceRange"),
                 "rating": rating.get("ratingValue") if isinstance(rating, dict) else None,
-                "rating_count": (
-                    rating.get("reviewCount") if isinstance(rating, dict) else None
-                ),
+                "rating_count": (rating.get("reviewCount") if isinstance(rating, dict) else None),
                 "telephone": data.get("telephone"),
                 "menu": menu or None,
             }

--- a/src/pyscrappy/scrapers/weather.py
+++ b/src/pyscrappy/scrapers/weather.py
@@ -18,12 +18,26 @@ _FORECAST = "https://api.open-meteo.com/v1/forecast"
 
 # Minimal WMO weather-code -> description mapping.
 _WMO = {
-    0: "Clear sky", 1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
-    45: "Fog", 48: "Depositing rime fog", 51: "Light drizzle",
-    53: "Moderate drizzle", 55: "Dense drizzle", 61: "Slight rain",
-    63: "Moderate rain", 65: "Heavy rain", 71: "Slight snow", 73: "Moderate snow",
-    75: "Heavy snow", 80: "Rain showers", 81: "Moderate rain showers",
-    82: "Violent rain showers", 95: "Thunderstorm", 96: "Thunderstorm with hail",
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Fog",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    71: "Slight snow",
+    73: "Moderate snow",
+    75: "Heavy snow",
+    80: "Rain showers",
+    81: "Moderate rain showers",
+    82: "Violent rain showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with hail",
 }
 
 

--- a/src/pyscrappy/scrapers/wikipedia.py
+++ b/src/pyscrappy/scrapers/wikipedia.py
@@ -132,29 +132,35 @@ class WikipediaScraper(BaseScraper):
                 headline = element.find("span", class_="mw-headline")
                 if headline:
                     current_section = headline.get_text(strip=True)
-                    items.append({
-                        "type": "header",
-                        "level": element.name,
-                        "text": current_section,
-                    })
+                    items.append(
+                        {
+                            "type": "header",
+                            "level": element.name,
+                            "text": current_section,
+                        }
+                    )
 
             elif element.name == "p":
                 text = self._clean_text(element.get_text())
                 if text:
-                    items.append({
-                        "type": "paragraph",
-                        "section": current_section,
-                        "text": text,
-                    })
+                    items.append(
+                        {
+                            "type": "paragraph",
+                            "section": current_section,
+                            "text": text,
+                        }
+                    )
 
             elif element.name == "table" and "wikitable" in element.get("class", []):
                 table_data = self._parse_table(element)
                 if table_data:
-                    items.append({
-                        "type": "table",
-                        "section": current_section,
-                        "data": table_data,
-                    })
+                    items.append(
+                        {
+                            "type": "table",
+                            "section": current_section,
+                            "data": table_data,
+                        }
+                    )
 
         return items
 
@@ -183,10 +189,7 @@ class WikipediaScraper(BaseScraper):
         for row in rows[1:]:
             cells = row.find_all(["td", "th"])
             if len(cells) == len(headers):
-                data.append({
-                    h: self._clean_text(c.get_text())
-                    for h, c in zip(headers, cells)
-                })
+                data.append({h: self._clean_text(c.get_text()) for h, c in zip(headers, cells)})
         return data
 
     def _clean_text(self, text: str) -> str:

--- a/src/pyscrappy/scrapers/youtube.py
+++ b/src/pyscrappy/scrapers/youtube.py
@@ -60,9 +60,7 @@ class YouTubeScraper(BaseScraper):
             return self._scrape_search(query, max_results, render_js)
         raise ValueError("Provide either query or channel_url")
 
-    def _scrape_search(
-        self, query: str, max_results: int, render_js: bool
-    ) -> ScrapeResult:
+    def _scrape_search(self, query: str, max_results: int, render_js: bool) -> ScrapeResult:
         url = f"https://www.youtube.com/results?search_query={quote_plus(query)}"
         html = self.fetch_html(url, render_js=render_js)
         videos = self._extract_from_html(html, max_results)
@@ -187,9 +185,7 @@ class YouTubeScraper(BaseScraper):
 
         return video
 
-    def _extract_from_rendered_html(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_from_rendered_html(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Fallback: parse rendered HTML with BeautifulSoup."""
         soup = self.parse_html(html)
         videos: list[dict[str, Any]] = []

--- a/src/pyscrappy/scrapers/zomato.py
+++ b/src/pyscrappy/scrapers/zomato.py
@@ -60,22 +60,22 @@ class ZomatoScraper(BaseScraper):
         errors: list[ScrapeError] = []
 
         if render_js:
-            html = self.browser.get_html(
-                url, wait_for="networkidle", scroll_pages=scroll_pages
-            )
+            html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
         restaurants = self._extract_restaurants(html, max_results)
 
         if not restaurants:
-            errors.append(ScrapeError(
-                url=url,
-                message=(
-                    "No restaurants extracted. Zomato requires JS rendering"
-                    " — use render_js=True."
-                ),
-            ))
+            errors.append(
+                ScrapeError(
+                    url=url,
+                    message=(
+                        "No restaurants extracted. Zomato requires JS rendering"
+                        " — use render_js=True."
+                    ),
+                )
+            )
 
         return ScrapeResult(
             data=restaurants,
@@ -83,9 +83,7 @@ class ZomatoScraper(BaseScraper):
             errors=errors,
         )
 
-    def _extract_restaurants(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_restaurants(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Extract restaurant data from Zomato HTML."""
         # Try embedded JSON first
         json_data = self._extract_from_next_data(html, max_results)
@@ -129,10 +127,7 @@ class ZomatoScraper(BaseScraper):
             restaurant["url"] = href
 
         # Rating
-        rating_el = card.select_one(
-            "[class*='rating'], "
-            "[class*='Rating']"
-        )
+        rating_el = card.select_one("[class*='rating'], [class*='Rating']")
         if rating_el:
             text = rating_el.get_text(strip=True)
             if text and text[0].isdigit():
@@ -155,13 +150,12 @@ class ZomatoScraper(BaseScraper):
 
         return restaurant
 
-    def _extract_from_next_data(
-        self, html: str, max_results: int
-    ) -> list[dict[str, Any]]:
+    def _extract_from_next_data(self, html: str, max_results: int) -> list[dict[str, Any]]:
         """Extract from Zomato's embedded page data."""
         match = re.search(
             r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
-            html, re.DOTALL,
+            html,
+            re.DOTALL,
         )
         if not match:
             return []
@@ -175,9 +169,7 @@ class ZomatoScraper(BaseScraper):
         self._find_restaurants(data, restaurants, max_results)
         return restaurants
 
-    def _find_restaurants(
-        self, data: Any, results: list[dict[str, Any]], max_results: int
-    ) -> None:
+    def _find_restaurants(self, data: Any, results: list[dict[str, Any]], max_results: int) -> None:
         """Recursively find restaurant objects in Zomato's JSON."""
         if len(results) >= max_results:
             return
@@ -185,29 +177,32 @@ class ZomatoScraper(BaseScraper):
         if isinstance(data, dict):
             # Zomato nests restaurant data in various structures
             info = data.get("info") or data.get("restaurant") or data
-            if isinstance(info, dict) and info.get("name") and (
-                info.get("cuisine_string") or info.get("cuisines")
+            if (
+                isinstance(info, dict)
+                and info.get("name")
+                and (info.get("cuisine_string") or info.get("cuisines"))
             ):
                 cuisines = info.get("cuisine_string", "")
                 if not cuisines and info.get("cuisines"):
                     cuisines = ", ".join(
-                        c.get("name", "") for c in info["cuisines"]
-                        if isinstance(c, dict)
+                        c.get("name", "") for c in info["cuisines"] if isinstance(c, dict)
                     )
-                results.append({
-                    "name": info.get("name", ""),
-                    "cuisine": cuisines,
-                    "rating": info.get("rating", {}).get("aggregate_rating")
-                    if isinstance(info.get("rating"), dict)
-                    else info.get("rating"),
-                    "price": (
-                        info.get("average_cost_for_two")
-                        or info.get("cfo", {}).get("text", "")
-                    ),
-                    "address": info.get("location", {}).get("address", "")
-                    if isinstance(info.get("location"), dict) else "",
-                    "url": f"https://www.zomato.com/restaurant/{info.get('id', '')}",
-                })
+                results.append(
+                    {
+                        "name": info.get("name", ""),
+                        "cuisine": cuisines,
+                        "rating": info.get("rating", {}).get("aggregate_rating")
+                        if isinstance(info.get("rating"), dict)
+                        else info.get("rating"),
+                        "price": (
+                            info.get("average_cost_for_two") or info.get("cfo", {}).get("text", "")
+                        ),
+                        "address": info.get("location", {}).get("address", "")
+                        if isinstance(info.get("location"), dict)
+                        else "",
+                        "url": f"https://www.zomato.com/restaurant/{info.get('id', '')}",
+                    }
+                )
                 return
 
             for value in data.values():

--- a/tests/test_core/test_base.py
+++ b/tests/test_core/test_base.py
@@ -1,6 +1,6 @@
 """Tests for pyscrappy.core.base."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from bs4 import BeautifulSoup

--- a/tests/test_core/test_browser.py
+++ b/tests/test_core/test_browser.py
@@ -26,6 +26,7 @@ class TestBrowserManagerInit:
 class TestBrowserManagerImportError:
     def test_start_raises_browser_not_installed_when_no_playwright(self, monkeypatch):
         import builtins
+
         real_import = builtins.__import__
 
         def mock_import(name, *args, **kwargs):

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -1,6 +1,6 @@
 """Tests for pyscrappy.core.config."""
 
-from pyscrappy.core.config import ScraperConfig, _DEFAULT_USER_AGENTS
+from pyscrappy.core.config import _DEFAULT_USER_AGENTS, ScraperConfig
 
 
 class TestScraperConfig:

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -268,18 +268,14 @@ class TestHttpClientCaching:
         client.close()
 
     def test_cache_hit_skips_network(self):
-        client, mock_httpx = self._mock_client(
-            ScraperConfig(rate_limit=0, cache_ttl=60)
-        )
+        client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         for _ in range(3):
             client.get("https://example.com")
         assert mock_httpx.get.call_count == 1  # only first hit the network
         client.close()
 
     def test_params_are_part_of_key(self):
-        client, mock_httpx = self._mock_client(
-            ScraperConfig(rate_limit=0, cache_ttl=60)
-        )
+        client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get("https://api.example.com", params={"q": "a"})
         client.get("https://api.example.com", params={"q": "a"})  # cached
         client.get("https://api.example.com", params={"q": "b"})  # new key
@@ -287,9 +283,7 @@ class TestHttpClientCaching:
         client.close()
 
     def test_clear_cache_forces_refetch(self):
-        client, mock_httpx = self._mock_client(
-            ScraperConfig(rate_limit=0, cache_ttl=60)
-        )
+        client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get("https://example.com")
         client.clear_cache()
         client.get("https://example.com")
@@ -298,9 +292,7 @@ class TestHttpClientCaching:
 
     def test_non_2xx_not_cached(self):
         # get_raw bypasses caching entirely; only successful get() responses cache
-        client, mock_httpx = self._mock_client(
-            ScraperConfig(rate_limit=0, cache_ttl=60)
-        )
+        client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get_raw("https://example.com")
         client.get_raw("https://example.com")
         assert mock_httpx.get.call_count == 2

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -31,6 +31,7 @@ class TestScrapeMetadata:
         meta = ScrapeMetadata()
         # Should be parseable as ISO datetime
         from datetime import datetime
+
         dt = datetime.fromisoformat(meta.timestamp)
         assert dt is not None
 
@@ -95,6 +96,7 @@ class TestScrapeResult:
 
     def test_to_dataframe_missing_pandas(self, monkeypatch):
         import builtins
+
         real_import = builtins.__import__
 
         def mock_import(name, *args, **kwargs):
@@ -108,10 +110,7 @@ class TestScrapeResult:
             result.to_dataframe()
 
     def test_to_dataframe_with_pandas(self):
-        try:
-            import pandas as pd
-        except ImportError:
-            pytest.skip("pandas not installed")
+        pytest.importorskip("pandas")
 
         result = ScrapeResult(data=[{"a": 1, "b": 2}, {"a": 3, "b": 4}])
         df = result.to_dataframe()

--- a/tests/test_core/test_proxy.py
+++ b/tests/test_core/test_proxy.py
@@ -86,9 +86,7 @@ class TestScraperApiRouting:
         return client, mock
 
     def test_routes_through_service(self):
-        cfg = ScraperConfig(
-            scraper_api={"provider": "scraperapi", "api_key": "K"}, rate_limit=0
-        )
+        cfg = ScraperConfig(scraper_api={"provider": "scraperapi", "api_key": "K"}, rate_limit=0)
         client, mock = self._client(cfg)
         client.get_html("https://ebay.com/sch", params={"q": "laptop"})
         call = mock.get.call_args

--- a/tests/test_generic/test_extractors.py
+++ b/tests/test_generic/test_extractors.py
@@ -25,16 +25,12 @@ class TestMetadataExtractor:
         assert result["title"] == "Test Page"
 
     def test_extract_description(self):
-        soup = _soup(
-            '<html><head><meta name="description" content="A test page"></head></html>'
-        )
+        soup = _soup('<html><head><meta name="description" content="A test page"></head></html>')
         result = self.extractor.extract(soup)
         assert result["description"] == "A test page"
 
     def test_extract_author(self):
-        soup = _soup(
-            '<html><head><meta name="author" content="John Doe"></head></html>'
-        )
+        soup = _soup('<html><head><meta name="author" content="John Doe"></head></html>')
         result = self.extractor.extract(soup)
         assert result["author"] == "John Doe"
 
@@ -47,10 +43,10 @@ class TestMetadataExtractor:
 
     def test_extract_og_tags(self):
         soup = _soup(
-            '<html><head>'
+            "<html><head>"
             '<meta property="og:title" content="OG Title">'
             '<meta property="og:image" content="https://img.com/pic.jpg">'
-            '</head></html>'
+            "</head></html>"
         )
         result = self.extractor.extract(soup)
         assert result["og"]["title"] == "OG Title"
@@ -58,9 +54,7 @@ class TestMetadataExtractor:
 
     def test_extract_twitter_card(self):
         soup = _soup(
-            '<html><head>'
-            '<meta name="twitter:card" content="summary_large_image">'
-            '</head></html>'
+            '<html><head><meta name="twitter:card" content="summary_large_image"></head></html>'
         )
         result = self.extractor.extract(soup)
         assert result["twitter_card"]["card"] == "summary_large_image"
@@ -119,11 +113,7 @@ class TestTextExtractor:
 
     def test_extract_headings(self):
         soup = _soup(
-            "<html><body>"
-            "<h1>Main Title</h1>"
-            "<h2>Section One</h2>"
-            "<h3>Subsection</h3>"
-            "</body></html>"
+            "<html><body><h1>Main Title</h1><h2>Section One</h2><h3>Subsection</h3></body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result["headings"]) == 3
@@ -152,11 +142,11 @@ class TestTextExtractor:
 
     def test_removes_noise_classes(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<div class="sidebar">Sidebar content</div>'
             '<div class="ad-banner">Ad content</div>'
-            '<p>This is the real content paragraph of the page that should remain.</p>'
-            '</body></html>'
+            "<p>This is the real content paragraph of the page that should remain.</p>"
+            "</body></html>"
         )
         result = self.extractor.extract(soup)
         assert "Sidebar content" not in result["text"]
@@ -177,10 +167,10 @@ class TestLinkExtractor:
 
     def test_extract_links(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="https://example.com/page1">Page 1</a>'
             '<a href="/page2">Page 2</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = self.extractor.extract(soup, "https://example.com")
         assert len(result) == 2
@@ -190,23 +180,23 @@ class TestLinkExtractor:
 
     def test_deduplication(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="https://example.com/page">Link 1</a>'
             '<a href="https://example.com/page">Link 2</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = self.extractor.extract(soup, "https://example.com")
         assert len(result) == 1
 
     def test_skips_javascript_mailto_tel_hash(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="javascript:void(0)">JS</a>'
             '<a href="mailto:test@test.com">Email</a>'
             '<a href="tel:+1234567890">Phone</a>'
             '<a href="#">Top</a>'
             '<a href="https://real.com">Real</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
@@ -214,9 +204,9 @@ class TestLinkExtractor:
 
     def test_extracts_rel(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="https://external.com" rel="nofollow noopener">External</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = self.extractor.extract(soup)
         assert result[0]["rel"] == "nofollow noopener"
@@ -227,9 +217,7 @@ class TestLinkExtractor:
         assert len(result) == 0
 
     def test_relative_urls_resolved(self):
-        soup = _soup(
-            '<html><body><a href="/relative/path">Link</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/relative/path">Link</a></body></html>')
         result = self.extractor.extract(soup, "https://base.com")
         assert result[0]["url"] == "https://base.com/relative/path"
 
@@ -240,9 +228,9 @@ class TestImageExtractor:
 
     def test_extract_images(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<img src="https://img.com/pic.jpg" alt="A picture" width="100" height="200">'
-            '</body></html>'
+            "</body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
@@ -253,9 +241,7 @@ class TestImageExtractor:
 
     def test_lazy_loaded_images(self):
         soup = _soup(
-            '<html><body>'
-            '<img data-src="https://img.com/lazy.jpg" alt="Lazy">'
-            '</body></html>'
+            '<html><body><img data-src="https://img.com/lazy.jpg" alt="Lazy"></body></html>'
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
@@ -263,9 +249,7 @@ class TestImageExtractor:
 
     def test_data_lazy_src(self):
         soup = _soup(
-            '<html><body>'
-            '<img data-lazy-src="https://img.com/lazy2.jpg" alt="Lazy2">'
-            '</body></html>'
+            '<html><body><img data-lazy-src="https://img.com/lazy2.jpg" alt="Lazy2"></body></html>'
         )
         result = self.extractor.extract(soup)
         assert result[0]["url"] == "https://img.com/lazy2.jpg"
@@ -276,9 +260,7 @@ class TestImageExtractor:
         assert len(result) == 0
 
     def test_relative_image_url_resolved(self):
-        soup = _soup(
-            '<html><body><img src="/images/pic.jpg"></body></html>'
-        )
+        soup = _soup('<html><body><img src="/images/pic.jpg"></body></html>')
         result = self.extractor.extract(soup, "https://example.com")
         assert result[0]["url"] == "https://example.com/images/pic.jpg"
 
@@ -296,11 +278,11 @@ class TestTableExtractor:
 
     def test_extract_table(self):
         soup = _soup(
-            '<html><body><table>'
-            '<tr><th>Name</th><th>Age</th></tr>'
-            '<tr><td>Alice</td><td>30</td></tr>'
-            '<tr><td>Bob</td><td>25</td></tr>'
-            '</table></body></html>'
+            "<html><body><table>"
+            "<tr><th>Name</th><th>Age</th></tr>"
+            "<tr><td>Alice</td><td>30</td></tr>"
+            "<tr><td>Bob</td><td>25</td></tr>"
+            "</table></body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
@@ -310,21 +292,21 @@ class TestTableExtractor:
 
     def test_multiple_tables(self):
         soup = _soup(
-            '<html><body>'
-            '<table><tr><th>A</th></tr><tr><td>1</td></tr></table>'
-            '<table><tr><th>B</th></tr><tr><td>2</td></tr></table>'
-            '</body></html>'
+            "<html><body>"
+            "<table><tr><th>A</th></tr><tr><td>1</td></tr></table>"
+            "<table><tr><th>B</th></tr><tr><td>2</td></tr></table>"
+            "</body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 2
 
     def test_skips_rows_with_wrong_column_count(self):
         soup = _soup(
-            '<html><body><table>'
-            '<tr><th>A</th><th>B</th></tr>'
-            '<tr><td>1</td></tr>'
-            '<tr><td>2</td><td>3</td></tr>'
-            '</table></body></html>'
+            "<html><body><table>"
+            "<tr><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td></tr>"
+            "<tr><td>2</td><td>3</td></tr>"
+            "</table></body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
@@ -332,25 +314,21 @@ class TestTableExtractor:
         assert result[0][0] == {"A": "2", "B": "3"}
 
     def test_empty_table_skipped(self):
-        soup = _soup('<html><body><table></table></body></html>')
+        soup = _soup("<html><body><table></table></body></html>")
         result = self.extractor.extract(soup)
         assert result == []
 
     def test_table_with_no_data_rows(self):
-        soup = _soup(
-            '<html><body><table>'
-            '<tr><th>Header</th></tr>'
-            '</table></body></html>'
-        )
+        soup = _soup("<html><body><table><tr><th>Header</th></tr></table></body></html>")
         result = self.extractor.extract(soup)
         assert result == []
 
     def test_headers_from_td_in_first_row(self):
         soup = _soup(
-            '<html><body><table>'
-            '<tr><td>Col1</td><td>Col2</td></tr>'
-            '<tr><td>A</td><td>B</td></tr>'
-            '</table></body></html>'
+            "<html><body><table>"
+            "<tr><td>Col1</td><td>Col2</td></tr>"
+            "<tr><td>A</td><td>B</td></tr>"
+            "</table></body></html>"
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1

--- a/tests/test_generic/test_pagination.py
+++ b/tests/test_generic/test_pagination.py
@@ -15,76 +15,58 @@ def _soup(html: str) -> BeautifulSoup:
 
 class TestFindNextPageUrl:
     def test_link_rel_next(self):
-        soup = _soup(
-            '<html><head><link rel="next" href="/page/2"></head></html>'
-        )
+        soup = _soup('<html><head><link rel="next" href="/page/2"></head></html>')
         result = find_next_page_url(soup, "https://example.com/page/1")
         assert result == "https://example.com/page/2"
 
     def test_next_text_link(self):
-        soup = _soup(
-            '<html><body><a href="/page/2">Next</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/page/2">Next</a></body></html>')
         result = find_next_page_url(soup, "https://example.com/page/1")
         assert result == "https://example.com/page/2"
 
     def test_next_arrow_link(self):
-        soup = _soup(
-            '<html><body><a href="/page/2">></a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/page/2">></a></body></html>')
         result = find_next_page_url(soup, "https://example.com/page/1")
         assert result == "https://example.com/page/2"
 
     def test_next_double_arrow(self):
-        soup = _soup(
-            '<html><body><a href="/page/2">\u00bb</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/page/2">\u00bb</a></body></html>')
         result = find_next_page_url(soup, "https://example.com/page/1")
         assert result == "https://example.com/page/2"
 
     def test_next_page_text(self):
-        soup = _soup(
-            '<html><body><a href="?page=2">Next Page</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="?page=2">Next Page</a></body></html>')
         result = find_next_page_url(soup, "https://example.com?page=1")
         assert result == "https://example.com?page=2"
 
     def test_aria_label_next(self):
-        soup = _soup(
-            '<html><body><a href="/p/2" aria-label="Next page">2</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/p/2" aria-label="Next page">2</a></body></html>')
         result = find_next_page_url(soup, "https://example.com/p/1")
         assert result is not None
 
     def test_next_class_with_page_url(self):
-        soup = _soup(
-            '<html><body><a href="?page=3" class="next-btn">3</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="?page=3" class="next-btn">3</a></body></html>')
         result = find_next_page_url(soup, "https://example.com?page=2")
         assert result == "https://example.com?page=3"
 
     def test_numbered_pagination(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="?page=1">1</a>'
             '<a href="?page=2">2</a>'
             '<a href="?page=3">3</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = find_next_page_url(soup, "https://example.com?page=2")
         assert result == "https://example.com?page=3"
 
     def test_no_next_page(self):
-        soup = _soup(
-            '<html><body><a href="/about">About</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="/about">About</a></body></html>')
         result = find_next_page_url(soup, "https://example.com/page/5")
         assert result is None
 
     def test_load_more_text(self):
-        soup = _soup(
-            '<html><body><a href="?page=2">Load More</a></body></html>'
-        )
+        soup = _soup('<html><body><a href="?page=2">Load More</a></body></html>')
         result = find_next_page_url(soup, "https://example.com?page=1")
         assert result == "https://example.com?page=2"
 
@@ -112,11 +94,11 @@ class TestExtractPageNumber:
 class TestFindPageNumberLinks:
     def test_finds_pagination_links(self):
         soup = _soup(
-            '<html><body>'
+            "<html><body>"
             '<a href="?page=1">1</a>'
             '<a href="?page=2">2</a>'
             '<a href="?page=3">3</a>'
-            '</body></html>'
+            "</body></html>"
         )
         result = _find_page_number_links(soup, "https://example.com")
         assert len(result) == 3
@@ -124,16 +106,11 @@ class TestFindPageNumberLinks:
         assert result[2] == (3, "https://example.com?page=3")
 
     def test_ignores_non_pagination_links(self):
-        soup = _soup(
-            '<html><body>'
-            '<a href="/about">About</a>'
-            '<a href="?page=2">2</a>'
-            '</body></html>'
-        )
+        soup = _soup('<html><body><a href="/about">About</a><a href="?page=2">2</a></body></html>')
         result = _find_page_number_links(soup, "https://example.com")
         assert len(result) == 1
 
     def test_empty_page(self):
-        soup = _soup('<html><body></body></html>')
+        soup = _soup("<html><body></body></html>")
         result = _find_page_number_links(soup, "https://example.com")
         assert result == []

--- a/tests/test_generic/test_scraper.py
+++ b/tests/test_generic/test_scraper.py
@@ -2,12 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.models import ScrapeResult
 from pyscrappy.generic.scraper import GenericScraper
-
 
 SAMPLE_HTML = """
 <html lang="en">
@@ -101,7 +97,7 @@ class TestGenericScraperScrape:
         result = scraper.scrape(url="https://example.com")
         links = result.data[0]["links"]
         assert len(links) >= 1
-        urls = [l["url"] for l in links]
+        urls = [link["url"] for link in links]
         assert "https://example.com/link1" in urls
         scraper.close()
 
@@ -235,7 +231,9 @@ class TestGenericScraperPagination:
         scraper.close()
 
     def test_stops_when_no_next_page(self):
-        page1 = "<html><body><p>Only page with long enough content for the extractor.</p></body></html>"
+        page1 = (
+            "<html><body><p>Only page with long enough content for the extractor.</p></body></html>"
+        )
         scraper = GenericScraper()
         mock_http = MagicMock()
         mock_http.get_html.return_value = page1

--- a/tests/test_mcp/test_agent.py
+++ b/tests/test_mcp/test_agent.py
@@ -93,9 +93,7 @@ async def test_string_arguments_are_parsed(monkeypatch):
             {
                 "role": "assistant",
                 "content": "",
-                "tool_calls": [
-                    {"function": {"name": "define_word", "arguments": '{"word": "x"}'}}
-                ],
+                "tool_calls": [{"function": {"name": "define_word", "arguments": '{"word": "x"}'}}],
             },
             {"role": "assistant", "content": "done"},
         ],

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,10 +2,8 @@
 
 import pytest
 
-import pyscrappy
-from pyscrappy import BaseScraper, get_scraper, list_scrapers, register, register_scraper
+from pyscrappy import BaseScraper, get_scraper, list_scrapers, register, register_scraper, registry
 from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
-from pyscrappy import registry
 
 
 class _Dummy(BaseScraper):

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -17,13 +17,24 @@ def _with(scraper, *responses):
 
 class TestGitHub:
     def test_parse(self):
-        payload = json.dumps({"items": [{
-            "name": "pyscrappy", "full_name": "mldsveda/pyscrappy",
-            "owner": {"login": "mldsveda"}, "description": "scraping toolkit",
-            "html_url": "https://github.com/mldsveda/pyscrappy",
-            "stargazers_count": 90, "forks_count": 31, "language": "Python",
-            "open_issues_count": 2, "updated_at": "2026-01-01",
-        }]})
+        payload = json.dumps(
+            {
+                "items": [
+                    {
+                        "name": "pyscrappy",
+                        "full_name": "mldsveda/pyscrappy",
+                        "owner": {"login": "mldsveda"},
+                        "description": "scraping toolkit",
+                        "html_url": "https://github.com/mldsveda/pyscrappy",
+                        "stargazers_count": 90,
+                        "forks_count": 31,
+                        "language": "Python",
+                        "open_issues_count": 2,
+                        "updated_at": "2026-01-01",
+                    }
+                ]
+            }
+        )
         s = _with(GitHubScraper(token="t"), payload)
         r = s.scrape(query="scraping")
         assert len(r.data) == 1
@@ -42,11 +53,21 @@ class TestGitHub:
 
 class TestHackerNews:
     def test_parse(self):
-        payload = json.dumps({"hits": [{
-            "title": "Show HN: PyScrappy", "url": "https://example.com",
-            "points": 42, "author": "veda", "num_comments": 7,
-            "created_at": "2026-01-01", "objectID": "12345",
-        }]})
+        payload = json.dumps(
+            {
+                "hits": [
+                    {
+                        "title": "Show HN: PyScrappy",
+                        "url": "https://example.com",
+                        "points": 42,
+                        "author": "veda",
+                        "num_comments": 7,
+                        "created_at": "2026-01-01",
+                        "objectID": "12345",
+                    }
+                ]
+            }
+        )
         s = _with(HackerNewsScraper(), payload)
         r = s.scrape(query="pyscrappy")
         assert len(r.data) == 1
@@ -64,11 +85,21 @@ class TestHackerNews:
 
 class TestOpenLibrary:
     def test_parse(self):
-        payload = json.dumps({"docs": [{
-            "title": "Dune", "author_name": ["Frank Herbert"],
-            "first_publish_year": 1965, "edition_count": 100,
-            "language": ["eng"], "key": "/works/OL893415W", "cover_i": 111,
-        }]})
+        payload = json.dumps(
+            {
+                "docs": [
+                    {
+                        "title": "Dune",
+                        "author_name": ["Frank Herbert"],
+                        "first_publish_year": 1965,
+                        "edition_count": 100,
+                        "language": ["eng"],
+                        "key": "/works/OL893415W",
+                        "cover_i": 111,
+                    }
+                ]
+            }
+        )
         s = _with(OpenLibraryScraper(), payload)
         r = s.scrape(query="dune")
         assert len(r.data) == 1
@@ -87,16 +118,30 @@ class TestOpenLibrary:
 
 class TestWeather:
     def test_geocode_then_forecast(self):
-        geo = json.dumps({"results": [{
-            "name": "London", "country": "United Kingdom",
-            "latitude": 51.5, "longitude": -0.12,
-        }]})
-        forecast = json.dumps({
-            "current": {"time": "2026-01-01T12:00", "temperature_2m": 15.0,
-                        "relative_humidity_2m": 60, "wind_speed_10m": 10.0,
-                        "weather_code": 3},
-            "current_units": {"temperature_2m": "°C", "wind_speed_10m": "km/h"},
-        })
+        geo = json.dumps(
+            {
+                "results": [
+                    {
+                        "name": "London",
+                        "country": "United Kingdom",
+                        "latitude": 51.5,
+                        "longitude": -0.12,
+                    }
+                ]
+            }
+        )
+        forecast = json.dumps(
+            {
+                "current": {
+                    "time": "2026-01-01T12:00",
+                    "temperature_2m": 15.0,
+                    "relative_humidity_2m": 60,
+                    "wind_speed_10m": 10.0,
+                    "weather_code": 3,
+                },
+                "current_units": {"temperature_2m": "°C", "wind_speed_10m": "km/h"},
+            }
+        )
         s = _with(WeatherScraper(), geo, forecast)
         r = s.scrape(location="London")
         assert len(r.data) == 1

--- a/tests/test_scrapers/test_data_apis.py
+++ b/tests/test_scrapers/test_data_apis.py
@@ -16,12 +16,22 @@ def _mock(scraper, *responses):
 
 class TestCrypto:
     def test_top_coins(self):
-        payload = json.dumps([{
-            "id": "bitcoin", "name": "Bitcoin", "symbol": "btc",
-            "current_price": 64000, "market_cap": 1200000000000,
-            "market_cap_rank": 1, "price_change_percentage_24h": 1.5,
-            "total_volume": 30000000000, "high_24h": 64500, "low_24h": 63000,
-        }])
+        payload = json.dumps(
+            [
+                {
+                    "id": "bitcoin",
+                    "name": "Bitcoin",
+                    "symbol": "btc",
+                    "current_price": 64000,
+                    "market_cap": 1200000000000,
+                    "market_cap_rank": 1,
+                    "price_change_percentage_24h": 1.5,
+                    "total_volume": 30000000000,
+                    "high_24h": 64500,
+                    "low_24h": 63000,
+                }
+            ]
+        )
         s = _mock(CryptoScraper(), payload)
         r = s.scrape(max_results=1)
         assert len(r.data) == 1
@@ -34,8 +44,9 @@ class TestCrypto:
 
     def test_query_resolves_ids(self):
         search = json.dumps({"coins": [{"id": "ethereum"}]})
-        markets = json.dumps([{"id": "ethereum", "name": "Ethereum", "symbol": "eth",
-                               "current_price": 1800}])
+        markets = json.dumps(
+            [{"id": "ethereum", "name": "Ethereum", "symbol": "eth", "current_price": 1800}]
+        )
         s = _mock(CryptoScraper(), search, markets)
         r = s.scrape(query="eth")
         assert r.data[0]["name"] == "Ethereum"
@@ -45,11 +56,14 @@ class TestCrypto:
 
 class TestCurrency:
     def test_rates_and_conversion(self):
-        payload = json.dumps({
-            "result": "success", "base_code": "USD",
-            "time_last_update_utc": "Sat, 01 Jan 2026 00:00:00 +0000",
-            "rates": {"EUR": 0.9, "GBP": 0.8, "JPY": 150.0},
-        })
+        payload = json.dumps(
+            {
+                "result": "success",
+                "base_code": "USD",
+                "time_last_update_utc": "Sat, 01 Jan 2026 00:00:00 +0000",
+                "rates": {"EUR": 0.9, "GBP": 0.8, "JPY": 150.0},
+            }
+        )
         s = _mock(CurrencyScraper(), payload)
         r = s.scrape(base="USD", to="EUR,GBP", amount=100)
         assert len(r.data) == 2  # only EUR + GBP
@@ -58,7 +72,9 @@ class TestCurrency:
         assert by_code["GBP"]["converted"] == 80.0
 
     def test_api_error(self):
-        s = _mock(CurrencyScraper(), json.dumps({"result": "error", "error-type": "unsupported-code"}))
+        s = _mock(
+            CurrencyScraper(), json.dumps({"result": "error", "error-type": "unsupported-code"})
+        )
         r = s.scrape(base="XXX")
         assert r.data == []
         assert "unsupported-code" in r.errors[0].message
@@ -66,13 +82,26 @@ class TestCurrency:
 
 class TestDictionary:
     def test_definitions(self):
-        payload = json.dumps([{
-            "word": "test", "phonetic": "/tɛst/",
-            "meanings": [{"partOfSpeech": "noun", "definitions": [
-                {"definition": "A procedure to establish quality.",
-                 "example": "a test of skill", "synonyms": ["trial"]},
-            ]}],
-        }])
+        payload = json.dumps(
+            [
+                {
+                    "word": "test",
+                    "phonetic": "/tɛst/",
+                    "meanings": [
+                        {
+                            "partOfSpeech": "noun",
+                            "definitions": [
+                                {
+                                    "definition": "A procedure to establish quality.",
+                                    "example": "a test of skill",
+                                    "synonyms": ["trial"],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        )
         s = _mock(DictionaryScraper(), payload)
         r = s.scrape(word="test")
         assert len(r.data) == 1

--- a/tests/test_scrapers/test_food.py
+++ b/tests/test_scrapers/test_food.py
@@ -10,27 +10,31 @@ from pyscrappy.scrapers.zomato import ZomatoScraper
 ZOMATO_NEXT_DATA = {
     "props": {
         "pageProps": {
-            "sections": [{
-                "cards": [{
-                    "info": {
-                        "id": "67890",
-                        "name": "Biryani House",
-                        "cuisine_string": "Biryani, North Indian",
-                        "rating": {"aggregate_rating": "4.3"},
-                        "average_cost_for_two": 600,
-                        "location": {"address": "123 Main St, Mumbai"},
-                    }
-                }]
-            }]
+            "sections": [
+                {
+                    "cards": [
+                        {
+                            "info": {
+                                "id": "67890",
+                                "name": "Biryani House",
+                                "cuisine_string": "Biryani, North Indian",
+                                "rating": {"aggregate_rating": "4.3"},
+                                "average_cost_for_two": 600,
+                                "location": {"address": "123 Main St, Mumbai"},
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     }
 }
 
 ZOMATO_HTML_JSON = (
-    '<html><body>'
+    "<html><body>"
     '<script id="__NEXT_DATA__" type="application/json">'
     + json.dumps(ZOMATO_NEXT_DATA)
-    + '</script></body></html>'
+    + "</script></body></html>"
 )
 
 ZOMATO_HTML_RENDERED = """

--- a/tests/test_scrapers/test_imdb.py
+++ b/tests/test_scrapers/test_imdb.py
@@ -10,31 +10,40 @@ from pyscrappy.scrapers.imdb import IMDBScraper
 
 # --- Sample OMDb payloads ---------------------------------------------------
 
-DETAILS_JSON = json.dumps({
-    "Title": "Inception",
-    "Year": "2010",
-    "Rated": "PG-13",
-    "Runtime": "148 min",
-    "Genre": "Action, Adventure, Sci-Fi",
-    "Director": "Christopher Nolan",
-    "Actors": "Leonardo DiCaprio, Joseph Gordon-Levitt",
-    "Plot": "A thief who steals corporate secrets...",
-    "imdbRating": "8.8",
-    "imdbVotes": "2,500,000",
-    "imdbID": "tt1375666",
-    "Type": "movie",
-    "Poster": "https://example.com/poster.jpg",
-    "Response": "True",
-})
+DETAILS_JSON = json.dumps(
+    {
+        "Title": "Inception",
+        "Year": "2010",
+        "Rated": "PG-13",
+        "Runtime": "148 min",
+        "Genre": "Action, Adventure, Sci-Fi",
+        "Director": "Christopher Nolan",
+        "Actors": "Leonardo DiCaprio, Joseph Gordon-Levitt",
+        "Plot": "A thief who steals corporate secrets...",
+        "imdbRating": "8.8",
+        "imdbVotes": "2,500,000",
+        "imdbID": "tt1375666",
+        "Type": "movie",
+        "Poster": "https://example.com/poster.jpg",
+        "Response": "True",
+    }
+)
 
-SEARCH_JSON = json.dumps({
-    "Search": [
-        {"Title": "Inception", "Year": "2010", "imdbID": "tt1375666",
-         "Type": "movie", "Poster": "https://example.com/p.jpg"},
-    ],
-    "totalResults": "41",
-    "Response": "True",
-})
+SEARCH_JSON = json.dumps(
+    {
+        "Search": [
+            {
+                "Title": "Inception",
+                "Year": "2010",
+                "imdbID": "tt1375666",
+                "Type": "movie",
+                "Poster": "https://example.com/p.jpg",
+            },
+        ],
+        "totalResults": "41",
+        "Response": "True",
+    }
+)
 
 NOT_FOUND_JSON = json.dumps({"Response": "False", "Error": "Movie not found!"})
 
@@ -121,12 +130,18 @@ class TestIMDBSearchByTitle:
 
 class TestNormalise:
     def test_na_becomes_absent(self):
-        payload = json.dumps({
-            "Title": "X", "Year": "2020", "imdbID": "tt1",
-            "Rated": "N/A", "Director": "N/A", "Response": "True",
-        })
+        payload = json.dumps(
+            {
+                "Title": "X",
+                "Year": "2020",
+                "imdbID": "tt1",
+                "Rated": "N/A",
+                "Director": "N/A",
+                "Response": "True",
+            }
+        )
         scraper = _scraper_with([payload])
         movie = scraper.scrape(query="tt1").data[0]
         assert movie["title"] == "X"
-        assert "rated" not in movie      # "N/A" dropped
+        assert "rated" not in movie  # "N/A" dropped
         assert "director" not in movie

--- a/tests/test_scrapers/test_music.py
+++ b/tests/test_scrapers/test_music.py
@@ -8,7 +8,6 @@ import pytest
 from pyscrappy.scrapers.soundcloud import SoundCloudScraper
 from pyscrappy.scrapers.spotify import SpotifyScraper
 
-
 # --- SoundCloud ---
 
 SC_HYDRATION = [
@@ -47,9 +46,9 @@ SC_HYDRATION = [
 ]
 
 SC_HTML_WITH_HYDRATION = (
-    '<html><body><script>window.__sc_hydration = '
+    "<html><body><script>window.__sc_hydration = "
     + json.dumps(SC_HYDRATION)
-    + '; </script></body></html>'
+    + "; </script></body></html>"
 )
 
 SC_HTML_RENDERED = """
@@ -148,10 +147,10 @@ SPOTIFY_RESOURCE_DATA = {
 }
 
 SPOTIFY_HTML_WITH_RESOURCE = (
-    '<html><body>'
+    "<html><body>"
     '<script id="initial-state" type="text/plain">'
     + __import__("base64").b64encode(json.dumps(SPOTIFY_RESOURCE_DATA).encode()).decode()
-    + '</script></body></html>'
+    + "</script></body></html>"
 )
 
 SPOTIFY_HTML_RENDERED = """

--- a/tests/test_scrapers/test_news.py
+++ b/tests/test_scrapers/test_news.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyscrappy.core.models import ScrapeResult
 from pyscrappy.scrapers.news import NewsScraper
 
 RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
@@ -218,6 +217,7 @@ class TestNewsScraperHelpers:
 
     def test_xml_text_missing_element(self):
         from xml.etree import ElementTree
+
         root = ElementTree.fromstring("<item><title>Test</title></item>")
         assert NewsScraper._xml_text(root, "title") == "Test"
         assert NewsScraper._xml_text(root, "description") == ""

--- a/tests/test_scrapers/test_other.py
+++ b/tests/test_scrapers/test_other.py
@@ -1,13 +1,9 @@
 """Tests for remaining scrapers: LinkedIn, ImageSearch."""
 
-import json
 from unittest.mock import MagicMock
 
-import pytest
-
-from pyscrappy.scrapers.linkedin import LinkedInJobsScraper
 from pyscrappy.scrapers.image_search import ImageSearchScraper
-
+from pyscrappy.scrapers.linkedin import LinkedInJobsScraper
 
 # --- LinkedIn ---
 
@@ -75,7 +71,7 @@ class TestLinkedInJobsScraper:
         mock_http.get_html.side_effect = [LINKEDIN_HTML, empty]
         scraper._http = mock_http
 
-        result = scraper.scrape(query="test", max_pages=2)
+        scraper.scrape(query="test", max_pages=2)
 
         calls = mock_http.get_html.call_args_list
         assert "start=0" in calls[0][0][0]

--- a/tests/test_scrapers/test_social.py
+++ b/tests/test_scrapers/test_social.py
@@ -5,10 +5,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyscrappy.scrapers.youtube import YouTubeScraper
 from pyscrappy.scrapers.instagram import InstagramScraper
 from pyscrappy.scrapers.twitter import TwitterScraper
-
+from pyscrappy.scrapers.youtube import YouTubeScraper
 
 # --- YouTube ---
 
@@ -17,25 +16,33 @@ YT_INITIAL_DATA = {
         "twoColumnSearchResultsRenderer": {
             "primaryContents": {
                 "sectionListRenderer": {
-                    "contents": [{
-                        "itemSectionRenderer": {
-                            "contents": [{
-                                "videoRenderer": {
-                                    "videoId": "dQw4w9WgXcQ",
-                                    "title": {"runs": [{"text": "Python Tutorial"}]},
-                                    "ownerText": {"runs": [{"text": "Corey Schafer"}]},
-                                    "viewCountText": {"simpleText": "5M views"},
-                                    "publishedTimeText": {"simpleText": "2 years ago"},
-                                    "lengthText": {"simpleText": "45:23"},
-                                    "thumbnailOverlays": [{}],
-                                    "thumbnail": {"thumbnails": [
-                                        {"url": "https://i.ytimg.com/vi/x/default.jpg"},
-                                        {"url": "https://i.ytimg.com/vi/x/hqdefault.jpg"},
-                                    ]},
-                                }
-                            }]
+                    "contents": [
+                        {
+                            "itemSectionRenderer": {
+                                "contents": [
+                                    {
+                                        "videoRenderer": {
+                                            "videoId": "dQw4w9WgXcQ",
+                                            "title": {"runs": [{"text": "Python Tutorial"}]},
+                                            "ownerText": {"runs": [{"text": "Corey Schafer"}]},
+                                            "viewCountText": {"simpleText": "5M views"},
+                                            "publishedTimeText": {"simpleText": "2 years ago"},
+                                            "lengthText": {"simpleText": "45:23"},
+                                            "thumbnailOverlays": [{}],
+                                            "thumbnail": {
+                                                "thumbnails": [
+                                                    {"url": "https://i.ytimg.com/vi/x/default.jpg"},
+                                                    {
+                                                        "url": "https://i.ytimg.com/vi/x/hqdefault.jpg"
+                                                    },
+                                                ]
+                                            },
+                                        }
+                                    }
+                                ]
+                            }
                         }
-                    }]
+                    ]
                 }
             }
         }
@@ -43,9 +50,9 @@ YT_INITIAL_DATA = {
 }
 
 YT_HTML = (
-    '<html><body><script>var ytInitialData = '
+    "<html><body><script>var ytInitialData = "
     + json.dumps(YT_INITIAL_DATA)
-    + ';</script></body></html>'
+    + ";</script></body></html>"
 )
 
 YT_RENDERED_HTML = """
@@ -97,11 +104,18 @@ class TestYouTubeScraper:
     def test_max_results_limit(self):
         scraper = YouTubeScraper()
         # Build HTML with multiple videos
-        data = {"contents": [{"videoRenderer": {
-            "videoId": f"vid{i}",
-            "title": {"runs": [{"text": f"Video {i}"}]},
-        }} for i in range(10)]}
-        html = f'<html><body><script>var ytInitialData = {json.dumps(data)};</script></body></html>'
+        data = {
+            "contents": [
+                {
+                    "videoRenderer": {
+                        "videoId": f"vid{i}",
+                        "title": {"runs": [{"text": f"Video {i}"}]},
+                    }
+                }
+                for i in range(10)
+            ]
+        }
+        html = f"<html><body><script>var ytInitialData = {json.dumps(data)};</script></body></html>"
         mock_http = MagicMock()
         mock_http.get_html.return_value = html
         scraper._http = mock_http
@@ -127,37 +141,43 @@ class TestYouTubeScraper:
 
 IG_SHARED_DATA = {
     "entry_data": {
-        "ProfilePage": [{
-            "graphql": {
-                "user": {
-                    "full_name": "National Geographic",
-                    "biography": "Experience the world.",
-                    "edge_followed_by": {"count": 250000000},
-                    "edge_follow": {"count": 150},
-                    "edge_owner_to_timeline_media": {
-                        "count": 25000,
-                        "edges": [{
-                            "node": {
-                                "shortcode": "ABC123",
-                                "edge_media_to_caption": {"edges": [{"node": {"text": "Beautiful sunset"}}]},
-                                "edge_liked_by": {"count": 100000},
-                                "edge_media_to_comment": {"count": 500},
-                            }
-                        }],
-                    },
-                    "is_verified": True,
-                    "profile_pic_url_hd": "https://pic.com/natgeo.jpg",
-                    "external_url": "https://natgeo.com",
+        "ProfilePage": [
+            {
+                "graphql": {
+                    "user": {
+                        "full_name": "National Geographic",
+                        "biography": "Experience the world.",
+                        "edge_followed_by": {"count": 250000000},
+                        "edge_follow": {"count": 150},
+                        "edge_owner_to_timeline_media": {
+                            "count": 25000,
+                            "edges": [
+                                {
+                                    "node": {
+                                        "shortcode": "ABC123",
+                                        "edge_media_to_caption": {
+                                            "edges": [{"node": {"text": "Beautiful sunset"}}]
+                                        },
+                                        "edge_liked_by": {"count": 100000},
+                                        "edge_media_to_comment": {"count": 500},
+                                    }
+                                }
+                            ],
+                        },
+                        "is_verified": True,
+                        "profile_pic_url_hd": "https://pic.com/natgeo.jpg",
+                        "external_url": "https://natgeo.com",
+                    }
                 }
             }
-        }]
+        ]
     }
 }
 
 IG_HTML_WITH_JSON = (
-    '<html><body><script>window._sharedData = '
+    "<html><body><script>window._sharedData = "
     + json.dumps(IG_SHARED_DATA)
-    + ';</script></body></html>'
+    + ";</script></body></html>"
 )
 
 IG_HTML_FALLBACK = """
@@ -172,30 +192,36 @@ IG_HTML_FALLBACK = """
 
 IG_HASHTAG_DATA = {
     "entry_data": {
-        "TagPage": [{
-            "graphql": {
-                "hashtag": {
-                    "edge_hashtag_to_media": {
-                        "edges": [{
-                            "node": {
-                                "shortcode": "XYZ789",
-                                "edge_media_to_caption": {"edges": [{"node": {"text": "Sunset pic"}}]},
-                                "edge_liked_by": {"count": 5000},
-                                "edge_media_to_comment": {"count": 50},
-                                "is_video": False,
-                            }
-                        }]
+        "TagPage": [
+            {
+                "graphql": {
+                    "hashtag": {
+                        "edge_hashtag_to_media": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "shortcode": "XYZ789",
+                                        "edge_media_to_caption": {
+                                            "edges": [{"node": {"text": "Sunset pic"}}]
+                                        },
+                                        "edge_liked_by": {"count": 5000},
+                                        "edge_media_to_comment": {"count": 50},
+                                        "is_video": False,
+                                    }
+                                }
+                            ]
+                        }
                     }
                 }
             }
-        }]
+        ]
     }
 }
 
 IG_HASHTAG_HTML = (
-    '<html><body><script>window._sharedData = '
+    "<html><body><script>window._sharedData = "
     + json.dumps(IG_HASHTAG_DATA)
-    + ';</script></body></html>'
+    + ";</script></body></html>"
 )
 
 
@@ -290,22 +316,24 @@ TWITTER_RENDERED_HTML = """
 """
 
 TWITTER_JSON_HTML = (
-    '<html><body><script>window.__INITIAL_STATE__ = '
-    + json.dumps({
-        "entities": {
-            "tweets": {
-                "entities": {
-                    "12345": {
-                        "full_text": "JSON extracted tweet",
-                        "created_at": "Mon Jan 15 10:00:00 +0000 2024",
-                        "retweet_count": 20,
-                        "favorite_count": 100,
+    "<html><body><script>window.__INITIAL_STATE__ = "
+    + json.dumps(
+        {
+            "entities": {
+                "tweets": {
+                    "entities": {
+                        "12345": {
+                            "full_text": "JSON extracted tweet",
+                            "created_at": "Mon Jan 15 10:00:00 +0000 2024",
+                            "retweet_count": 20,
+                            "favorite_count": 100,
+                        }
                     }
                 }
             }
         }
-    })
-    + ';</script></body></html>'
+    )
+    + ";</script></body></html>"
 )
 
 
@@ -324,7 +352,7 @@ class TestTwitterScraper:
         mock_http.get_html.return_value = "<html><body></body></html>"
         scraper._http = mock_http
 
-        result = scraper.scrape(hashtag="python")
+        scraper.scrape(hashtag="python")
         url = mock_http.get_html.call_args[0][0]
         assert "%23python" in url  # #python URL-encoded
         scraper.close()

--- a/tests/test_scrapers/test_stock.py
+++ b/tests/test_scrapers/test_stock.py
@@ -1,64 +1,68 @@
 """Tests for pyscrappy.scrapers.stock."""
 
-import json
 from unittest.mock import MagicMock
 
-import pytest
-
-from pyscrappy.core.exceptions import NetworkError
 from pyscrappy.core.models import ScrapeResult
 from pyscrappy.scrapers.stock import StockScraper
 
 QUOTE_JSON = {
     "chart": {
-        "result": [{
-            "meta": {
-                "symbol": "AAPL",
-                "currency": "USD",
-                "exchangeName": "NMS",
-                "regularMarketPrice": 175.50,
-                "chartPreviousClose": 174.20,
-                "regularMarketVolume": 50000000,
-                "regularMarketDayHigh": 176.00,
-                "regularMarketDayLow": 173.80,
-                "fiftyTwoWeekHigh": 199.62,
-                "fiftyTwoWeekLow": 124.17,
+        "result": [
+            {
+                "meta": {
+                    "symbol": "AAPL",
+                    "currency": "USD",
+                    "exchangeName": "NMS",
+                    "regularMarketPrice": 175.50,
+                    "chartPreviousClose": 174.20,
+                    "regularMarketVolume": 50000000,
+                    "regularMarketDayHigh": 176.00,
+                    "regularMarketDayLow": 173.80,
+                    "fiftyTwoWeekHigh": 199.62,
+                    "fiftyTwoWeekLow": 124.17,
+                }
             }
-        }]
+        ]
     }
 }
 
 HISTORY_JSON = {
     "chart": {
-        "result": [{
-            "timestamp": [1704067200, 1704153600],
-            "indicators": {
-                "quote": [{
-                    "open": [185.0, 186.0],
-                    "high": [186.5, 187.0],
-                    "low": [184.0, 185.5],
-                    "close": [186.0, 186.5],
-                    "volume": [40000000, 35000000],
-                }]
+        "result": [
+            {
+                "timestamp": [1704067200, 1704153600],
+                "indicators": {
+                    "quote": [
+                        {
+                            "open": [185.0, 186.0],
+                            "high": [186.5, 187.0],
+                            "low": [184.0, 185.5],
+                            "close": [186.0, 186.5],
+                            "volume": [40000000, 35000000],
+                        }
+                    ]
+                },
             }
-        }]
+        ]
     }
 }
 
 PROFILE_JSON = {
     "chart": {
-        "result": [{
-            "meta": {
-                "symbol": "AAPL",
-                "longName": "Apple Inc.",
-                "shortName": "Apple",
-                "currency": "USD",
-                "exchangeName": "NMS",
-                "market": "us_market",
-                "exchangeTimezoneName": "America/New_York",
-                "instrumentType": "EQUITY",
+        "result": [
+            {
+                "meta": {
+                    "symbol": "AAPL",
+                    "longName": "Apple Inc.",
+                    "shortName": "Apple",
+                    "currency": "USD",
+                    "exchangeName": "NMS",
+                    "market": "us_market",
+                    "exchangeTimezoneName": "America/New_York",
+                    "instrumentType": "EQUITY",
+                }
             }
-        }]
+        ]
     }
 }
 

--- a/tests/test_scrapers/test_ubereats.py
+++ b/tests/test_scrapers/test_ubereats.py
@@ -5,25 +5,46 @@ from unittest.mock import MagicMock
 
 from pyscrappy.scrapers.ubereats import UberEatsScraper
 
-GEO_JSON = json.dumps({"results": [{
-    "name": "London", "latitude": 51.5, "longitude": -0.12,
-}]})
+GEO_JSON = json.dumps(
+    {
+        "results": [
+            {
+                "name": "London",
+                "latitude": 51.5,
+                "longitude": -0.12,
+            }
+        ]
+    }
+)
 
-FEED_JSON = json.dumps({"data": {"cityName": "london", "feedItems": [
-    {"type": "REGULAR_STORE", "store": {
-        "storeUuid": "abc-123",
-        "title": {"text": "Domino's Pizza"},
-        "meta": [{"text": "£0.99 Delivery Fee"}, {"text": "20 min"}],
-        "actionUrl": "/store/dominos/abc-123",
-    }},
-    {"type": "DIVIDER"},
-    {"type": "REGULAR_STORE", "store": {
-        "storeUuid": "def-456",
-        "title": {"text": "Five Guys"},
-        "meta": [{"text": "10 min"}],
-        "actionUrl": "/store/five-guys/def-456",
-    }},
-]}})
+FEED_JSON = json.dumps(
+    {
+        "data": {
+            "cityName": "london",
+            "feedItems": [
+                {
+                    "type": "REGULAR_STORE",
+                    "store": {
+                        "storeUuid": "abc-123",
+                        "title": {"text": "Domino's Pizza"},
+                        "meta": [{"text": "£0.99 Delivery Fee"}, {"text": "20 min"}],
+                        "actionUrl": "/store/dominos/abc-123",
+                    },
+                },
+                {"type": "DIVIDER"},
+                {
+                    "type": "REGULAR_STORE",
+                    "store": {
+                        "storeUuid": "def-456",
+                        "title": {"text": "Five Guys"},
+                        "meta": [{"text": "10 min"}],
+                        "actionUrl": "/store/five-guys/def-456",
+                    },
+                },
+            ],
+        }
+    }
+)
 
 STORE_HTML = """
 <html><head>

--- a/tests/test_scrapers/test_wikipedia.py
+++ b/tests/test_scrapers/test_wikipedia.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from pyscrappy.core.models import ScrapeResult
 from pyscrappy.scrapers.wikipedia import WikipediaScraper
 


### PR DESCRIPTION
Extend the existing ruff setup with formatting and local auto-fix, and clear
the lint errors that were failing CI.

- pyproject.toml: add `ignore = ["E501"]` (the formatter owns line width).
- CI: lint job now also checks tests/ and runs `ruff format --check`.
- .pre-commit-config.yaml: run ruff --fix and ruff-format on staged files at
  commit time (one-time `pre-commit install`).
- Fix pre-existing lint errors: unused pandas import replaced with
  pytest.importorskip, ambiguous `l` renamed to `link`, and two unused
  `result` assignments dropped (the scrape call is kept for its side effect).
- Apply the initial format pass across src/ and tests/. No behavior changes;
  tests still pass.

Bump version to 1.3.2 (pyproject, __init__, and both server.json fields).