### PR TITLE
docs: rewrite all MCP tool docstrings to A-grade tool definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.3"
+version = "1.3.4"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.3",
+  "version": "1.3.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -101,7 +101,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -118,13 +118,20 @@ async def scrape_url(
     max_pages: int = 1,
     render_js: bool = False,
 ) -> ScrapeToolResult:
-    """Scrape any URL and return structured text, links, images, tables and metadata.
+    """Scrape any HTTP(S) URL and return a ScrapeToolResult whose `data` holds one object per page containing extracted text (with word_count), links, images, tables, and page metadata.
+
+    Fetches the page over the network and parses the HTML; no data is stored or mutated. By default it makes a plain static HTTP request, so pages built client-side with JavaScript come back nearly empty. When that is detected, the returned `errors` list gets a hint to retry with render_js=true; set render_js=true to render with a headless browser instead (requires the pyscrappy[browser] extra). On empty or failed results, `data` is [], `count` is 0, and `errors` describes the problem rather than raising.
+
+    Returns:
+        ScrapeToolResult with fields: data (list of per-page dicts holding text, links, images, tables, metadata; also the keys named in `selectors` when provided), count (int number of items in data), scraper (str backend name), source_urls (list of str URLs actually fetched, one per page), and errors (list of {url, message} for non-fatal problems).
 
     Args:
-        url: The page to scrape.
-        selectors: Optional CSS selectors, e.g. {"title": "h1", "price": ".amount"}.
-        max_pages: Follow pagination up to this many pages (default 1).
-        render_js: Render JavaScript with a browser backend (needs pyscrappy[browser]).
+        url: String, the page URL to scrape including scheme, e.g. "https://example.com/products". Required, no default.
+        selectors: Optional dict mapping output field name to CSS selector to extract specific values into each data item, e.g. {"title": "h1", "price": ".amount"}. Default None (returns only the standard text/links/images/tables/metadata).
+        max_pages: Integer, follow "next"-style pagination up to this many pages, e.g. 3. Default 1 (scrape only the given URL).
+        render_js: Boolean, render JavaScript with a headless browser backend, e.g. True. Default False; allowed values True or False, and True needs the pyscrappy[browser] extra installed.
+
+    Use this for arbitrary or unsupported sites; for common sources prefer the purpose-built siblings (scrape_wikipedia, scrape_stock, scrape_news, search_amazon, etc.), which return cleaner fields. Gotcha: if results look empty on a modern site, re-call with render_js=true or scrape the underlying data endpoint the page fetches.
     """
     result = await _run(
         _scrape_url,
@@ -151,11 +158,16 @@ async def scrape_url(
 
 @mcp.tool()
 async def scrape_wikipedia(query: str, mode: str = "full") -> ScrapeToolResult:
-    """Fetch a Wikipedia article.
+    """Fetch a Wikipedia article by title or search term and return its text content.
+
+    Makes a live network request to Wikipedia, resolving the query to the best-matching article and extracting its body. The shape of the returned text depends on `mode`: "full" returns the entire article as one string; "paragraphs" returns the article split into a list of paragraph strings; "headers" returns a list of the article's section heading strings (its table of contents). If no article matches the query, an empty result is returned (empty string for "full", empty list for "paragraphs" or "headers").
 
     Args:
-        query: Article title or search term, e.g. "Model Context Protocol".
-        mode: "full", "paragraphs", or "headers".
+        query: String. Article title or search term. Example: "Model Context Protocol". No default (required).
+        mode: String, one of "full", "paragraphs", or "headers". Selects the return shape as described above. Example: "paragraphs". No default (required).
+
+    Usage Guidelines:
+        Use when you need the content of a known Wikipedia topic; pick "headers" first to survey structure, then "paragraphs" or "full" to pull the text. Requires network access and returns empty on a miss, so verify the query resolved before relying on the output.
     """
     with WikipediaScraper(_config()) as ws:
         return await _run(ws.scrape, query=query, mode=mode)
@@ -163,12 +175,30 @@ async def scrape_wikipedia(query: str, mode: str = "full") -> ScrapeToolResult:
 
 @mcp.tool()
 async def scrape_stock(symbol: str, mode: str = "quote", period: str = "1mo") -> ScrapeToolResult:
-    """Fetch stock market data from Yahoo Finance.
+    """Fetch stock market data from Yahoo Finance and return it as a dict.
+
+    The returned shape depends on `mode`:
+      - "quote": {"symbol", "price", "currency", "change", "change_percent", "market_time"}.
+      - "history": {"symbol", "period", "rows": [{"date", "open", "high", "low", "close", "volume"}, ...]}.
+      - "profile": {"symbol", "name", "sector", "industry", "country", "website", "summary"}.
+
+    Behavior:
+        Makes a live network request to Yahoo Finance on each call; no browser is
+        required and nothing is cached or persisted. If the symbol is unknown or
+        Yahoo returns no data, "rows" is an empty list (mode="history") or the
+        remaining fields are None (mode="quote"/"profile"); no exception is raised
+        for an empty result.
 
     Args:
