### PR TITLE
Add JSON output to the CLI agent

### DIFF
--- a/src/pyscrappy/mcp/agent.py
+++ b/src/pyscrappy/mcp/agent.py
@@ -71,14 +71,16 @@ async def run_agent(
     host: str = DEFAULT_HOST,
     max_steps: int = MAX_STEPS,
     verbose: bool = False,
+    json_output: bool = False,
 ) -> str:
     """Answer ``prompt`` with a local model, letting it call PyScrappy scrapers.
 
-    Talks to an Ollama-compatible ``/api/chat`` endpoint. Returns the model's
-    final text answer.
+    Talks to an Ollama-compatible ``/api/chat`` endpoint. Returns the model's final text
+    answer by default, or the latest raw tool result when ``json_output`` is enabled.
     """
     tools = await _tool_specs()
     messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
+    last_result: str | None = None
 
     async with httpx.AsyncClient(base_url=host, timeout=120.0) as client:
         for _ in range(max_steps):
@@ -92,7 +94,12 @@ async def run_agent(
 
             tool_calls = message.get("tool_calls")
             if not tool_calls:
-                return message.get("content", "")
+                answer = message.get("content", "")
+                if json_output:
+                    return (
+                        last_result if last_result is not None else json.dumps({"answer": answer})
+                    )
+                return answer
 
             for call in tool_calls:
                 fn = call["function"]
@@ -102,10 +109,13 @@ async def run_agent(
                     args = json.loads(args)
                 if verbose:
                     print(f"  → {name}({json.dumps(args)})", file=sys.stderr)
-                result = await _call_tool(name, args)
-                messages.append({"role": "tool", "name": name, "content": result})
+                last_result = await _call_tool(name, args)
+                messages.append({"role": "tool", "name": name, "content": last_result})
 
-    return "Stopped: reached the maximum number of tool-calling steps."
+    stopped = "Stopped: reached the maximum number of tool-calling steps."
+    if json_output:
+        return last_result if last_result is not None else json.dumps({"error": stopped})
+    return stopped
 
 
 def main() -> None:
@@ -125,6 +135,7 @@ def main() -> None:
     )
     chat.add_argument("--max-steps", type=int, default=MAX_STEPS, help="Max tool-calling rounds.")
     chat.add_argument("-v", "--verbose", action="store_true", help="Print each tool call.")
+    chat.add_argument("--json", action="store_true", help="Print the raw scraper result as JSON.")
 
     args = parser.parse_args()
 
@@ -138,6 +149,7 @@ def main() -> None:
                 host=args.host,
                 max_steps=args.max_steps,
                 verbose=args.verbose,
+                json_output=args.json,
             )
         )
         print(answer)

--- a/tests/test_mcp/test_agent.py
+++ b/tests/test_mcp/test_agent.py
@@ -59,6 +59,49 @@ async def test_direct_answer_no_tools(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_json_output_returns_raw_tool_result(monkeypatch):
+    _mock_ollama(
+        monkeypatch,
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "define_word", "arguments": {"word": "python"}}}
+                ],
+            },
+            {"role": "assistant", "content": "A python is a snake."},
+        ],
+    )
+    payload = {"data": [{"definition": "a snake"}], "count": 1}
+
+    async def fake_call_tool(name, arguments):
+        return json.dumps(payload)
+
+    monkeypatch.setattr(agent, "_call_tool", fake_call_tool)
+
+    output = await agent.run_agent("define python", model="test", json_output=True)
+    assert json.loads(output) == payload
+
+
+def test_json_flag_prints_only_json(monkeypatch, capsys):
+    payload = {"data": [{"definition": "a snake"}], "count": 1}
+
+    async def fake_run_agent(prompt, **kwargs):
+        assert kwargs["json_output"] is True
+        return json.dumps(payload)
+
+    monkeypatch.setattr(agent, "run_agent", fake_run_agent)
+    monkeypatch.setattr(agent.sys, "argv", ["pyscrappy", "chat", "define python", "--json"])
+
+    agent.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == payload
+    assert captured.err == ""
+
+
+@pytest.mark.anyio
 async def test_tool_call_round_trip(monkeypatch):
     # Turn 1: model asks for a tool. Turn 2: model answers using the result.
     _mock_ollama(


### PR DESCRIPTION
Adds a `--json` flag to `pyscrappy chat` so scraper results can be piped into other tools.

Normal text output stays unchanged when the flag is not used.

Tests:
- `pytest tests -q`
- `ruff check src tests`
- `ruff format --check src tests`
- `python -m build`

Closes #56
