### PR TITLE
fix: migrate MCP server to the standalone fastmcp package (mcp 2.x co…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.2"
+version = "1.3.3"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"
@@ -45,13 +45,16 @@ dataframe = ["pandas>=1.5"]
 # The MCP SDK requires Python >=3.10. The core library still supports 3.9, so
 # gate these deps behind a marker: on 3.9 they're skipped, on 3.10+ installed.
 mcp = [
-    "mcp>=1.2; python_version >= '3.10'",
+    # FastMCP graduated out of the mcp SDK (removed from mcp 2.x) into the
+    # standalone `fastmcp` package, which we import directly. It requires
+    # Python >=3.10; the core library still supports 3.9, so gate behind a marker.
+    "fastmcp>=2.0; python_version >= '3.10'",
     "anyio>=4.0; python_version >= '3.10'",
 ]
 all = [
     "playwright>=1.40",
     "pandas>=1.5",
-    "mcp>=1.2; python_version >= '3.10'",
+    "fastmcp>=2.0; python_version >= '3.10'",
     "anyio>=4.0; python_version >= '3.10'",
 ]
 

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -101,7 +101,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/mcp/agent.py
+++ b/src/pyscrappy/mcp/agent.py
@@ -32,8 +32,9 @@ MAX_STEPS = 8
 async def _tool_specs() -> list[dict[str, Any]]:
     """Convert the MCP tool registry into Ollama's tool-definition format.
 
-    Ollama uses the OpenAI function-calling shape, and MCP's ``inputSchema`` is
-    already JSON Schema, so this is a straight re-wrap — one source of truth.
+    Ollama uses the OpenAI function-calling shape, and a fastmcp tool's
+    ``parameters`` is already JSON Schema, so this is a straight re-wrap — one
+    source of truth.
     """
     # Ensure plugin-declared tools are registered before we read the tool list,
     # so the local-model agent sees them too (not just the MCP server).
@@ -47,7 +48,7 @@ async def _tool_specs() -> list[dict[str, Any]]:
             "function": {
                 "name": t.name,
                 "description": t.description or "",
-                "parameters": t.inputSchema,
+                "parameters": t.parameters,
             },
         }
         for t in tools
@@ -57,10 +58,10 @@ async def _tool_specs() -> list[dict[str, Any]]:
 async def _call_tool(name: str, arguments: dict[str, Any]) -> str:
     """Run one scraper tool via the MCP registry, returning JSON for the model."""
     try:
