### PR TITLE
mcp: make cache TTL configurable via PYSCRAPPY_MCP_CACHE_TTL env var

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -9,6 +9,7 @@ loop.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import anyio
@@ -47,8 +48,21 @@ mcp = FastMCP("pyscrappy")
 
 # Agents tend to ask for the same data repeatedly within a session, so cache
 # successful responses for a few minutes to cut latency and avoid rate limits.
-# Hardcoded for now; a future version will make this configurable.
-_CACHE_TTL = 300.0
+# Configurable via PYSCRAPPY_MCP_CACHE_TTL (seconds); falls back to 300s.
+_DEFAULT_CACHE_TTL = 300.0
+
+
+def _cache_ttl_from_env() -> float:
+    raw = os.getenv("PYSCRAPPY_MCP_CACHE_TTL")
+    if raw is None or raw.strip() == "":
+        return _DEFAULT_CACHE_TTL
+    try:
+        return float(raw)
+    except ValueError:
+        return _DEFAULT_CACHE_TTL
+
+
+_CACHE_TTL = _cache_ttl_from_env()
 
 
 def _config() -> ScraperConfig:

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -9,6 +9,7 @@ loop.
 
 from __future__ import annotations
 
+import math
 import os
 from typing import Any
 
@@ -57,9 +58,12 @@ def _cache_ttl_from_env() -> float:
     if raw is None or raw.strip() == "":
         return _DEFAULT_CACHE_TTL
     try:
-        return float(raw)
+        ttl = float(raw)
     except ValueError:
         return _DEFAULT_CACHE_TTL
+    if not math.isfinite(ttl):
+        return _DEFAULT_CACHE_TTL
+    return ttl
 
 
 _CACHE_TTL = _cache_ttl_from_env()
@@ -80,7 +84,7 @@ class ScrapeToolResult(BaseModel):
     """Structured result returned by every PyScrappy MCP tool.
 
     ``data`` holds the scraped items. The item shape depends on the source (a
-    movie, a stock quote, an article…), so it stays a list of free-form objects,
+    movie, a stock quote, an articleâ€¦), so it stays a list of free-form objects,
     while the envelope around it is typed and gives agents a stable schema.
     """
 
@@ -540,7 +544,7 @@ async def search_soundcloud(query: str, max_results: int = 20) -> ScrapeToolResu
     def _do() -> ScrapeResult:
         # The scraper drives Playwright's sync API, which pins the browser to
         # the thread that created it. Open, use and close it all inside this
-        # one worker thread — never split the lifecycle across threads.
+        # one worker thread â€” never split the lifecycle across threads.
         with SoundCloudScraper(_config()) as scs:
             return scs.scrape(
                 query=query,
@@ -668,7 +672,7 @@ def _register_plugin_tools() -> None:
 
                 # Expose the scraper method's signature (minus self) so FastMCP
                 # derives a typed input schema from it. The return annotation is
-                # forced to ScrapeToolResult — what _tool actually returns —
+                # forced to ScrapeToolResult â€” what _tool actually returns â€”
                 # otherwise FastMCP validates against the method's own return
                 # type (ScrapeResult) and rejects the result.
                 sig = inspect.signature(method)
@@ -677,7 +681,7 @@ def _register_plugin_tools() -> None:
                     parameters=params, return_annotation=ScrapeToolResult
                 )
                 # fastmcp derives the input schema from __annotations__ (not
-                # __signature__), so keep them in sync — otherwise pydantic looks
+                # __signature__), so keep them in sync â€” otherwise pydantic looks
                 # up a signature param that's absent from annotations and raises
                 # KeyError. The real _tool takes **kwargs, so we rewrite its
                 # annotations to the scraper method's typed params + return type.

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -84,7 +84,7 @@ class ScrapeToolResult(BaseModel):
     """Structured result returned by every PyScrappy MCP tool.
 
     ``data`` holds the scraped items. The item shape depends on the source (a
-    movie, a stock quote, an articleâ€¦), so it stays a list of free-form objects,
+    movie, a stock quote, an article…), so it stays a list of free-form objects,
     while the envelope around it is typed and gives agents a stable schema.
     """
 
@@ -544,7 +544,7 @@ async def search_soundcloud(query: str, max_results: int = 20) -> ScrapeToolResu
     def _do() -> ScrapeResult:
         # The scraper drives Playwright's sync API, which pins the browser to
         # the thread that created it. Open, use and close it all inside this
