### PR TITLE
docs: clarify MCP runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,20 @@ get structured web data back.
 pip install 'pyscrappy[mcp]'
 ```
 
-This installs a `pyscrappy-mcp` command (a stdio MCP server). You can also run it
-with `python -m pyscrappy.mcp`.
+The MCP extra installs the standalone `fastmcp` package and requires Python 3.10
+or newer. On Python 3.9 the core scraping library still works, but the MCP server
+is unavailable.
+
+This installs the `pyscrappy-mcp` command. It uses stdio by default for local MCP
+clients; Streamable HTTP and legacy SSE are available for remote deployments:
+
+```sh
+pyscrappy-mcp          # stdio (default)
+pyscrappy-mcp --http   # Streamable HTTP
+pyscrappy-mcp --sse    # legacy SSE
+```
+
+You can also run the stdio server with `python -m pyscrappy.mcp`.
 
 ### Register with Claude Code
 
@@ -413,7 +425,8 @@ when the process exits. Call `HttpClient.clear_cache()` to empty it manually.
 
 **Required:** `httpx`, `beautifulsoup4`, `lxml`
 
-**Optional:** `playwright` (JS rendering), `pandas` (DataFrames), `mcp` (MCP server)
+**Optional:** `playwright` (JS rendering), `pandas` (DataFrames), `fastmcp`
+(MCP server, Python 3.10+)
 
 ## License
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_readme_documents_mcp_runtime_requirements_and_transports():
+    readme = (Path(__file__).parents[1] / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "pip install 'pyscrappy[mcp]'" in readme
+    assert "standalone `fastmcp` package" in normalized
+    assert "requires Python 3.10 or newer" in normalized
+    assert "On Python 3.9 the core scraping library still works" in normalized
+    assert "pyscrappy-mcp          # stdio (default)" in readme
+    assert "pyscrappy-mcp --http   # Streamable HTTP" in readme
+    assert "pyscrappy-mcp --sse    # legacy SSE" in readme


### PR DESCRIPTION
## Summary
- clarify that the MCP extra installs the standalone `fastmcp` package and requires Python 3.10+
- document stdio, Streamable HTTP, and legacy SSE launch modes
- add a README contract test for the installation and transport guidance

Closes #54

## Validation
- `uv run --with pytest --with ruff pytest tests -q` (327 passed, 3 skipped, 19 deselected)
- `uv run --with ruff ruff check src tests/test_readme.py`