-        _content, structured = await mcp.call_tool(name, arguments)
+        result = await mcp.call_tool(name, arguments)
     except Exception as exc:  # surface the failure to the model, don't crash the loop
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
-    return json.dumps(structured, default=str)
+    return json.dumps(result.structured_content, default=str)
 
 
 async def run_agent(

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 import anyio
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from pyscrappy import (
@@ -542,12 +542,24 @@ def _register_plugin_tools() -> None:
                 _tool.__signature__ = sig.replace(
                     parameters=params, return_annotation=ScrapeToolResult
                 )
+                # fastmcp derives the input schema from __annotations__ (not
+                # __signature__), so keep them in sync — otherwise pydantic looks
+                # up a signature param that's absent from annotations and raises
+                # KeyError. The real _tool takes **kwargs, so we rewrite its
+                # annotations to the scraper method's typed params + return type.
+                _tool.__annotations__ = {
+                    p.name: (p.annotation if p.annotation is not inspect.Parameter.empty else Any)
+                    for p in params
+                }
+                _tool.__annotations__["return"] = ScrapeToolResult
                 return _tool
 
             fn = _make()
             fn.__name__ = tool_name
             fn.__doc__ = (method.__doc__ or f"Run the {scraper_name} scraper.").strip()
-            mcp.add_tool(fn, name=tool_name, description=fn.__doc__)
+            # fastmcp derives the tool name and description from fn.__name__ /
+            # fn.__doc__ (set just above), so no explicit name/description kwargs.
+            mcp.add_tool(fn)
             _registered_plugin_tools.add(tool_name)
 
 
@@ -594,9 +606,12 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.http or args.sse:
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
-        mcp.run(transport="sse" if args.sse else "streamable-http")
+        # fastmcp 3.x takes host/port as run() kwargs (there's no mcp.settings).
+        mcp.run(
+            transport="sse" if args.sse else "streamable-http",
+            host=args.host,
+            port=args.port,
+        )
     else:
         mcp.run()
 

--- a/tests/test_mcp/test_agent.py
+++ b/tests/test_mcp/test_agent.py
@@ -9,10 +9,10 @@ import json
 import httpx
 import pytest
 
-# The agent module imports the MCP SDK (mcp.server.fastmcp). It's an optional
-# dependency (pyscrappy[mcp]); if it isn't installed, skip these tests cleanly
-# instead of erroring the whole collection.
-pytest.importorskip("mcp.server.fastmcp")
+# The agent module imports fastmcp. It's an optional dependency
+# (pyscrappy[mcp]); if it isn't installed, skip these tests cleanly instead of
+# erroring the whole collection.
+pytest.importorskip("fastmcp")
 
 from pyscrappy.mcp import agent  # noqa: E402  (import after the skip guard)
 

--- a/tests/test_mcp/test_plugin_tools.py
+++ b/tests/test_mcp/test_plugin_tools.py
@@ -41,19 +41,17 @@ async def test_declared_tool_is_first_class():
     assert "search_reddit_test" in names
 
     tool = next(t for t in tools if t.name == "search_reddit_test")
-    props = tool.inputSchema.get("properties", {})
+    props = tool.parameters.get("properties", {})
     # The scraper method's signature drives the schema.
     assert set(props) == {"subreddit", "sort"}
-    assert tool.inputSchema.get("required") == ["subreddit"]
+    assert tool.parameters.get("required") == ["subreddit"]
 
 
 @pytest.mark.anyio
 async def test_declared_tool_runs():
     mcp = _server().mcp
-    _content, structured = await mcp.call_tool(
-        "search_reddit_test", {"subreddit": "python", "sort": "top"}
-    )
-    assert structured["data"] == [{"sub": "python", "sort": "top"}]
+    result = await mcp.call_tool("search_reddit_test", {"subreddit": "python", "sort": "top"})
+    assert result.structured_content["data"] == [{"sub": "python", "sort": "top"}]
 
 
 @pytest.mark.anyio
@@ -62,7 +60,21 @@ async def test_plugin_without_mcp_tools_has_no_dedicated_tool():
     names = {t.name for t in await mcp.list_tools()}
     assert "plain_test" not in names
     # ...but it is still reachable via the generic dispatcher.
-    _content, structured = await mcp.call_tool(
-        "scrape_with", {"name": "plain_test", "args": {"q": "x"}}
-    )
-    assert structured["scraper"] == "plain_test"
+    result = await mcp.call_tool("scrape_with", {"name": "plain_test", "args": {"q": "x"}})
+    assert result.structured_content["scraper"] == "plain_test"
+
+
+@pytest.mark.anyio
+async def test_agent_call_tool_reads_structured_result():
+    """Exercise the real agent._call_tool against the live registry (the mocked
+    agent tests skip this path). Guards the fastmcp ToolResult shape: the result
+    is a ToolResult object with .structured_content, not a (content, structured)
+    tuple."""
+    _server()
+    from pyscrappy.mcp import agent
+
+    out = await agent._call_tool("search_reddit_test", {"subreddit": "python"})
+    import json
+
+    parsed = json.loads(out)
+    assert parsed["data"] == [{"sub": "python", "sort": "hot"}]

--- a/tests/test_mcp/test_plugin_tools.py
+++ b/tests/test_mcp/test_plugin_tools.py
@@ -2,8 +2,13 @@
 
 import pytest
 
-from pyscrappy import BaseScraper, register_scraper
-from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+# These tests import the MCP server, which needs fastmcp (optional, Python >=3.10
+# only). Skip the whole module cleanly when it isn't installed (e.g. on 3.9)
+# instead of erroring at collection.
+pytest.importorskip("fastmcp")
+
+from pyscrappy import BaseScraper, register_scraper  # noqa: E402
+from pyscrappy.core.models import ScrapeMetadata, ScrapeResult  # noqa: E402
 
 
 @register_scraper("reddit_test")


### PR DESCRIPTION
…mpat)## Why

The mcp SDK 2.0 removed the bundled FastMCP (mcp.server.fastmcp), which the MCP
server imported. Our dependency was unpinned (mcp>=1.2), so fresh installs
resolved mcp 2.x and the server failed to start with:

    ModuleNotFoundError: No module named 'mcp.server.fastmcp'

(Surfaced by the Glama build, which installs on Python 3.14 with the newest mcp.)

## What changed

Migrated to the standalone `fastmcp` package (where FastMCP now lives) instead of
pinning to the old mcp 1.x line.

- pyproject.toml: mcp>=1.2 -> fastmcp>=2.0 in the [mcp] and [all] extras.
- server.py:
  - import `from fastmcp import FastMCP`
  - add_tool(fn, name=, description=) -> add_tool(fn); fastmcp derives the name
    and description from fn.__name__ / fn.__doc__
  - host/port moved from mcp.settings to run() kwargs (fastmcp 3.x has no
    settings object)
  - plugin tools set __signature__ to expose a typed input schema; fastmcp 3.x
    derives the schema from __annotations__, so those are now kept in sync
    (previously raised KeyError on the first plugin tool arg)
- agent.py:
  - tool.inputSchema -> tool.parameters (fastmcp Tool attribute)
  - call_tool now returns a ToolResult object, so read result.structured_content
    instead of unpacking a (content, structured) tuple

## Tests

- Updated the mcp tests for the new Tool/ToolResult shapes and pointed the
  importorskip guard at `fastmcp`.
- Added test_agent_call_tool_reads_structured_result, which exercises the real
  agent._call_tool against the live registry. The existing agent tests mock
  _call_tool, so the real ToolResult path was untested and hid a latent bug.
- 337 passing (non-integration). Verified the server entrypoint starts on Python
  3.14 with all 24 tools registered.

Bump version to 1.3.3 (pyproject, __init__, both server.json fields).