-        symbol: Ticker symbol, e.g. "AAPL", "GOOGL".
-        mode: "quote", "history", or "profile".
-        period: History window when mode="history", e.g. "1mo", "1y".
+        symbol: Ticker symbol as a string. Example: "AAPL". No default (required).
+        mode: String selecting what to fetch; one of "quote", "history", "profile". Example: "quote". No default (required).
+        period: String history window, used only when mode="history" and ignored otherwise; one of "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max". Example: "1y". Default: "1mo".
+
+    Usage:
+        Use for a single ticker's live quote, OHLCV history, or company profile;
+        confirm the ticker is valid with list_available_scrapers or a quote lookup
+        before requesting history. For non-stock assets or bulk multi-symbol
+        requests, prefer the dedicated batch scraper instead.
     """
     with StockScraper(_config()) as ss:
         return await _run(ss.scrape, symbol=symbol, mode=mode, period=period)
@@ -181,15 +211,17 @@ async def scrape_news(
     article_url: str | None = None,
     max_articles: int = 50,
 ) -> ScrapeToolResult:
-    """Fetch news articles from an RSS feed, a news site, or a single article.
+    """Fetch news articles from an RSS/Atom feed, a news site (feed auto-discovered), or a single article, and return a list of article dicts (typically: title, url, published date, author, summary, and full text where available).
 
-    Provide exactly one of feed_url, site_url, or article_url.
+    Provide exactly one of feed_url, site_url, or article_url. Fetches live content over the network at call time; results are not cached. article_url returns one article; feed_url and site_url return up to max_articles. Returns an empty list if the feed/site yields no articles or if a feed cannot be discovered or parsed.
 
     Args:
-        feed_url: Direct URL to an RSS/Atom feed.
-        site_url: News site URL — its feed is auto-discovered.
-        article_url: A single article URL to extract full text from.
-        max_articles: Max articles to return from a feed (default 50).
+        feed_url: String, direct URL to an RSS/Atom feed. Example: "https://example.com/rss.xml". Default: None.
+        site_url: String, news site homepage URL whose feed is auto-discovered. Example: "https://example.com". Default: None.
+        article_url: String, single article URL to extract full text from. Example: "https://example.com/2026/news-story". Default: None.
+        max_articles: Integer, max articles to return for feed_url or site_url; ignored for article_url. Example: 20. Default: 50.
+
+    Use this for news content; prefer feed_url when you already know the feed, site_url when you only have the homepage, and article_url for one specific story. Call list_available_scrapers first if unsure which scraper tool fits a given source.
     """
     with NewsScraper(_config()) as ns:
         return await _run(
@@ -203,12 +235,20 @@ async def scrape_news(
 
 @mcp.tool()
 async def search_images(query: str, max_images: int = 20, engine: str = "bing") -> ScrapeToolResult:
-    """Search for images and return their URLs and metadata.
+    """Search the web for images and return a list of result objects with image URLs and metadata.
+
+    Each result is a dict with keys: "image_url" (direct link to the image), "thumbnail_url" (small preview), "source_url" (page the image was found on), "title" (caption or alt text), "width", and "height" (pixels). Results are returned in the engine's relevance order.
+
+    Behavior:
+        Issues a live query to the chosen search engine over the network, so results vary by engine, region, and time. No files are downloaded and no browser is launched; only metadata and URLs are returned. Returns an empty list if the query matches nothing or the engine returns no results.
 
     Args:
-        query: Image search query, e.g. "golden gate bridge".
-        max_images: Maximum number of image results (default 20).
-        engine: Search engine to use (default "bing").
+        query: Search terms as a string, e.g. "golden gate bridge". Required, no default.
+        max_images: Integer cap on the number of results returned, e.g. 10. Defaults to 20.
+        engine: String naming the search engine, one of "bing", "google", or "duckduckgo", e.g. "google". Defaults to "bing".
+
+    Usage Guidelines:
+        Use when you need image URLs or dimensions rather than a downloaded file; the returned "image_url" values can be fetched or passed to a downloader tool afterward. Raise max_images cautiously since larger values are slower and some engines cap the total available results.
     """
     with ImageSearchScraper(_config()) as iss:
         return await _run(iss.scrape, query=query, max_images=max_images, engine=engine)
@@ -216,11 +256,16 @@ async def search_images(query: str, max_images: int = 20, engine: str = "bing") 
 
 @mcp.tool()
 async def search_youtube(query: str, max_results: int = 20) -> ScrapeToolResult:
-    """Search YouTube and return video titles, channels, links and metadata.
+    """Search YouTube for videos matching a query and return a list of matching videos with their metadata.
+
+    Performs a live YouTube search over the network, so results reflect current YouTube data and may vary between calls; it is read-only and has no side effects. Returns a list of video objects, each typically containing: title (str), channel (str), url/link (str) to the video, video_id (str), duration (str), view_count (int), and published/upload date (str). Returns an empty list when the query matches no videos.
 
     Args:
-        query: Search query, e.g. "model context protocol tutorial".
-        max_results: Maximum number of videos to return (default 20).
+        query: The search text, as a string. Example: "model context protocol tutorial". No default (required).
+        max_results: Maximum number of videos to return, as an integer. Example: 10. Default 20.
+
+    Usage Guidelines:
+        Use when you need to discover YouTube videos by keyword and get their links and metadata; the returned url is the entry point for any follow-up fetching or transcription tools. Keep max_results modest to limit latency, and note that ranking is YouTube's relevance order, not chronological.
     """
     with YouTubeScraper(_config()) as yts:
         return await _run(yts.scrape, query=query, max_results=max_results)
@@ -230,12 +275,16 @@ async def search_youtube(query: str, max_results: int = 20) -> ScrapeToolResult:
 async def search_linkedin_jobs(
     query: str, location: str = "", max_pages: int = 1
 ) -> ScrapeToolResult:
-    """Search LinkedIn job postings.
+    """Search LinkedIn public job postings and return a list of matched jobs.
+
+    Scrapes LinkedIn's public job search results over the network (no login required) and returns a list of dicts, one per posting, typically with keys: title, company, location, url, and posted_date. Returns an empty list if no postings match or the query yields no results. Live web scraping, so results reflect LinkedIn at call time and may vary between runs.
 
     Args:
-        query: Job title or keywords, e.g. "machine learning engineer".
-        location: Location filter, e.g. "London" or "United Kingdom".
-        max_pages: Pages of results to scrape (default 1).
+        query: Job title or keywords as a string. Example: "machine learning engineer". No default (required).
+        location: Location filter as a string; city, region, or country. Example: "London" or "United Kingdom". No default (required).
+        max_pages: Number of result pages to scrape, as an integer. Each extra page adds jobs but more scraping time. Example: 2. Default: 1.
+
+    Use this when you specifically need LinkedIn job listings; call list_available_scrapers first to confirm this scraper is available, and raise max_pages only when the first page does not return enough results.
     """
     with LinkedInJobsScraper(_config()) as ljs:
         return await _run(ljs.scrape, query=query, location=location, max_pages=max_pages)
@@ -245,12 +294,16 @@ async def search_linkedin_jobs(
 async def get_crypto(
     query: str | None = None, max_results: int = 20, vs_currency: str = "usd"
 ) -> ScrapeToolResult:
-    """Get cryptocurrency market data (price, market cap, 24h change).
+    """Fetch live cryptocurrency market data and return a list of coin records, each with fields: id, symbol, name, current price (in vs_currency), market cap, and 24h price change (percent).
+
+    Fetches from a live crypto market data API over the network, so results reflect current prices and require internet access; no local state is read or written. When query is omitted, returns the top coins ranked by market cap. If no coins match the query, returns an empty list rather than raising.
 
     Args:
-        query: Comma-separated coins (e.g. "bitcoin, ethereum"). Omit for top coins.
-        max_results: Max coins to return (default 20).
-        vs_currency: Fiat currency for prices, e.g. "usd", "eur" (default "usd").
+        query: String of comma-separated coin ids. Example: "bitcoin, ethereum". Default None (returns top coins by market cap).
+        max_results: Integer maximum number of coins to return. Example: 10. Default 20.
+        vs_currency: String fiat or quote currency code for prices, lowercase. Example: "usd". Allowed: any currency supported by the data source, e.g. "usd", "eur", "gbp", "jpy". Default "usd".
+
+    Use this to look up current prices or market snapshots for specific coins or the top market. Pass coin ids (e.g. "bitcoin"), not tickers (e.g. "btc"), in query; if a lookup returns an empty list, verify the id spelling. This tool covers only crypto market data and does not scrape web pages; for general web scraping call list_available_scrapers first.
     """
     with CryptoScraper(_config()) as c:
         return await _run(c.scrape, query=query, max_results=max_results, vs_currency=vs_currency)
@@ -260,12 +313,20 @@ async def get_crypto(
 async def convert_currency(
     base: str = "USD", to: str | None = None, amount: float = 1.0
 ) -> ScrapeToolResult:
-    """Get currency exchange rates and convert an amount.
+    """Fetch live exchange rates and convert an amount from one currency to others.
+
+    Returns a dict with the base currency, the amount converted, and a mapping of each target currency code to its converted value and unit exchange rate (e.g. {"base": "USD", "amount": 100, "results": {"EUR": {"rate": 0.92, "value": 92.0}}}).
+
+    Behavior:
+        Queries a live external exchange-rate API over the network, so results reflect current market rates and require internet access. No local state is read or written. If a requested target code is unknown or unsupported, it is omitted from "results"; if none of the targets resolve, "results" is an empty dict.
 
     Args:
-        base: Base currency code, e.g. "USD".
-        to: Comma-separated target codes (e.g. "EUR,GBP"). Omit for all rates.
-        amount: Amount of base currency to convert (default 1).
+        base: Base currency code as a 3-letter ISO 4217 string. Example: "USD". No default (required).
+        to: Target currency codes as a comma-separated string; omit or leave empty to return rates for all available currencies. Example: "EUR,GBP". Default: "" (all rates).
+        amount: Amount of the base currency to convert, as a number (int or float). Example: 100. Default: 1.
+
+    Usage:
+        Use for one-off currency conversion or to pull current rates for specific pairs; pass a single code in "to" for a quick pair rate, or omit "to" to survey all rates before choosing targets. Rates are point-in-time and not suitable for historical or as-of-date lookups.
     """
     with CurrencyScraper(_config()) as c:
         return await _run(c.scrape, base=base, to=to, amount=amount)
@@ -273,10 +334,17 @@ async def convert_currency(
 
 @mcp.tool()
 async def define_word(word: str) -> ScrapeToolResult:
-    """Look up a word's definitions, part of speech, and examples (English).
+    """Look up an English word and return its dictionary entry: definitions, part(s) of speech, and example sentences.
+
+    Fetches from an online dictionary data source, so a network connection is required. Read-only with no side effects. If the word is not found (misspelled or not in the dictionary), returns an empty result or a not-found response rather than raising.
+
+    Returns a structured entry for the word, typically containing the word itself, one or more part-of-speech groupings, and for each a list of definitions with optional example sentences.
 
     Args:
-        word: The word to define.
+        word: The English word to define, as a string. Example: "serendipity". No default (required). Single words only; not phrases or non-English terms.
+
+    Usage:
+        Use for quick dictionary lookups of a single English word's meaning, grammar category, and usage examples. For spelling variants or unknown words, expect an empty/not-found result and verify the spelling before retrying.
     """
     with DictionaryScraper(_config()) as d:
         return await _run(d.scrape, word=word)
@@ -286,12 +354,16 @@ async def define_word(word: str) -> ScrapeToolResult:
 async def search_github(
     query: str, max_results: int = 20, sort: str = "best-match"
 ) -> ScrapeToolResult:
-    """Search GitHub repositories (name, owner, stars, description, language).
+    """Search GitHub for public repositories and return a list of repository records.
+
+    Queries the GitHub search API over the network and returns a list of dicts, each with: name (str), owner (str), stars (int), description (str), and language (str). Results are ordered per the sort argument. Returns an empty list when no repository matches the query. Requires network access; may be subject to GitHub API rate limits.
 
     Args:
-        query: Search query, e.g. "web scraping language:python".
-        max_results: Max repositories to return (default 20).
-        sort: "best-match" (default), "stars", "forks", or "updated".
+        query: String search expression using GitHub search syntax, including qualifiers like "language:" or "stars:". Example: "web scraping language:python". No default (required).
+        max_results: Integer maximum number of repositories to return. Example: 10. Default 20.
+        sort: String ordering for results; one of "best-match", "stars", "forks", or "updated". Example: "stars". Default "best-match".
+
+    Use this to discover repositories by keyword, language, or popularity when you have a text query rather than a known repo path. Prefer "best-match" for relevance and "stars" to surface the most popular projects; narrow broad queries with GitHub qualifiers (e.g. "language:python stars:>100") to avoid rate-limited, low-signal results.
     """
     with GitHubScraper(_config()) as gh:
         return await _run(gh.scrape, query=query, max_results=max_results, sort=sort)
@@ -301,12 +373,16 @@ async def search_github(
 async def search_hackernews(
     query: str, max_results: int = 20, by: str = "relevance"
 ) -> ScrapeToolResult:
-    """Search Hacker News stories (title, url, points, author, comments).
+    """Search Hacker News stories and return a list of matching story dicts, each with title, url, points, author (username), and comments (comment count).
+
+    Queries the public Hacker News search index (Algolia HN API) over the network; makes no local changes. Returns an empty list when nothing matches or the query is empty.
 
     Args:
-        query: Search query.
-        max_results: Max stories to return (default 20).
-        by: "relevance" (default) or "date" (most recent first).
+        query: Search terms to match against story titles and text; type: string; example: "rust async runtime"; no default (required).
+        max_results: Maximum number of stories to return; type: integer; example: 10; default: 20.
+        by: Result ordering; type: string; one of "relevance" or "date" ("date" sorts most recent first); example: "date"; default: "relevance".
+
+    Use this to pull real Hacker News discussion for a topic; prefer by="date" for breaking or time-sensitive topics and by="relevance" (default) otherwise, and use the returned url and comments fields to link out or gauge engagement.
     """
     with HackerNewsScraper(_config()) as hn:
         return await _run(hn.scrape, query=query, max_results=max_results, by=by)
@@ -314,11 +390,19 @@ async def search_hackernews(
 
 @mcp.tool()
 async def search_books(query: str, max_results: int = 20) -> ScrapeToolResult:
-    """Search books via Open Library (title, author, year, editions).
+    """Search books by title, author, or free text via the Open Library search API and return a list of matching book records.
+
+    Queries Open Library over the network (no browser or authentication required). Returns a list of dicts, each typically containing: title (str), author_names (list of str), first_publish_year (int or None), edition_count (int), and the Open Library work key (str, e.g. "/works/OL45804W"). Fields missing upstream are omitted or None. Returns an empty list when the query matches nothing. Read-only: no local files or state are modified.
 
     Args:
-        query: Title, author, or free-text search.
-        max_results: Max books to return (default 20).
+        query: Title, author, or free-text search string. Type: string. Example: "the hobbit tolkien". Required, no default.
+        max_results: Maximum number of books to return. Type: integer. Example: 10. Default: 20. Allowed: any positive integer.
+
+    Returns:
+        A list of book-record dicts as described above; empty list if there are no matches.
+
+    Usage:
+        Use for bibliographic lookups (finding editions, publication years, or authors) rather than for full text or file-based sources. For broad or misspelled queries pass a larger max_results and refine the query, since Open Library ranks loosely by relevance.
     """
     with OpenLibraryScraper(_config()) as ol:
         return await _run(ol.scrape, query=query, max_results=max_results)
@@ -326,10 +410,15 @@ async def search_books(query: str, max_results: int = 20) -> ScrapeToolResult:
 
 @mcp.tool()
 async def get_weather(location: str) -> ScrapeToolResult:
-    """Get current weather for a place (temperature, humidity, wind, condition).
+    """Fetch the current weather conditions for a named place and return a dict with keys: temperature (number, degrees Celsius), humidity (number, percent), wind (number, wind speed), condition (str, e.g. "Clear", "Rain"), and location (str, the resolved place name).
+
+    Makes a live network call to an external weather provider on each invocation, so results reflect real-time conditions and require internet access. If the location cannot be resolved or the provider returns no match, the tool returns an empty result (or an error field) rather than raising.
 
     Args:
-        location: Place name, e.g. "London" or "Tokyo, Japan".
+        location: String naming the place to look up; a city name, optionally with a region or country to disambiguate. Example: "Tokyo, Japan". No default; this parameter is required.
+
+    Usage Guidelines:
+        Use for point-in-time current conditions only; this tool does not return forecasts or historical data. When a bare city name is ambiguous (e.g. "Springfield"), add a region or country to the string to ensure the correct match.
     """
     with WeatherScraper(_config()) as w:
         return await _run(w.scrape, location=location)
@@ -337,11 +426,15 @@ async def get_weather(location: str) -> ScrapeToolResult:
 
 @mcp.tool()
 async def search_ubereats(city: str, max_results: int = 30) -> ScrapeToolResult:
-    """List Uber Eats restaurants delivering in a city (name, ETA, fee, url).
+    """Search Uber Eats for restaurants delivering in a given city, returning a ScrapeToolResult envelope whose `data` is a list of restaurant objects (typically `name`, `eta`, delivery `fee`, and store `url`).
+
+    Fetches live listings from Uber Eats over the network at call time; no API key is required. The `data` list is capped at `max_results` and each item's store `url` is the input for `get_ubereats_menu`. Alongside `data`, the envelope carries `count`, `scraper`, `source_urls`, and `errors` (non-fatal issues, each with a `url` and `message`). If the city is unrecognized or no restaurants are found, `data` is an empty list and `count` is 0.
 
     Args:
-        city: City name, e.g. "London".
-        max_results: Maximum restaurants to return (default 30).
+        city: City name to search, as a string. Example: "London". No default (required).
+        max_results: Maximum number of restaurants to return, as an integer. Example: 10. Default 30.
+
+    Use this to discover restaurants and their store URLs in a city; call it before get_ubereats_menu, which takes a store `url` from this tool's results to fetch that restaurant's full menu. For non-Uber Eats restaurant listings, use scrape_zomato instead.
     """
     with UberEatsScraper(_config()) as ue:
         return await _run(ue.scrape, city=city, max_results=max_results)
@@ -349,10 +442,15 @@ async def search_ubereats(city: str, max_results: int = 30) -> ScrapeToolResult:
 
 @mcp.tool()
 async def get_ubereats_menu(store_url: str) -> ScrapeToolResult:
-    """Get an Uber Eats restaurant's menu (items, prices) from its store URL.
+    """Fetch an Uber Eats restaurant's live menu from its store URL and return the menu items with their names, descriptions, and prices.
+
+    Scrapes the restaurant page over the network at call time, so results reflect current listings and require internet access. Prices and availability depend on the store's configured location and hours. Returns a structured list of menu items (typically grouped by section/category); if the URL is invalid, the restaurant is unavailable, or the menu is empty, an empty result (no items) is returned rather than an error.
 
     Args:
-        store_url: A store URL from a search_ubereats result's "url" field.
+        store_url: URL string of the Uber Eats store page, taken from a search_ubereats result's "url" field. Example: "https://www.ubereats.com/store/some-restaurant/abc123". No default (required).
+
+    Usage Guidelines:
+        Use after search_ubereats to turn a chosen restaurant result into its full menu; call search_ubereats first to obtain a valid store_url rather than constructing one by hand. Do not pass a plain search or homepage URL, as only a store page URL yields menu data.
     """
     with UberEatsScraper(_config()) as ue:
         return await _run(ue.get_menu, store_url)
@@ -360,11 +458,16 @@ async def get_ubereats_menu(store_url: str) -> ScrapeToolResult:
 
 @mcp.tool()
 async def search_amazon(query: str, max_pages: int = 1) -> ScrapeToolResult:
-    """Search Amazon products and return title, price, rating, and image.
+    """Scrape Amazon search results for a query and return a list of matching products, each with its title, price, rating, and image URL.
+
+    This performs a live network scrape of Amazon's public search results pages (no login, no API key). It has no side effects beyond outgoing HTTP requests. Results reflect Amazon's current listings and may vary by region, availability, and anti-bot throttling. Returns a list of dicts, one per product, each shaped as {"title": str, "price": str, "rating": str, "image": str}; fields that Amazon omits for a listing come back as empty strings or None. Returns an empty list when the query yields no products or when scraping is blocked.
 
     Args:
-        query: Product search query, e.g. "wireless headphones".
-        max_pages: Number of result pages to scrape (default 1).
+        query: Product search phrase, as a string. Example: "wireless headphones". No default (required).
+        max_pages: Number of result pages to scrape, as an integer; higher values return more products but take longer and raise the chance of throttling. Example: 3. Default: 1.
+
+    Usage Guidelines:
+        Use to fetch a broad, current list of Amazon products for a keyword; call list_available_scrapers first if you are unsure this scraper is enabled. Prefer a small max_pages (1 to 3) to stay fast and avoid rate limiting, and treat price/rating strings as display text rather than parsed numbers.
     """
     with AmazonScraper(_config()) as az:
         return await _run(az.scrape, query=query, max_pages=max_pages)
@@ -372,11 +475,16 @@ async def search_amazon(query: str, max_pages: int = 1) -> ScrapeToolResult:
 
 @mcp.tool()
 async def search_newegg(query: str, max_pages: int = 1) -> ScrapeToolResult:
-    """Search Newegg for electronics and computer hardware.
+    """Search Newegg for electronics and computer hardware, returning a list of product dicts each with title, price, product_url, image_url, rating, and item_number.
+
+    Live-scrapes Newegg search result pages over the network; requires outbound internet access and returns an empty list if no products match or the page structure cannot be parsed. Read-only, with no side effects beyond the outbound HTTP requests.
 
     Args:
-        query: Product search query, e.g. "graphics card".
-        max_pages: Number of result pages to scrape (default 1).
+        query: Product search terms, given as a string. Example: "graphics card". No default (required).
+        max_pages: Number of result pages to scrape, given as an integer; higher values return more products but take longer. Example: 3. Default 1.
+
+    Usage Guidelines:
+        Use for Newegg-specific electronics and PC hardware pricing or availability; for other retailers or product categories, prefer the matching sibling scraper (call list_available_scrapers first to see them). Start with the default max_pages=1 and increase only if you need more results, since each additional page adds a network round trip.
     """
     with NeweggScraper(_config()) as ne:
         return await _run(ne.scrape, query=query, max_pages=max_pages)
@@ -386,15 +494,17 @@ async def search_newegg(query: str, max_pages: int = 1) -> ScrapeToolResult:
 async def search_ikea(
     query: str, max_results: int = 24, country: str = "us", lang: str = "en"
 ) -> ScrapeToolResult:
-    """Search IKEA furniture and home products (name, type, price, rating).
+    """Search IKEA's online catalog for furniture and home products, returning a list of product dicts with fields name, type, price, and rating.
 
-    Prices and availability are per-country: pass the country's IKEA store code.
+    Scrapes the IKEA store website for the given country at call time, so results require network access and reflect that store's live listings. Prices, availability, and currency are per-country and per-language. Returns an empty list if the query matches no products.
 
     Args:
-        query: Product search query, e.g. "desk" or "bookshelf".
-        max_results: Maximum number of products to return (default 24).
-        country: IKEA store country code, e.g. "us", "gb", "de" (default "us").
-        lang: Language code for that store, e.g. "en", "de" (default "en").
+        query: String search term for the product name or type, e.g. "desk" or "bookshelf". Required, no default.
+        max_results: Integer cap on the number of products returned; e.g. 10. Default 24.
+        country: String two-letter IKEA store country code that sets pricing and availability; allowed values are IKEA market codes such as "us", "gb", "de", "fr", "se". Example "gb". Default "us".
+        lang: String language code for that store's listings; must be a language the chosen country's store supports, e.g. "en" for "us"/"gb" or "de" for "de". Example "de". Default "en".
+
+    Use this to look up IKEA products and their prices for a specific market; call list_available_scrapers first to confirm the retailer is supported. Note that country and lang must be a valid pair for the target store, and prices are meaningful only in that country's currency.
     """
     with IKEAScraper(_config(), country=country, lang=lang) as ik:
         return await _run(ik.scrape, query=query, max_results=max_results)
@@ -402,14 +512,15 @@ async def search_ikea(
 
 @mcp.tool()
 async def search_soundcloud(query: str, max_results: int = 20) -> ScrapeToolResult:
-    """Search SoundCloud for tracks (title, artist, plays, likes, URL).
+    """Search SoundCloud for tracks and return a list of track dicts, each with keys: title (str), artist (str), plays (int), likes (int), and url (str, the track page URL).
 
-    Uses a browser backend to render SoundCloud's JavaScript, so it needs
-    ``pyscrappy[browser]`` and is slower than the HTTP-based tools.
+    Renders SoundCloud's JavaScript search results with a browser backend (Playwright/Selenium), so it requires the pyscrappy[browser] extra to be installed and launches a headless browser per call. This makes it slower and heavier than the HTTP-based search tools. Results reflect SoundCloud's live public search at call time; no login or API key is used. Returns an empty list if the query matches no tracks.
 
     Args:
-        query: Search query, e.g. "lofi beats".
-        max_results: Maximum number of tracks to return (default 20).
+        query: Search query string. Example: "lofi beats". No default (required).
+        max_results: Maximum number of tracks to return, as an integer. Example: 10. Default 20.
+
+    Use this when you specifically need SoundCloud track data (play/like counts and track URLs); for video results prefer search_youtube. Run list_available_scrapers first to confirm the SoundCloud browser backend is installed, since this tool fails without pyscrappy[browser].
     """
 
     def _do() -> ScrapeResult:
@@ -430,16 +541,15 @@ async def search_soundcloud(query: str, max_results: int = 20) -> ScrapeToolResu
 
 @mcp.tool()
 async def lookup_movie(query: str, max_pages: int = 1) -> ScrapeToolResult:
-    """Look up movie/TV data from IMDB (via the OMDb API).
+    """Look up movie and TV data from IMDB via the OMDb API and return a JSON-serializable dict; a title search returns {"results": [...]} with each item holding title, year, imdb_id, and type, while an IMDB-id lookup returns a single record with full details (plot, ratings, cast, runtime, genre).
 
-    Requires a free OMDb API key in the ``OMDB_API_KEY`` environment variable
-    (get one at https://www.omdbapi.com/apikey.aspx). If it's missing, the tool
-    returns an error explaining how to set it.
+    Reads over the network from the OMDb HTTP API; no browser is needed and nothing is written or cached. Requires a free OMDb API key in the OMDB_API_KEY environment variable (get one at https://www.omdbapi.com/apikey.aspx); if it is missing the tool returns {"error": ...} explaining how to set it. When the query matches nothing, it returns an empty results list rather than raising.
 
     Args:
-        query: A title to search for (e.g. "inception"), or an IMDB id
-            (e.g. "tt1375666") for a direct lookup.
-        max_pages: Pages of search results to fetch, 10 per page (title search).
+        query: String. A title to search for (e.g. "inception"), or an IMDB id starting with "tt" for a direct single-record lookup (e.g. "tt1375666"). Required, no default.
+        max_pages: Integer. Number of search-result pages to fetch at 10 results per page; only applies to title searches and is ignored for IMDB-id lookups (e.g. 3). Default 1.
+
+    Use this for on-demand film and TV metadata lookups; pass an IMDB id when you already have one to skip search and get complete details, and raise max_pages only when a broad title needs more than the first 10 matches.
     """
     with IMDBScraper(_config()) as ims:
         return await _run(ims.scrape, query=query, max_pages=max_pages)
@@ -449,12 +559,17 @@ async def lookup_movie(query: str, max_pages: int = 1) -> ScrapeToolResult:
 async def scrape_zomato(
     city: str, query: str | None = None, max_results: int = 50
 ) -> ScrapeToolResult:
-    """Search restaurants on Zomato by city.
+    """Search Zomato for restaurants in a city and return a list of restaurant records.
+
+    Scrapes Zomato's public restaurant listings over the network for the given city, optionally filtered by a cuisine or name term. Each result is a dict with fields such as name, cuisine, rating, price_for_two, address, and url; the exact keys depend on what Zomato exposes for each listing. Returns a list of these dicts ordered as Zomato ranks them, capped at max_results. Returns an empty list if the city is unknown or no restaurants match the query. Requires outbound network access; results reflect live Zomato data at call time and may vary between calls.
 
     Args:
-        city: City name, e.g. "Bangalore".
-        query: Optional cuisine or restaurant search term.
-        max_results: Maximum number of restaurants to return (default 50).
+        city: String city name to search within. Example: "Bangalore". Required, no default.
+        query: Optional string cuisine or restaurant search term to filter results. Example: "biryani". Defaults to None (returns all restaurants for the city).
+        max_results: Integer maximum number of restaurants to return. Example: 20. Defaults to 50.
+
+    Usage:
+        Call list_available_scrapers first to confirm Zomato is supported in your region. Use this when you need Zomato-sourced restaurant data specifically; for other platforms use the corresponding sibling scraper. Note that ratings and prices are point-in-time scrapes, not a stable API, so avoid caching them as authoritative.
     """
     with ZomatoScraper(_config()) as zs:
         return await _run(zs.scrape, city=city, query=query, max_results=max_results)
@@ -462,10 +577,15 @@ async def scrape_zomato(
 
 @mcp.tool()
 async def list_available_scrapers() -> dict[str, list[str]]:
-    """List every scraper available to this server, including installed plugins.
+    """List every scraper registered with this server and return their names for use with scrape_with.
 
-    Third-party `pyscrappy-*` plugin packages register scrapers that show up here
-    automatically. Use a returned name with `scrape_with`.
+    Reads the server's in-process scraper registry, which includes built-in scrapers plus any installed third-party pyscrappy-* plugin packages that self-register on import. No network or browser access is performed and no state is changed. If no scrapers are registered, returns an empty list.
+
+    Returns:
+        list[str]: Scraper name identifiers (for example ["amazon", "flipkart", "youtube"]), each usable as the scraper argument to scrape_with. Empty list when none are registered.
+
+    Usage Guidelines:
+        Call this first to discover valid scraper names, then pass a returned name to scrape_with; use it to confirm a plugin registered correctly after installing a pyscrappy-* package.
     """
     from pyscrappy import list_scrapers
 
@@ -474,15 +594,15 @@ async def list_available_scrapers() -> dict[str, list[str]]:
 
 @mcp.tool()
 async def scrape_with(name: str, args: dict[str, Any] | None = None) -> ScrapeToolResult:
-    """Run any registered scraper by name, including plugins, with arbitrary args.
+    """Run any registered scraper (built-in or plugin) by name and return that scraper's raw scrape() output.
 
-    This is the generic entry point for scrapers that don't have a dedicated tool
-    of their own — notably third-party plugins. Call `list_available_scrapers`
-    first to see valid names.
+    This is the generic dispatch entry point for scrapers that lack a dedicated tool, notably third-party plugins. It looks up the scraper in the registry, calls its scrape() method with the given args, and returns whatever that scraper returns (typically a dict or list of records; exact shape is scraper-specific). Side effects and requirements (network requests, browser/headless rendering, auth) depend entirely on the target scraper. If name is not a registered scraper, it raises an error rather than returning empty; if the scraper runs but finds nothing, it returns that scraper's empty result (e.g. an empty list).
 
     Args:
-        name: A scraper name from `list_available_scrapers`, e.g. "wikipedia".
-        args: Keyword arguments passed to that scraper's `scrape()` method.
+        name: String, the scraper's registered name from list_available_scrapers. Example: "wikipedia". No default (required).
+        args: Dict of keyword arguments forwarded to the named scraper's scrape() method; required keys depend on that scraper. Example: {"query": "Alan Turing", "lang": "en"}. No default (required).
+
+    Use this only when no dedicated tool exists for the scraper you want; prefer a purpose-built tool when one is available. Always call list_available_scrapers first to get a valid name, since passing an unregistered name errors out.
     """
     from pyscrappy import get_scraper
 


### PR DESCRIPTION
scoring) get complete, consistent definitions. Each tool now:

- states its purpose and the return shape (a Returns: block)
- notes behavior, side effects, network/browser needs, and empty-result handling
- documents every parameter with type, example, default, and allowed values
- gives usage guidance (when to use it vs sibling tools, gotchas)

Motivated by a tool-definition audit that scored several tools C/B (lowest 2.7/5),
mostly for missing behavior notes, usage guidance, and incomplete parameters.

Docstrings only — no behavior change. All 24 tools still register with valid
schemas; 337 tests pass; lint/format clean.

Bump version to 1.3.4.