-        # one worker thread â€” never split the lifecycle across threads.
+        # one worker thread — never split the lifecycle across threads.
         with SoundCloudScraper(_config()) as scs:
             return scs.scrape(
                 query=query,
@@ -672,7 +672,7 @@ def _register_plugin_tools() -> None:
 
                 # Expose the scraper method's signature (minus self) so FastMCP
                 # derives a typed input schema from it. The return annotation is
-                # forced to ScrapeToolResult â€” what _tool actually returns â€”
+                # forced to ScrapeToolResult — what _tool actually returns —
                 # otherwise FastMCP validates against the method's own return
                 # type (ScrapeResult) and rejects the result.
                 sig = inspect.signature(method)
@@ -681,7 +681,7 @@ def _register_plugin_tools() -> None:
                     parameters=params, return_annotation=ScrapeToolResult
                 )
                 # fastmcp derives the input schema from __annotations__ (not
-                # __signature__), so keep them in sync â€” otherwise pydantic looks
+                # __signature__), so keep them in sync — otherwise pydantic looks
                 # up a signature param that's absent from annotations and raises
                 # KeyError. The real _tool takes **kwargs, so we rewrite its
                 # annotations to the scraper method's typed params + return type.

--- a/tests/test_mcp/test_cache_ttl.py
+++ b/tests/test_mcp/test_cache_ttl.py
@@ -1,4 +1,6 @@
-﻿"""Tests for the MCP server's configurable cache TTL (pyscrappy.mcp.server)."""
+"""Tests for the MCP server's configurable cache TTL (pyscrappy.mcp.server)."""
+
+import importlib
 
 import pytest
 
@@ -20,3 +22,22 @@ def test_env_override_is_honored(monkeypatch):
 def test_invalid_env_value_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("PYSCRAPPY_MCP_CACHE_TTL", "not-a-number")
     assert server._cache_ttl_from_env() == server._DEFAULT_CACHE_TTL
+
+
+def test_non_finite_env_value_falls_back_to_default(monkeypatch):
+    for value in ("nan", "inf", "-inf"):
+        monkeypatch.setenv("PYSCRAPPY_MCP_CACHE_TTL", value)
+        assert server._cache_ttl_from_env() == server._DEFAULT_CACHE_TTL
+
+
+def test_module_level_ttl_honors_env_var_at_import(monkeypatch):
+    """_CACHE_TTL and _config() are set at import time from the env var."""
+    monkeypatch.setenv("PYSCRAPPY_MCP_CACHE_TTL", "42")
+    try:
+        importlib.reload(server)
+        assert server._CACHE_TTL == 42.0
+        assert server._config().cache_ttl == 42.0
+    finally:
+        monkeypatch.delenv("PYSCRAPPY_MCP_CACHE_TTL", raising=False)
+        importlib.reload(server)
+        assert server._CACHE_TTL == server._DEFAULT_CACHE_TTL

--- a/tests/test_mcp/test_cache_ttl.py
+++ b/tests/test_mcp/test_cache_ttl.py
@@ -1,0 +1,22 @@
+﻿"""Tests for the MCP server's configurable cache TTL (pyscrappy.mcp.server)."""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from pyscrappy.mcp import server  # noqa: E402  (import after the skip guard)
+
+
+def test_default_ttl_when_env_unset(monkeypatch):
+    monkeypatch.delenv("PYSCRAPPY_MCP_CACHE_TTL", raising=False)
+    assert server._cache_ttl_from_env() == server._DEFAULT_CACHE_TTL
+
+
+def test_env_override_is_honored(monkeypatch):
+    monkeypatch.setenv("PYSCRAPPY_MCP_CACHE_TTL", "60")
+    assert server._cache_ttl_from_env() == 60.0
+
+
+def test_invalid_env_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("PYSCRAPPY_MCP_CACHE_TTL", "not-a-number")
+    assert server._cache_ttl_from_env() == server._DEFAULT_CACHE_TTL


### PR DESCRIPTION
Closes #64

`_CACHE_TTL` in `pyscrappy/mcp/server.py` was hardcoded to 300s. This adds
a `PYSCRAPPY_MCP_CACHE_TTL` env var override, falling back to the existing
300s default when unset or invalid.

Added tests covering:
- default is used when the env var is unset
- the override is honored
- an invalid value falls back to the default