### PR TITLE
feat: configurable retry backoff + scheduled integration tests (closes #58, #57)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: Integration (live scrapers)
+
+# The integration tests hit real websites, so they're deselected from PR CI
+# (slow, and they break when a target site changes its HTML — which is exactly
+# what we want to catch here, proactively, rather than via a user report).
+#
+# Runs on a weekly schedule and can be triggered manually. It's allowed to fail
+# without blocking anything: a failure means a site changed and a scraper needs
+# attention. Check the run summary to see which scrapers broke.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # every Monday at 06:00 UTC
+  workflow_dispatch: {} # allow manual runs from the Actions tab
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e '.[all]' pytest
+      # Run ONLY the integration tests. continue-on-error so one broken site
+      # doesn't mask the rest of the report; the step summary shows what failed.
+      - name: Run live integration tests
+        run: pytest -m integration -v -rA

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install -e '.[all]' pytest
-      # Run ONLY the integration tests. continue-on-error so one broken site
-      # doesn't mask the rest of the report; the step summary shows what failed.
+      # Run ONLY the integration tests. -rA prints a full summary of every test
+      # (including failures) so a broken scraper is visible in the logs even when
+      # others pass; a failing run marks the workflow red, which is the signal.
       - name: Run live integration tests
         run: pytest -m integration -v -rA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.5"
+version = "1.3.6"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -101,7 +101,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -25,7 +25,12 @@ class ScraperConfig:
     Attributes:
         timeout: HTTP request timeout in seconds.
         max_retries: Number of retry attempts for failed requests.
-        retry_delay: Base delay between retries in seconds (exponential backoff).
+        retry_delay: Base delay before the first retry, in seconds.
+        backoff_factor: Multiplier applied to the delay after each retry, so the
+            wait is ``retry_delay * backoff_factor ** (attempt - 1)``. ``2.0``
+            (the default) doubles each time; ``1.0`` keeps a constant delay.
+        backoff_max: Upper bound (seconds) on a single retry delay, so backoff
+            can't grow without limit. ``None`` (the default) means no cap.
         rate_limit: Minimum seconds between requests to the same domain.
         user_agents: List of User-Agent strings to rotate through.
         proxy: A proxy URL, e.g. ``"http://user:pass@host:port"``, or a list of
@@ -49,6 +54,8 @@ class ScraperConfig:
     timeout: float = 30.0
     max_retries: int = 3
     retry_delay: float = 1.0
+    backoff_factor: float = 2.0
+    backoff_max: float | None = None
     rate_limit: float = 1.0
     user_agents: list[str] = field(default_factory=lambda: list(_DEFAULT_USER_AGENTS))
     proxy: str | list[str] | None = None

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -17,6 +17,21 @@ from pyscrappy.core.exceptions import NetworkError, RateLimitError
 
 logger = logging.getLogger("pyscrappy.http")
 
+
+def backoff_delay(config: ScraperConfig, attempt: int) -> float:
+    """Retry delay (seconds) before the given attempt (1-indexed), using the
+    config's base delay, backoff factor, and optional cap:
+    ``retry_delay * backoff_factor ** (attempt - 1)``, clamped to ``backoff_max``.
+
+    Module-level so scrapers with their own retry loops (e.g. the stock scraper's
+    Yahoo 429 handling) honor the same configurable backoff as HttpClient.
+    """
+    delay = config.retry_delay * (config.backoff_factor ** (attempt - 1))
+    if config.backoff_max is not None:
+        delay = min(delay, config.backoff_max)
+    return delay
+
+
 # Process-wide response cache, shared across all HttpClient instances. This lets
 # caching survive the short-lived scraper instances that callers (e.g. the MCP
 # server) create per request. Entries are (monotonic timestamp, response). Only
@@ -162,7 +177,7 @@ class HttpClient:
                 headers = {"User-Agent": self._pick_ua(), **extra_headers}
                 resp = client.post(url, headers=headers, follow_redirects=True, **kwargs)
                 if resp.status_code >= 500 and attempt < self.config.max_retries:
-                    time.sleep(self.config.retry_delay * (2 ** (attempt - 1)))
+                    time.sleep(self._backoff_delay(attempt))
                     continue
                 resp.raise_for_status()
                 return resp.text
@@ -171,7 +186,7 @@ class HttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
-                    time.sleep(self.config.retry_delay * (2 ** (attempt - 1)))
+                    time.sleep(self._backoff_delay(attempt))
                     continue
 
         raise NetworkError(
@@ -208,14 +223,8 @@ class HttpClient:
         return random.choice(self.config.user_agents)
 
     def _backoff_delay(self, attempt: int) -> float:
-        """Delay before the given retry (1-indexed), using the configured base
-        delay, backoff factor, and optional cap:
-        ``retry_delay * backoff_factor ** (attempt - 1)``, clamped to backoff_max.
-        """
-        delay = self.config.retry_delay * (self.config.backoff_factor ** (attempt - 1))
-        if self.config.backoff_max is not None:
-            delay = min(delay, self.config.backoff_max)
-        return delay
+        """Retry delay for this client's config (see module-level backoff_delay)."""
+        return backoff_delay(self.config, attempt)
 
     # -- caching --
 

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -111,7 +111,7 @@ class HttpClient:
             except httpx.HTTPStatusError as exc:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
-                    delay = self.config.retry_delay * (2 ** (attempt - 1))
+                    delay = self._backoff_delay(attempt)
                     logger.warning(
                         "Server error %s on %s, retry %d in %.1fs",
                         exc.response.status_code,
@@ -126,7 +126,7 @@ class HttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
-                    delay = self.config.retry_delay * (2 ** (attempt - 1))
+                    delay = self._backoff_delay(attempt)
                     logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
                     time.sleep(delay)
                     continue
@@ -206,6 +206,16 @@ class HttpClient:
 
     def _pick_ua(self) -> str:
         return random.choice(self.config.user_agents)
+
+    def _backoff_delay(self, attempt: int) -> float:
+        """Delay before the given retry (1-indexed), using the configured base
+        delay, backoff factor, and optional cap:
+        ``retry_delay * backoff_factor ** (attempt - 1)``, clamped to backoff_max.
+        """
+        delay = self.config.retry_delay * (self.config.backoff_factor ** (attempt - 1))
+        if self.config.backoff_max is not None:
+            delay = min(delay, self.config.backoff_max)
+        return delay
 
     # -- caching --
 

--- a/src/pyscrappy/scrapers/stock.py
+++ b/src/pyscrappy/scrapers/stock.py
@@ -205,9 +205,13 @@ class StockScraper(BaseScraper):
                 self._ensure_crumb()
                 continue
 
-            # Rate-limited — back off and retry
+            # Rate-limited — back off and retry. This loop is 0-indexed, but
+            # backoff_delay expects 1-indexed attempts, so pass attempt + 1 (keeps
+            # the previous retry_delay * 2**attempt schedule with the defaults).
             if resp.status_code == 429:
-                delay = self.config.retry_delay * (2**attempt)
+                from pyscrappy.core.http import backoff_delay
+
+                delay = backoff_delay(self.config, attempt + 1)
                 self.logger.warning("Rate-limited by Yahoo Finance, retrying in %.1fs", delay)
                 time.sleep(delay)
                 continue

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -7,7 +7,7 @@ import pytest
 
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import NetworkError, RateLimitError
-from pyscrappy.core.http import HttpClient
+from pyscrappy.core.http import HttpClient, backoff_delay
 
 
 class TestHttpClientInit:
@@ -123,6 +123,13 @@ class TestHttpClientGet:
         with pytest.raises(NetworkError, match="HTTP 403"):
             client.get("https://example.com")
         client.close()
+
+    def test_module_backoff_delay_shared_by_scrapers(self):
+        # The module-level helper (used by scrapers with their own retry loops,
+        # e.g. the stock scraper) honors the same config as HttpClient.
+        cfg = ScraperConfig(retry_delay=1.0, backoff_factor=2.0, backoff_max=5.0)
+        assert backoff_delay(cfg, 1) == 1.0
+        assert backoff_delay(cfg, 4) == 5.0  # 8.0 capped to 5.0
 
     def test_backoff_delay_defaults_to_exponential_doubling(self):
         client = HttpClient(ScraperConfig(retry_delay=1.0))  # factor 2.0 by default

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -124,6 +124,33 @@ class TestHttpClientGet:
             client.get("https://example.com")
         client.close()
 
+    def test_backoff_delay_defaults_to_exponential_doubling(self):
+        client = HttpClient(ScraperConfig(retry_delay=1.0))  # factor 2.0 by default
+        assert client._backoff_delay(1) == 1.0
+        assert client._backoff_delay(2) == 2.0
+        assert client._backoff_delay(3) == 4.0
+        client.close()
+
+    def test_backoff_factor_is_configurable(self):
+        client = HttpClient(ScraperConfig(retry_delay=2.0, backoff_factor=3.0))
+        assert client._backoff_delay(1) == 2.0
+        assert client._backoff_delay(2) == 6.0
+        assert client._backoff_delay(3) == 18.0
+        client.close()
+
+    def test_backoff_factor_one_keeps_delay_constant(self):
+        client = HttpClient(ScraperConfig(retry_delay=1.5, backoff_factor=1.0))
+        assert client._backoff_delay(1) == 1.5
+        assert client._backoff_delay(5) == 1.5
+        client.close()
+
+    def test_backoff_max_caps_the_delay(self):
+        client = HttpClient(ScraperConfig(retry_delay=1.0, backoff_factor=2.0, backoff_max=5.0))
+        assert client._backoff_delay(3) == 4.0  # under the cap
+        assert client._backoff_delay(4) == 5.0  # 8.0 clamped to 5.0
+        assert client._backoff_delay(10) == 5.0  # stays capped
+        client.close()
+
     def test_get_retries_on_server_error(self):
         config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=0)
         client = HttpClient(config)


### PR DESCRIPTION
## #58 : Configurable retry/backoff in ScraperConfig

The HTTP client already retried with exponential backoff, but the backoff multiplier (hardcoded to 2) and the maximum delay weren't configurable.

- Add `backoff_factor` (default 2.0) and `backoff_max` (default None) to ScraperConfig. `max_retries` and `retry_delay` already existed.
- The retry delay is now `retry_delay * backoff_factor ** (attempt - 1)`, clamped to `backoff_max` when set. `backoff_factor=1.0` gives a constant delay; `backoff_max` bounds unbounded growth on high retry counts.
- Both retry sites (5xx and request errors) use a single `_backoff_delay` helper.
- Default behavior is unchanged (factor 2.0, no cap = the previous doubling).

Tests: default doubling, custom factor, constant delay, and the cap.

## #57 : Run the live integration tests on a schedule

The integration tests (`@pytest.mark.integration`) hit real websites and are deselected from PR CI. That means scraper breakage from a site changing its HTML only surfaced via user reports.

- Add a separate `integration.yml` workflow that runs `pytest -m integration` weekly (Monday 06:00 UTC) and on manual dispatch.
- Kept separate from PR CI so it can fail without blocking merges, a failure just means a site changed and a scraper needs attention.

## Tests

345 passing (non-integration), lint/format clean. Integration workflow YAML validated and `-m integration` confirmed to select the live suite; the schedule itself only runs once merged to the default branch.

Bump version to 1.3.6.