### PR TITLE
test: cover cache TTL expiry triggering a re-fetch (closes #59)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.4"
+version = "1.3.5"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.4",
+  "version": "1.3.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -101,7 +101,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 __all__ = [
     # Core

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -274,6 +274,23 @@ class TestHttpClientCaching:
         assert mock_httpx.get.call_count == 1  # only first hit the network
         client.close()
 
+    def test_expired_entry_triggers_refetch(self, monkeypatch):
+        # Drive a fake clock so the entry ages past its TTL without sleeping.
+        import pyscrappy.core.http as http_mod
+
+        now = [1000.0]
+        monkeypatch.setattr(http_mod.time, "monotonic", lambda: now[0])
+
+        client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
+        client.get("https://example.com")  # network + cache
+        now[0] += 30  # within TTL -> served from cache
+        client.get("https://example.com")
+        assert mock_httpx.get.call_count == 1
+        now[0] += 31  # total 61s > 60s TTL -> entry is stale, must re-fetch
+        client.get("https://example.com")
+        assert mock_httpx.get.call_count == 2
+        client.close()
+
     def test_params_are_part_of_key(self):
         client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get("https://api.example.com", params={"q": "a"})


### PR DESCRIPTION
The cache_ttl expiry path (an entry older than the TTL is treated as a miss and re-fetched) had no test. Adds one using a fake monotonic clock so it's deterministic and instant, no sleep.

No source change: the TTL feature already exists via ScraperConfig.cache_ttl (0 = off, positive = cache with that TTL). This just closes the coverage gap the issue called for. Kept the cache_ttl=0=off semantics rather than the None=forever the issue proposed, since always-bounded caching is the safer design.

Bump version to 1.3.5.