### PR TITLE
feat: native async scraping across all scrapers (scrape_async)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.3.6"
+version = "1.4.0"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.3.6",
+  "version": "1.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -27,6 +27,7 @@ Quick start::
 """
 
 from pyscrappy.concurrent import scrape_all, scrape_many
+from pyscrappy.core.async_http import AsyncHttpClient
 from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import (
@@ -101,7 +102,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.3.6"
+__version__ = "1.4.0"
 
 __all__ = [
     # Core
@@ -146,8 +147,10 @@ __all__ = [
     "WikipediaScraper",
     # Convenience
     "scrape",
+    "scrape_async",
     "scrape_many",
     "scrape_all",
+    "AsyncHttpClient",
     # Plugins / registry
     "BaseScraper",
     "register_scraper",
@@ -189,3 +192,25 @@ def scrape(
             max_pages=max_pages,
             render_js=render_js,
         )
+
+
+async def scrape_async(
+    url: str,
+    selectors: "dict[str, str] | None" = None,
+    max_pages: int = 1,
+    config: "ScraperConfig | None" = None,
+) -> ScrapeResult:
+    """Async one-liner to scrape any URL, for asyncio callers.
+
+    Uses a native AsyncHttpClient (no thread pool). JS rendering is not supported
+    here; use :func:`scrape` with ``render_js=True`` for browser-rendered pages.
+
+    Example::
+
+        import asyncio
+        from pyscrappy import scrape_async
+        result = asyncio.run(scrape_async("https://example.com"))
+    """
+    return await GenericScraper(config).scrape_async(
+        url=url, selectors=selectors, max_pages=max_pages
+    )

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -1,93 +1,75 @@
-"""HTTP client with retry, rate-limiting, and User-Agent rotation."""
+"""Async HTTP client — the asyncio counterpart to ``HttpClient``.
+
+Mirrors the sync client's retry, rate-limiting, User-Agent/header handling, and
+the shared in-memory response cache, but built on ``httpx.AsyncClient`` so async
+callers (FastAPI services, async agents) get native concurrency without pushing
+blocking calls onto a thread pool.
+
+The sync ``HttpClient`` is unchanged; this is additive.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import random
-import threading
 import time
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import httpx
 
 from pyscrappy.core import scraper_api
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import NetworkError, RateLimitError
+from pyscrappy.core.http import (
+    _CACHE_LOCK,
+    _SHARED_CACHE,
+    backoff_delay,
+)
 
-logger = logging.getLogger("pyscrappy.http")
-
-
-def backoff_delay(config: ScraperConfig, attempt: int) -> float:
-    """Retry delay (seconds) before the given attempt (1-indexed), using the
-    config's base delay, backoff factor, and optional cap:
-    ``retry_delay * backoff_factor ** (attempt - 1)``, clamped to ``backoff_max``.
-
-    Module-level so scrapers with their own retry loops (e.g. the stock scraper's
-    Yahoo 429 handling) honor the same configurable backoff as HttpClient.
-    """
-    delay = config.retry_delay * (config.backoff_factor ** (attempt - 1))
-    if config.backoff_max is not None:
-        delay = min(delay, config.backoff_max)
-    return delay
+logger = logging.getLogger("pyscrappy.async_http")
 
 
-# Process-wide response cache, shared across all HttpClient instances. This lets
-# caching survive the short-lived scraper instances that callers (e.g. the MCP
-# server) create per request. Entries are (monotonic timestamp, response). Only
-# populated when a client's config.cache_ttl > 0; guarded by a lock because
-# scrapers may run in worker threads.
-_SHARED_CACHE: dict[str, tuple[float, httpx.Response]] = {}
-_CACHE_LOCK = threading.Lock()
-
-
-class HttpClient:
-    """Sync HTTP client wrapping httpx with automatic retries and rate-limiting.
+class AsyncHttpClient:
+    """Async HTTP client wrapping httpx.AsyncClient with retries and rate-limiting.
 
     Usage::
 
-        config = ScraperConfig(timeout=20, max_retries=2)
-        with HttpClient(config) as client:
-            html = client.get_html("https://example.com")
+        async with AsyncHttpClient(config) as client:
+            html = await client.get_html("https://example.com")
+
+    Shares the process-wide response cache with the sync ``HttpClient``, so a
+    value fetched by either is visible to the other within the TTL.
     """
 
     def __init__(self, config: ScraperConfig | None = None) -> None:
         self.config = config or ScraperConfig()
-        self._client: httpx.Client | None = None
+        self._client: httpx.AsyncClient | None = None
         self._last_request_time: dict[str, float] = {}
 
-    # -- context manager --
-
-    def __enter__(self) -> HttpClient:
+    async def __aenter__(self) -> AsyncHttpClient:
         self._client = self._build_client()
         return self
 
-    def __exit__(self, *exc: Any) -> None:
-        self.close()
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
 
-    def close(self) -> None:
+    async def aclose(self) -> None:
         if self._client:
-            self._client.close()
+            await self._client.aclose()
             self._client = None
 
     # -- public API --
 
-    def get(self, url: str, **kwargs: Any) -> httpx.Response:
-        """Perform a GET request with retries and rate-limiting.
-
-        When ``config.cache_ttl > 0``, a successful response is cached in memory
-        and returned for repeat requests within the TTL, skipping both the
-        network and the rate limiter.
-        """
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        """GET with retries, rate-limiting, and optional caching (see HttpClient.get)."""
         cache_key = self._cache_key(url, kwargs.get("params"))
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("Cache hit for %s", url)
             return cached
 
-        # Route through a scraping-API service if configured, so blocked sites
-        # come back unblocked. Any caller params are folded into the *target*
-        # URL first, then the whole URL is handed to the service endpoint.
         if scraper_api.is_configured(self.config.scraper_api):
             caller_params = kwargs.pop("params", None)
             if caller_params:
@@ -98,24 +80,20 @@ class HttpClient:
             kwargs["params"] = api_params
 
         client = self._ensure_client()
-        self._rate_limit(url)
-
-        # Merge any caller-supplied headers on top of a rotated User-Agent,
-        # so scrapers can add site-specific headers (e.g. Referer) without
-        # colliding with the headers kwarg httpx expects.
+        await self._rate_limit(url)
         extra_headers = kwargs.pop("headers", None) or {}
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
                 headers = self._merge_headers(extra_headers)
-                resp = client.get(url, headers=headers, follow_redirects=True, **kwargs)
+                resp = await client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
                 if resp.status_code == 429:
                     retry_after = float(resp.headers.get("Retry-After", self.config.retry_delay))
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
-                        time.sleep(retry_after)
+                        await asyncio.sleep(retry_after)
                         continue
                     raise RateLimitError(f"Rate-limited by {url} after {attempt} attempts")
 
@@ -126,58 +104,48 @@ class HttpClient:
             except httpx.HTTPStatusError as exc:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
-                    delay = self._backoff_delay(attempt)
-                    logger.warning(
-                        "Server error %s on %s, retry %d in %.1fs",
-                        exc.response.status_code,
-                        url,
-                        attempt,
-                        delay,
-                    )
-                    time.sleep(delay)
+                    await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
 
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
-                    delay = self._backoff_delay(attempt)
-                    logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
-                    time.sleep(delay)
+                    await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
 
         raise NetworkError(
             f"Failed to fetch {url} after {self.config.max_retries} attempts"
         ) from last_exc
 
-    def get_raw(self, url: str, **kwargs: Any) -> httpx.Response:
-        """Like :meth:`get` but does NOT raise on non-2xx status codes.
-
-        Useful when the caller needs to inspect the status code itself
-        (e.g. to detect auth failures and retry with new credentials).
-        """
+    async def get_raw(self, url: str, **kwargs: Any) -> httpx.Response:
+        """Like :meth:`get` but does NOT raise on non-2xx status codes."""
         client = self._ensure_client()
-        self._rate_limit(url)
+        await self._rate_limit(url)
         extra_headers = kwargs.pop("headers", None) or {}
         headers = self._merge_headers(extra_headers)
-        return client.get(url, headers=headers, follow_redirects=True, **kwargs)
+        return await client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
-    def post_json(self, url: str, **kwargs: Any) -> str:
+    async def get_html(self, url: str, **kwargs: Any) -> str:
+        """Fetch a URL and return the response body as text."""
+        return (await self.get(url, **kwargs)).text
+
+    async def post_json(self, url: str, **kwargs: Any) -> str:
         """POST a request (JSON body via ``json=``) and return the response text.
 
         Retries on 5xx like :meth:`get`, and carries the session's cookies.
         """
         client = self._ensure_client()
-        self._rate_limit(url)
+        await self._rate_limit(url)
         extra_headers = kwargs.pop("headers", None) or {}
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
                 headers = self._merge_headers(extra_headers)
-                resp = client.post(url, headers=headers, follow_redirects=True, **kwargs)
+                resp = await client.post(url, headers=headers, follow_redirects=True, **kwargs)
                 if resp.status_code >= 500 and attempt < self.config.max_retries:
-                    time.sleep(self._backoff_delay(attempt))
+                    await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
                 resp.raise_for_status()
                 return resp.text
@@ -186,7 +154,7 @@ class HttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
-                    time.sleep(self._backoff_delay(attempt))
+                    await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
 
         raise NetworkError(
@@ -197,47 +165,35 @@ class HttpClient:
         """Set a cookie on the underlying session (used before a request)."""
         self._ensure_client().cookies.set(name, value, domain=domain)
 
-    def get_html(self, url: str, **kwargs: Any) -> str:
-        """Fetch a URL and return the response body as text."""
-        return self.get(url, **kwargs).text
+    # -- internals (mirror the sync client) --
 
-    # -- internals --
-
-    def _build_client(self) -> httpx.Client:
+    def _build_client(self) -> httpx.AsyncClient:
         transport_kwargs: dict[str, Any] = {}
         proxy = self.config.pick_proxy()
         if proxy:
             transport_kwargs["proxy"] = proxy
-        return httpx.Client(
+        return httpx.AsyncClient(
             timeout=self.config.timeout,
             verify=self.config.verify_ssl,
             **transport_kwargs,
         )
 
-    def _ensure_client(self) -> httpx.Client:
+    def _ensure_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = self._build_client()
         return self._client
 
     def _pick_ua(self) -> str:
-        # A configured single user_agent overrides rotation.
         if self.config.user_agent:
             return self.config.user_agent
         return random.choice(self.config.user_agents)
 
     def _merge_headers(self, extra: dict[str, str]) -> dict[str, str]:
-        """Build the request headers: config.headers (lowest priority), then the
-        chosen User-Agent, then per-call headers (highest priority)."""
         return {**self.config.headers, "User-Agent": self._pick_ua(), **extra}
 
-    def _backoff_delay(self, attempt: int) -> float:
-        """Retry delay for this client's config (see module-level backoff_delay)."""
-        return backoff_delay(self.config, attempt)
-
-    # -- caching --
+    # Cache is shared with the sync client (same module-level store + lock).
 
     def _cache_key(self, url: str, params: Any) -> str:
-        """Build a cache key from the URL and any query params."""
         if not params:
             return url
         try:
@@ -255,7 +211,7 @@ class HttpClient:
                 return None
             ts, resp = entry
             if time.monotonic() - ts > self.config.cache_ttl:
-                del _SHARED_CACHE[key]  # expired
+                del _SHARED_CACHE[key]
                 return None
             return resp
 
@@ -264,20 +220,12 @@ class HttpClient:
             with _CACHE_LOCK:
                 _SHARED_CACHE[key] = (time.monotonic(), resp)
 
-    @staticmethod
-    def clear_cache() -> None:
-        """Empty the process-wide response cache."""
-        with _CACHE_LOCK:
-            _SHARED_CACHE.clear()
-
-    def _rate_limit(self, url: str) -> None:
-        from urllib.parse import urlparse
-
+    async def _rate_limit(self, url: str) -> None:
         domain = urlparse(url).netloc
         now = time.monotonic()
         last = self._last_request_time.get(domain, 0.0)
         wait = self.config.rate_limit - (now - last)
         if wait > 0:
             logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
-            time.sleep(wait)
+            await asyncio.sleep(wait)
         self._last_request_time[domain] = time.monotonic()

--- a/src/pyscrappy/core/base.py
+++ b/src/pyscrappy/core/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup
 
@@ -12,12 +13,23 @@ from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.http import HttpClient
 from pyscrappy.core.models import ScrapeResult
 
+if TYPE_CHECKING:
+    from pyscrappy.core.async_http import AsyncHttpClient
+
 
 class BaseScraper(ABC):
     """Base class that all PyScrappy scrapers inherit from.
 
     Provides shared HTTP/browser fetching, parsing, and a consistent interface.
     Subclasses must implement :meth:`scrape`.
+
+    Every scraper also exposes an async counterpart, :meth:`scrape_async`, backed
+    by the shared async helpers below (:attr:`async_http`, :meth:`fetch_html_async`,
+    :meth:`fetch_and_parse_async`). The async path uses a native ``AsyncHttpClient``
+    and reuses the same synchronous parsing/extraction, so no scraping logic is
+    duplicated. JS rendering is sync-only (the browser backend), so ``scrape_async``
+    always fetches over plain HTTP; use :meth:`scrape` with ``render_js`` for pages
+    that need a browser.
     """
 
     name: str = "base"
@@ -26,6 +38,7 @@ class BaseScraper(ABC):
         self.config = config or ScraperConfig()
         self.logger = logging.getLogger(f"pyscrappy.{self.name}")
         self._http: HttpClient | None = None
+        self._async_http: AsyncHttpClient | None = None
         self._browser: BrowserManager | None = None
 
     def __enter__(self) -> BaseScraper:
@@ -33,6 +46,12 @@ class BaseScraper(ABC):
 
     def __exit__(self, *exc: object) -> None:
         self.close()
+
+    async def __aenter__(self) -> BaseScraper:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.aclose()
 
     def close(self) -> None:
         if self._http:
@@ -42,9 +61,30 @@ class BaseScraper(ABC):
             self._browser.close()
             self._browser = None
 
+    async def aclose(self) -> None:
+        """Close async resources (the async HTTP client). Sync resources, if any
+        were also opened, are closed too."""
+        if self._async_http:
+            await self._async_http.aclose()
+            self._async_http = None
+        self.close()
+
     @abstractmethod
     def scrape(self, **kwargs: object) -> ScrapeResult:
         """Run the scraper and return results."""
+
+    async def scrape_async(self, **kwargs: object) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape`.
+
+        Scrapers override this with a version that awaits the async fetch helpers
+        and reuses the same parsing/extraction as :meth:`scrape`. The default
+        implementation raises, so a scraper that hasn't been ported is explicit
+        rather than silently falling back to blocking I/O.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not provide a native async scrape yet; "
+            "use the synchronous scrape() instead."
+        )
 
     # -- shared helpers --
 
@@ -53,6 +93,14 @@ class BaseScraper(ABC):
         if self._http is None:
             self._http = HttpClient(self.config)
         return self._http
+
+    @property
+    def async_http(self) -> AsyncHttpClient:
+        if self._async_http is None:
+            from pyscrappy.core.async_http import AsyncHttpClient
+
+            self._async_http = AsyncHttpClient(self.config)
+        return self._async_http
 
     @property
     def browser(self) -> BrowserManager:
@@ -67,6 +115,13 @@ class BaseScraper(ABC):
             return self.browser.get_html(url, **kwargs)  # type: ignore[arg-type]
         return self.http.get_html(url, **kwargs)
 
+    async def fetch_html_async(self, url: str, **kwargs: object) -> str:
+        """Async fetch of a page's HTML over plain HTTP (no JS rendering).
+
+        The browser backend is sync-only, so there is no ``render_js`` option here.
+        """
+        return await self.async_http.get_html(url, **kwargs)
+
     def parse_html(self, html: str) -> BeautifulSoup:
         """Parse an HTML string into a BeautifulSoup tree."""
         return BeautifulSoup(html, "lxml")
@@ -74,3 +129,7 @@ class BaseScraper(ABC):
     def fetch_and_parse(self, url: str, render_js: bool = False, **kwargs: object) -> BeautifulSoup:
         """Fetch + parse in one call."""
         return self.parse_html(self.fetch_html(url, render_js=render_js, **kwargs))
+
+    async def fetch_and_parse_async(self, url: str, **kwargs: object) -> BeautifulSoup:
+        """Async fetch + parse in one call (plain HTTP, no JS rendering)."""
+        return self.parse_html(await self.fetch_html_async(url, **kwargs))

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -32,6 +32,13 @@ class ScraperConfig:
         backoff_max: Upper bound (seconds) on a single retry delay, so backoff
             can't grow without limit. ``None`` (the default) means no cap.
         rate_limit: Minimum seconds between requests to the same domain.
+        user_agent: A single User-Agent string to use for every request. When set,
+            it overrides ``user_agents`` rotation (some sites block the default
+            UAs or require a specific one). ``None`` (the default) rotates through
+            ``user_agents``.
+        headers: Extra HTTP headers sent on every request (e.g.
+            ``{"Accept-Language": "en-US"}``). Merged under the User-Agent, and a
+            per-call ``headers=`` argument still takes precedence over these.
         user_agents: List of User-Agent strings to rotate through.
         proxy: A proxy URL, e.g. ``"http://user:pass@host:port"``, or a list of
             proxy URLs to rotate through (one is picked at random per request).
@@ -57,6 +64,8 @@ class ScraperConfig:
     backoff_factor: float = 2.0
     backoff_max: float | None = None
     rate_limit: float = 1.0
+    user_agent: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
     user_agents: list[str] = field(default_factory=lambda: list(_DEFAULT_USER_AGENTS))
     proxy: str | list[str] | None = None
     scraper_api: dict[str, str] | None = None

--- a/src/pyscrappy/generic/scraper.py
+++ b/src/pyscrappy/generic/scraper.py
@@ -136,6 +136,60 @@ class GenericScraper(BaseScraper):
             errors=all_errors,
         )
 
+    async def scrape_async(
+        self,
+        url: str,
+        selectors: dict[str, str] | None = None,
+        max_pages: int = 1,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` for asyncio callers.
+
+        Fetches with a native ``AsyncHttpClient`` (no thread pool) and reuses the
+        same synchronous parsing/extraction. JS rendering is not supported here
+        (the browser backend is sync-only); use :meth:`scrape` with ``render_js``
+        for pages that need a browser.
+
+        Args, Returns: same as :meth:`scrape` (minus render_js/scroll_pages).
+        """
+        from pyscrappy.core.async_http import AsyncHttpClient
+
+        all_data: list[dict[str, Any]] = []
+        all_errors: list[ScrapeError] = []
+        visited: list[str] = []
+        current_url: str | None = url
+
+        async with AsyncHttpClient(self.config) as http:
+            for page_num in range(1, max_pages + 1):
+                if current_url is None:
+                    break
+                logger.info("Scraping page %d (async): %s", page_num, current_url)
+                visited.append(current_url)
+                try:
+                    html = await http.get_html(current_url)
+                except Exception as exc:
+                    all_errors.append(ScrapeError(url=current_url, message=str(exc)))
+                    break
+
+                soup = self.parse_html(html)
+                if selectors:
+                    all_data.extend(self._extract_with_selectors(soup, selectors, current_url))
+                else:
+                    all_data.append(self._extract_all(soup, current_url))
+
+                current_url = (
+                    find_next_page_url(soup, current_url) if page_num < max_pages else None
+                )
+
+        return ScrapeResult(
+            data=all_data,
+            metadata=ScrapeMetadata(
+                source_urls=visited,
+                total_pages=len(visited),
+                scraper=self.name,
+            ),
+            errors=all_errors,
+        )
+
     def _fetch_with_js_detection(self, url: str, render_js: bool | str, scroll_pages: int) -> str:
         """Fetch HTML, auto-detecting if JS rendering is needed."""
         if render_js is True:

--- a/src/pyscrappy/scrapers/amazon.py
+++ b/src/pyscrappy/scrapers/amazon.py
@@ -97,6 +97,52 @@ class AmazonScraper(BaseScraper):
                 break
             products.extend(page_products)
 
+        return self._build_result(products, errors, visited)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_pages: int = 1,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        products: list[dict[str, Any]] = []
+        errors: list[ScrapeError] = []
+        visited: list[str] = []
+
+        for page in range(1, max_pages + 1):
+            url = f"https://{self._domain}/s?k={query.replace(' ', '+')}&page={page}"
+            visited.append(url)
+
+            try:
+                soup = await self.fetch_and_parse_async(url, headers=self._HEADERS)
+            except Exception as exc:
+                errors.append(ScrapeError(url=url, message=str(exc)))
+                break
+
+            # Check for CAPTCHA
+            if soup.find("form", action=re.compile(r"validateCaptcha")):
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="Amazon returned a CAPTCHA page. Try using a proxy.",
+                    )
+                )
+                break
+
+            page_products = self._parse_search_results(soup, url)
+            if not page_products:
+                break
+            products.extend(page_products)
+
+        return self._build_result(products, errors, visited)
+
+    def _build_result(
+        self,
+        products: list[dict[str, Any]],
+        errors: list[ScrapeError],
+        visited: list[str],
+    ) -> ScrapeResult:
+        """Finalize a scrape: add the no-products error and build the result."""
         # Nothing extracted and no error recorded: the request "succeeded" but
         # yielded no products — almost always anti-bot blocking or a layout
         # change rather than a genuinely empty result. Say so, so callers aren't

--- a/src/pyscrappy/scrapers/crypto.py
+++ b/src/pyscrappy/scrapers/crypto.py
@@ -56,18 +56,43 @@ class CryptoScraper(BaseScraper):
             ScrapeResult with coin data (name, symbol, price, market cap, …).
         """
         ids = self._resolve_ids(query) if query else None
-        url = (
-            f"{_MARKETS}?vs_currency={vs_currency}"
-            f"&order=market_cap_desc&per_page={max_results}&page=1"
-        )
-        if ids:
-            url += f"&ids={quote_plus(','.join(ids))}"
+        url = self._build_markets_url(vs_currency, max_results, ids)
 
         try:
             payload = json.loads(self.http.get_html(url))
         except Exception as exc:
             return self._err(url, str(exc))
 
+        return self._build_result(payload, url, vs_currency)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str | None = None,
+        max_results: int = 20,
+        vs_currency: str = "usd",
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        ids = await self._resolve_ids_async(query) if query else None
+        url = self._build_markets_url(vs_currency, max_results, ids)
+
+        try:
+            payload = json.loads(await self.async_http.get_html(url))
+        except Exception as exc:
+            return self._err(url, str(exc))
+
+        return self._build_result(payload, url, vs_currency)
+
+    @staticmethod
+    def _build_markets_url(vs_currency: str, max_results: int, ids: list[str] | None) -> str:
+        url = (
+            f"{_MARKETS}?vs_currency={vs_currency}"
+            f"&order=market_cap_desc&per_page={max_results}&page=1"
+        )
+        if ids:
+            url += f"&ids={quote_plus(','.join(ids))}"
+        return url
+
+    def _build_result(self, payload: Any, url: str, vs_currency: str) -> ScrapeResult:
         if not isinstance(payload, list):
             return self._err(url, "Unexpected response from CoinGecko.")
 
@@ -86,6 +111,19 @@ class CryptoScraper(BaseScraper):
             try:
                 res = json.loads(self.http.get_html(f"{_SEARCH}?query={quote_plus(term)}"))
                 coins = res.get("coins", [])
+                if coins:
+                    ids.append(coins[0]["id"])
+            except Exception:
+                continue
+        return ids
+
+    async def _resolve_ids_async(self, query: str) -> list[str]:
+        """Async counterpart to :meth:`_resolve_ids`."""
+        ids: list[str] = []
+        for term in (t.strip() for t in query.split(",") if t.strip()):
+            try:
+                raw = await self.async_http.get_html(f"{_SEARCH}?query={quote_plus(term)}")
+                coins = json.loads(raw).get("coins", [])
                 if coins:
                     ids.append(coins[0]["id"])
             except Exception:

--- a/src/pyscrappy/scrapers/currency.py
+++ b/src/pyscrappy/scrapers/currency.py
@@ -56,6 +56,33 @@ class CurrencyScraper(BaseScraper):
         except Exception as exc:
             return self._err(url, str(exc))
 
+        return self._build_result(base, to, amount, url, payload)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        base: str = "USD",
+        to: str | None = None,
+        amount: float = 1.0,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = _API.format(base=base.upper())
+
+        try:
+            payload = json.loads(await self.async_http.get_html(url))
+        except Exception as exc:
+            return self._err(url, str(exc))
+
+        return self._build_result(base, to, amount, url, payload)
+
+    def _build_result(
+        self,
+        base: str,
+        to: str | None,
+        amount: float,
+        url: str,
+        payload: dict,
+    ) -> ScrapeResult:
+        """Build a ScrapeResult from a fetched exchange-rate payload."""
         if payload.get("result") != "success":
             msg = payload.get("error-type", "Unknown currency or API error.")
             return self._err(url, str(msg))

--- a/src/pyscrappy/scrapers/dictionary.py
+++ b/src/pyscrappy/scrapers/dictionary.py
@@ -57,6 +57,23 @@ class DictionaryScraper(BaseScraper):
         except Exception as exc:
             return self._err(url, str(exc))
 
+        return self._build_result(word, url, payload)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        word: str,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = _API.format(lang=self.lang, word=quote(word))
+
+        try:
+            payload = json.loads(await self.async_http.get_html(url))
+        except Exception as exc:
+            return self._err(url, str(exc))
+
+        return self._build_result(word, url, payload)
+
+    def _build_result(self, word: str, url: str, payload: Any) -> ScrapeResult:
         # The API returns a dict (with "title") when the word isn't found.
         if isinstance(payload, dict):
             return self._err(url, payload.get("title", f"No definition for {word!r}."))

--- a/src/pyscrappy/scrapers/github.py
+++ b/src/pyscrappy/scrapers/github.py
@@ -76,6 +76,38 @@ class GitHubScraper(BaseScraper):
                 errors=[ScrapeError(url=url, message=str(exc))],
             )
 
+        return self._build_result(payload, url)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = 30,
+        sort: str = "best-match",
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        per_page = min(max_results, 100)
+        url = f"{_API}?q={quote_plus(query)}&per_page={per_page}"
+        if sort != "best-match":
+            url += f"&sort={sort}"
+
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        try:
+            raw = await self.async_http.get_html(url, headers=headers)
+            payload = json.loads(raw)
+        except Exception as exc:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+                errors=[ScrapeError(url=url, message=str(exc))],
+            )
+
+        return self._build_result(payload, url)
+
+    def _build_result(self, payload: dict[str, Any], url: str) -> ScrapeResult:
+        """Shared payload handling for the sync and async scrape paths."""
         items = payload.get("items", [])
         repos = [self._parse(item) for item in items if isinstance(item, dict)]
 

--- a/src/pyscrappy/scrapers/hackernews.py
+++ b/src/pyscrappy/scrapers/hackernews.py
@@ -51,10 +51,7 @@ class HackerNewsScraper(BaseScraper):
         Returns:
             ScrapeResult with story data (title, url, points, author, comments, …).
         """
-        endpoint = "search_by_date" if by == "date" else "search"
-        base = _API.replace("/search", f"/{endpoint}")
-        hits = min(max_results, 1000)
-        url = f"{base}?query={quote_plus(query)}&tags={tags}&hitsPerPage={hits}"
+        url = self._build_url(query, max_results, by, tags)
 
         try:
             raw = self.http.get_html(url)
@@ -66,6 +63,38 @@ class HackerNewsScraper(BaseScraper):
                 errors=[ScrapeError(url=url, message=str(exc))],
             )
 
+        return self._build_result(url, payload)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = 20,
+        by: str = "relevance",
+        tags: str = "story",
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = self._build_url(query, max_results, by, tags)
+
+        try:
+            raw = await self.async_http.get_html(url)
+            payload = json.loads(raw)
+        except Exception as exc:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+                errors=[ScrapeError(url=url, message=str(exc))],
+            )
+
+        return self._build_result(url, payload)
+
+    @staticmethod
+    def _build_url(query: str, max_results: int, by: str, tags: str) -> str:
+        endpoint = "search_by_date" if by == "date" else "search"
+        base = _API.replace("/search", f"/{endpoint}")
+        hits = min(max_results, 1000)
+        return f"{base}?query={quote_plus(query)}&tags={tags}&hitsPerPage={hits}"
+
+    def _build_result(self, url: str, payload: dict[str, Any]) -> ScrapeResult:
         stories = [self._parse(hit) for hit in payload.get("hits", []) if isinstance(hit, dict)]
 
         errors: list[ScrapeError] = []

--- a/src/pyscrappy/scrapers/ikea.py
+++ b/src/pyscrappy/scrapers/ikea.py
@@ -62,13 +62,7 @@ class IKEAScraper(BaseScraper):
         Returns:
             ScrapeResult with product data (name, type, price, url, image, …).
         """
-        from urllib.parse import quote_plus
-
-        url = (
-            f"{_SEARCH_HOST}/{self.country}/{self.lang}/search-result-page"
-            f"?q={quote_plus(query)}&size={max_results}&types=PRODUCT"
-        )
-        errors: list[ScrapeError] = []
+        url = self._build_url(query, max_results)
 
         try:
             raw = self.http.get_html(url, headers=self._HEADERS)
@@ -79,6 +73,41 @@ class IKEAScraper(BaseScraper):
                 metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
                 errors=[ScrapeError(url=url, message=str(exc))],
             )
+
+        return self._build_result(payload, url)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = 24,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = self._build_url(query, max_results)
+
+        try:
+            raw = await self.async_http.get_html(url, headers=self._HEADERS)
+            payload = json.loads(raw)
+        except Exception as exc:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+                errors=[ScrapeError(url=url, message=str(exc))],
+            )
+
+        return self._build_result(payload, url)
+
+    def _build_url(self, query: str, max_results: int) -> str:
+        """Build the IKEA JSON search-API URL for a query."""
+        from urllib.parse import quote_plus
+
+        return (
+            f"{_SEARCH_HOST}/{self.country}/{self.lang}/search-result-page"
+            f"?q={quote_plus(query)}&size={max_results}&types=PRODUCT"
+        )
+
+    def _build_result(self, payload: dict[str, Any], url: str) -> ScrapeResult:
+        """Map the search-API payload into a ScrapeResult (shared sync/async)."""
+        errors: list[ScrapeError] = []
 
         items = (
             payload.get("searchResultPage", {}).get("products", {}).get("main", {}).get("items", [])

--- a/src/pyscrappy/scrapers/image_search.py
+++ b/src/pyscrappy/scrapers/image_search.py
@@ -67,11 +67,48 @@ class ImageSearchScraper(BaseScraper):
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
         )
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_images: int = 20,
+        engine: str = "bing",
+        download_to: str | None = None,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if engine == "google":
+            images, url = await self._search_google_async(query, max_images)
+        else:
+            images, url = await self._search_bing_async(query, max_images)
+
+        if download_to:
+            await self._download_images_async(images, download_to)
+
+        return ScrapeResult(
+            data=images,
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+        )
+
+    def _bing_url(self, query: str, max_images: int) -> str:
+        return (
+            f"https://www.bing.com/images/search?q={quote_plus(query)}&first=1&count={max_images}"
+        )
+
     def _search_bing(self, query: str, max_images: int) -> tuple[list[dict[str, Any]], str]:
         """Search Bing Images (server-rendered, no JS needed)."""
-        url = f"https://www.bing.com/images/search?q={quote_plus(query)}&first=1&count={max_images}"
+        url = self._bing_url(query, max_images)
         soup = self.fetch_and_parse(url)
+        return self._parse_bing(soup, url, max_images), url
 
+    async def _search_bing_async(
+        self, query: str, max_images: int
+    ) -> tuple[list[dict[str, Any]], str]:
+        """Async counterpart to :meth:`_search_bing`."""
+        url = self._bing_url(query, max_images)
+        soup = await self.fetch_and_parse_async(url)
+        return self._parse_bing(soup, url, max_images), url
+
+    def _parse_bing(self, soup: Any, url: str, max_images: int) -> list[dict[str, Any]]:
+        """Extract image records from a parsed Bing results page."""
         images: list[dict[str, Any]] = []
         for item in soup.select("a.iusc"):
             # Bing stores image metadata in the 'm' attribute as JSON
@@ -117,13 +154,27 @@ class ImageSearchScraper(BaseScraper):
                     if len(images) >= max_images:
                         break
 
-        return images, url
+        return images
+
+    def _google_url(self, query: str) -> str:
+        return f"https://www.google.com/search?q={quote_plus(query)}&tbm=isch"
 
     def _search_google(self, query: str, max_images: int) -> tuple[list[dict[str, Any]], str]:
         """Search Google Images (basic HTML — limited results without JS)."""
-        url = f"https://www.google.com/search?q={quote_plus(query)}&tbm=isch"
+        url = self._google_url(query)
         soup = self.fetch_and_parse(url)
+        return self._parse_google(soup, url, max_images), url
 
+    async def _search_google_async(
+        self, query: str, max_images: int
+    ) -> tuple[list[dict[str, Any]], str]:
+        """Async counterpart to :meth:`_search_google`."""
+        url = self._google_url(query)
+        soup = await self.fetch_and_parse_async(url)
+        return self._parse_google(soup, url, max_images), url
+
+    def _parse_google(self, soup: Any, url: str, max_images: int) -> list[dict[str, Any]]:
+        """Extract image records from a parsed Google results page."""
         images: list[dict[str, Any]] = []
         for img in soup.find_all("img", src=True):
             src = str(img["src"])
@@ -139,7 +190,7 @@ class ImageSearchScraper(BaseScraper):
             if len(images) >= max_images:
                 break
 
-        return images, url
+        return images
 
     def _download_images(self, images: list[dict[str, Any]], directory: str) -> None:
         """Download images to a local directory."""
@@ -155,6 +206,27 @@ class ImageSearchScraper(BaseScraper):
 
             try:
                 resp = self.http.get(img_url)
+                with open(filename, "wb") as f:
+                    f.write(resp.content)
+                img["local_path"] = filename
+                logger.info("Downloaded %s", filename)
+            except Exception as exc:
+                logger.warning("Failed to download %s: %s", img_url, exc)
+
+    async def _download_images_async(self, images: list[dict[str, Any]], directory: str) -> None:
+        """Async counterpart to :meth:`_download_images`."""
+        os.makedirs(directory, exist_ok=True)
+
+        for i, img in enumerate(images):
+            img_url = img.get("url", "")
+            if not img_url:
+                continue
+
+            ext = self._guess_extension(img_url)
+            filename = os.path.join(directory, f"image_{i + 1:04d}{ext}")
+
+            try:
+                resp = await self.async_http.get(img_url)
                 with open(filename, "wb") as f:
                     f.write(resp.content)
                 img["local_path"] = filename

--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -108,6 +108,55 @@ class IMDBScraper(BaseScraper):
             return self._lookup_by_id(query.strip())
         return self._search_by_title(query, max_pages)
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        genre: str | None = None,
+        query: str | None = None,
+        chart: str | None = None,
+        max_pages: int = 1,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if genre or chart:
+            unsupported = "genre" if genre else "chart"
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(scraper=self.name),
+                errors=[
+                    ScrapeError(
+                        url=_OMDB_BASE,
+                        message=(
+                            f"{unsupported!r} browsing is not supported. IMDB data "
+                            "is served via the OMDb API, which supports title "
+                            "search and id lookup only. Use query=<title> or "
+                            "query=<imdb id, e.g. tt1375666>."
+                        ),
+                    )
+                ],
+            )
+
+        if not query:
+            raise ValueError("Provide query=<title or IMDB id>.")
+
+        if not self.api_key:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(scraper=self.name),
+                errors=[
+                    ScrapeError(
+                        url=_OMDB_BASE,
+                        message=(
+                            "No OMDb API key. Set the OMDB_API_KEY environment "
+                            "variable or pass api_key=... to IMDBScraper. Get a "
+                            "free key at https://www.omdbapi.com/apikey.aspx"
+                        ),
+                    )
+                ],
+            )
+
+        if _IMDB_ID_RE.match(query.strip()):
+            return await self._lookup_by_id_async(query.strip())
+        return await self._search_by_title_async(query, max_pages)
+
     def _get(self, params: dict[str, str]) -> dict[str, Any]:
         """Call OMDb and return the parsed JSON object."""
         params = {**params, "apikey": self.api_key or ""}
@@ -116,9 +165,23 @@ class IMDBScraper(BaseScraper):
         raw = self.http.get_html(_OMDB_BASE, params=params)
         return json.loads(raw)
 
+    async def _get_async(self, params: dict[str, str]) -> dict[str, Any]:
+        """Async counterpart to :meth:`_get`."""
+        params = {**params, "apikey": self.api_key or ""}
+        import json
+
+        raw = await self.async_http.get_html(_OMDB_BASE, params=params)
+        return json.loads(raw)
+
     def _lookup_by_id(self, imdb_id: str) -> ScrapeResult:
+        return self._build_lookup_result(imdb_id, self._get({"i": imdb_id, "plot": "full"}))
+
+    async def _lookup_by_id_async(self, imdb_id: str) -> ScrapeResult:
+        payload = await self._get_async({"i": imdb_id, "plot": "full"})
+        return self._build_lookup_result(imdb_id, payload)
+
+    def _build_lookup_result(self, imdb_id: str, payload: dict[str, Any]) -> ScrapeResult:
         errors: list[ScrapeError] = []
-        payload = self._get({"i": imdb_id, "plot": "full"})
 
         if payload.get("Response") == "True":
             data = [self._normalise(payload)]
@@ -144,19 +207,8 @@ class IMDBScraper(BaseScraper):
         for page in range(1, max_pages + 1):
             payload = self._get({"s": query, "page": str(page)})
 
-            if payload.get("Response") != "True":
-                # OMDb returns "Movie not found!" / "Too many results." as errors.
-                if page == 1:
-                    errors.append(
-                        ScrapeError(
-                            url=_OMDB_BASE,
-                            message=f"OMDb: {payload.get('Error', 'no results')}",
-                        )
-                    )
-                break
-
-            results = payload.get("Search", [])
-            if not results:
+            results = self._search_page(payload, page, errors)
+            if results is None:
                 break
 
             # Enrich each search hit with full details (genre, rating, plot…).
@@ -170,6 +222,58 @@ class IMDBScraper(BaseScraper):
                     self._normalise(details if details.get("Response") == "True" else hit)
                 )
 
+        return self._build_search_result(movies, errors)
+
+    async def _search_by_title_async(self, query: str, max_pages: int) -> ScrapeResult:
+        movies: list[dict[str, Any]] = []
+        errors: list[ScrapeError] = []
+
+        for page in range(1, max_pages + 1):
+            payload = await self._get_async({"s": query, "page": str(page)})
+
+            results = self._search_page(payload, page, errors)
+            if results is None:
+                break
+
+            # Enrich each search hit with full details (genre, rating, plot…).
+            for hit in results:
+                imdb_id = hit.get("imdbID")
+                if not imdb_id:
+                    movies.append(self._normalise(hit))
+                    continue
+                details = await self._get_async({"i": imdb_id})
+                movies.append(
+                    self._normalise(details if details.get("Response") == "True" else hit)
+                )
+
+        return self._build_search_result(movies, errors)
+
+    def _search_page(
+        self, payload: dict[str, Any], page: int, errors: list[ScrapeError]
+    ) -> list[dict[str, Any]] | None:
+        """Validate one search-page payload; return its hits or None to stop.
+
+        Appends an error (page 1 only) when OMDb reports no results.
+        """
+        if payload.get("Response") != "True":
+            # OMDb returns "Movie not found!" / "Too many results." as errors.
+            if page == 1:
+                errors.append(
+                    ScrapeError(
+                        url=_OMDB_BASE,
+                        message=f"OMDb: {payload.get('Error', 'no results')}",
+                    )
+                )
+            return None
+
+        results = payload.get("Search", [])
+        if not results:
+            return None
+        return results
+
+    def _build_search_result(
+        self, movies: list[dict[str, Any]], errors: list[ScrapeError]
+    ) -> ScrapeResult:
         return ScrapeResult(
             data=movies,
             metadata=ScrapeMetadata(source_urls=[_OMDB_BASE], scraper=self.name),

--- a/src/pyscrappy/scrapers/instagram.py
+++ b/src/pyscrappy/scrapers/instagram.py
@@ -59,17 +59,37 @@ class InstagramScraper(BaseScraper):
             return self._scrape_hashtag(hashtag, max_posts, render_js, scroll_pages)
         raise ValueError("Provide either username or hashtag")
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        username: str | None = None,
+        hashtag: str | None = None,
+        max_posts: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if username:
+            url = f"https://www.instagram.com/{username}/"
+            html = await self.async_http.get_html(url)
+            return self._build_profile_result(html, url, username)
+        if hashtag:
+            url = f"https://www.instagram.com/explore/tags/{hashtag}/"
+            html = await self.async_http.get_html(url)
+            return self._build_hashtag_result(html, url, max_posts)
+        raise ValueError("Provide either username or hashtag")
+
     def _scrape_profile(
         self, username: str, max_posts: int, render_js: bool, scroll_pages: int
     ) -> ScrapeResult:
         url = f"https://www.instagram.com/{username}/"
-        errors: list[ScrapeError] = []
 
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
+        return self._build_profile_result(html, url, username)
+
+    def _build_profile_result(self, html: str, url: str, username: str) -> ScrapeResult:
+        errors: list[ScrapeError] = []
         data = self._extract_shared_data(html)
         if data:
             profile = self._parse_profile_json(data, username)
@@ -93,13 +113,16 @@ class InstagramScraper(BaseScraper):
         self, hashtag: str, max_posts: int, render_js: bool, scroll_pages: int
     ) -> ScrapeResult:
         url = f"https://www.instagram.com/explore/tags/{hashtag}/"
-        errors: list[ScrapeError] = []
 
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
+        return self._build_hashtag_result(html, url, max_posts)
+
+    def _build_hashtag_result(self, html: str, url: str, max_posts: int) -> ScrapeResult:
+        errors: list[ScrapeError] = []
         data = self._extract_shared_data(html)
         posts: list[dict[str, Any]] = []
 

--- a/src/pyscrappy/scrapers/linkedin.py
+++ b/src/pyscrappy/scrapers/linkedin.py
@@ -95,6 +95,58 @@ class LinkedInJobsScraper(BaseScraper):
             errors=errors,
         )
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        location: str = "",
+        max_pages: int = 1,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        jobs: list[dict[str, Any]] = []
+        errors: list[ScrapeError] = []
+        visited: list[str] = []
+
+        for page in range(max_pages):
+            start = page * 25
+            url = (
+                f"https://www.linkedin.com/jobs/search/?"
+                f"keywords={quote_plus(query)}"
+                f"&location={quote_plus(location)}"
+                f"&start={start}"
+            )
+            visited.append(url)
+
+            try:
+                soup = await self.fetch_and_parse_async(url)
+            except Exception as exc:
+                errors.append(ScrapeError(url=url, message=str(exc)))
+                break
+
+            # Check if we got an auth wall
+            if soup.find("form", class_="login__form"):
+                errors.append(
+                    ScrapeError(
+                        url=url,
+                        message="LinkedIn requires authentication for this page.",
+                    )
+                )
+                break
+
+            page_jobs = self._parse_job_cards(soup)
+            if not page_jobs:
+                break
+            jobs.extend(page_jobs)
+
+        return ScrapeResult(
+            data=jobs,
+            metadata=ScrapeMetadata(
+                source_urls=visited,
+                total_pages=len(visited),
+                scraper=self.name,
+            ),
+            errors=errors,
+        )
+
     def _parse_job_cards(self, soup: Any) -> list[dict[str, Any]]:
         """Parse job cards from LinkedIn's public job search page."""
         jobs: list[dict[str, Any]] = []

--- a/src/pyscrappy/scrapers/newegg.py
+++ b/src/pyscrappy/scrapers/newegg.py
@@ -101,6 +101,52 @@ class NeweggScraper(BaseScraper):
             errors=errors,
         )
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_pages: int = 1,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        products: list[dict[str, Any]] = []
+        errors: list[ScrapeError] = []
+        visited: list[str] = []
+
+        for page in range(1, max_pages + 1):
+            url = f"https://{self._domain}/p/pl?d={query.replace(' ', '+')}&page={page}"
+            visited.append(url)
+
+            try:
+                soup = await self.fetch_and_parse_async(url, headers=self._HEADERS)
+            except Exception as exc:
+                errors.append(ScrapeError(url=url, message=str(exc)))
+                break
+
+            page_products = self._parse_search_results(soup)
+            if not page_products:
+                break
+            products.extend(page_products)
+
+        if not products and not errors:
+            errors.append(
+                ScrapeError(
+                    url=visited[-1] if visited else "",
+                    message=(
+                        "No products extracted. Newegg may have changed its page "
+                        "layout, or the query returned no results."
+                    ),
+                )
+            )
+
+        return ScrapeResult(
+            data=products,
+            metadata=ScrapeMetadata(
+                source_urls=visited,
+                total_pages=len(visited),
+                scraper=self.name,
+            ),
+            errors=errors,
+        )
+
     def _parse_search_results(self, soup: Any) -> list[dict[str, Any]]:
         """Parse product cards from a search results page."""
         products: list[dict[str, Any]] = []

--- a/src/pyscrappy/scrapers/news.py
+++ b/src/pyscrappy/scrapers/news.py
@@ -61,9 +61,35 @@ class NewsScraper(BaseScraper):
             return self._scrape_site(site_url, max_articles)
         raise ValueError("Provide at least one of: feed_url, site_url, or article_url")
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        feed_url: str | None = None,
+        site_url: str | None = None,
+        article_url: str | None = None,
+        max_articles: int = 50,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if article_url:
+            return await self._scrape_article_async(article_url)
+        if feed_url:
+            return await self._scrape_feed_async(feed_url, max_articles)
+        if site_url:
+            return await self._scrape_site_async(site_url, max_articles)
+        raise ValueError("Provide at least one of: feed_url, site_url, or article_url")
+
     def _scrape_feed(self, url: str, max_articles: int) -> ScrapeResult:
         """Parse an RSS or Atom feed."""
         xml_text = self.http.get_html(url)
+        articles = self._parse_feed_xml(xml_text, max_articles)
+
+        return ScrapeResult(
+            data=articles,
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+        )
+
+    async def _scrape_feed_async(self, url: str, max_articles: int) -> ScrapeResult:
+        """Async counterpart to :meth:`_scrape_feed`."""
+        xml_text = await self.async_http.get_html(url)
         articles = self._parse_feed_xml(xml_text, max_articles)
 
         return ScrapeResult(
@@ -75,14 +101,28 @@ class NewsScraper(BaseScraper):
         """Auto-discover an RSS feed from a website, then parse it."""
         html = self.http.get_html(url)
         soup = self.parse_html(html)
-        errors: list[ScrapeError] = []
 
         feed_url = self._discover_feed(soup, url)
         if feed_url:
             return self._scrape_feed(feed_url, max_articles)
 
-        # Fallback: extract article links from the page directly
+        return self._build_site_fallback(soup, url, max_articles)
+
+    async def _scrape_site_async(self, url: str, max_articles: int) -> ScrapeResult:
+        """Async counterpart to :meth:`_scrape_site`."""
+        html = await self.async_http.get_html(url)
+        soup = self.parse_html(html)
+
+        feed_url = self._discover_feed(soup, url)
+        if feed_url:
+            return await self._scrape_feed_async(feed_url, max_articles)
+
+        return self._build_site_fallback(soup, url, max_articles)
+
+    def _build_site_fallback(self, soup: Any, url: str, max_articles: int) -> ScrapeResult:
+        """Build the no-RSS fallback result: article links extracted from HTML."""
         self.logger.info("No RSS feed found, extracting article links from HTML")
+        errors: list[ScrapeError] = []
         articles = self._extract_article_links(soup, url)
         if not articles:
             errors.append(ScrapeError(url=url, message="No RSS feed or article links found"))
@@ -96,7 +136,15 @@ class NewsScraper(BaseScraper):
     def _scrape_article(self, url: str) -> ScrapeResult:
         """Extract the full text of a single news article."""
         soup = self.fetch_and_parse(url)
+        return self._build_article(soup, url)
 
+    async def _scrape_article_async(self, url: str) -> ScrapeResult:
+        """Async counterpart to :meth:`_scrape_article`."""
+        soup = await self.fetch_and_parse_async(url)
+        return self._build_article(soup, url)
+
+    def _build_article(self, soup: Any, url: str) -> ScrapeResult:
+        """Extract article fields from a parsed page (pure, no fetching)."""
         article: dict[str, Any] = {"url": url}
 
         # Title

--- a/src/pyscrappy/scrapers/openlibrary.py
+++ b/src/pyscrappy/scrapers/openlibrary.py
@@ -50,12 +50,28 @@ class OpenLibraryScraper(BaseScraper):
             raw = self.http.get_html(url)
             payload = json.loads(raw)
         except Exception as exc:
-            return ScrapeResult(
-                data=[],
-                metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
-                errors=[ScrapeError(url=url, message=str(exc))],
-            )
+            return self._err(url, str(exc))
 
+        return self._build_result(payload, url)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = f"{_API}?q={quote_plus(query)}&limit={max_results}"
+
+        try:
+            raw = await self.async_http.get_html(url)
+            payload = json.loads(raw)
+        except Exception as exc:
+            return self._err(url, str(exc))
+
+        return self._build_result(payload, url)
+
+    def _build_result(self, payload: dict[str, Any], url: str) -> ScrapeResult:
+        """Shared payload handling for the sync and async scrape paths."""
         books = [self._parse(doc) for doc in payload.get("docs", []) if isinstance(doc, dict)]
 
         errors: list[ScrapeError] = []
@@ -66,6 +82,13 @@ class OpenLibraryScraper(BaseScraper):
             data=books,
             metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
             errors=errors,
+        )
+
+    def _err(self, url: str, message: str) -> ScrapeResult:
+        return ScrapeResult(
+            data=[],
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+            errors=[ScrapeError(url=url, message=message)],
         )
 
     @staticmethod

--- a/src/pyscrappy/scrapers/soundcloud.py
+++ b/src/pyscrappy/scrapers/soundcloud.py
@@ -49,13 +49,27 @@ class SoundCloudScraper(BaseScraper):
             ScrapeResult with track data (title, artist, plays, duration, url).
         """
         url = f"https://soundcloud.com/search/sounds?q={quote_plus(query)}"
-        errors: list[ScrapeError] = []
 
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
+        return self._build_result(html, url, max_results)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = f"https://soundcloud.com/search/sounds?q={quote_plus(query)}"
+        html = await self.async_http.get_html(url)
+        return self._build_result(html, url, max_results)
+
+    def _build_result(self, html: str, url: str, max_results: int) -> ScrapeResult:
+        """Extract tracks from fetched HTML and build the ScrapeResult."""
+        errors: list[ScrapeError] = []
         tracks = self._extract_tracks(html, max_results)
 
         if not tracks:

--- a/src/pyscrappy/scrapers/spotify.py
+++ b/src/pyscrappy/scrapers/spotify.py
@@ -65,17 +65,37 @@ class SpotifyScraper(BaseScraper):
             return self._scrape_search(query, search_type, max_results, render_js)
         raise ValueError("Provide either query or playlist_url")
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str | None = None,
+        search_type: str = "tracks",
+        playlist_url: str | None = None,
+        max_results: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if playlist_url:
+            html = await self.async_http.get_html(playlist_url)
+            return self._build_playlist_result(html, playlist_url, max_results)
+        if query:
+            url = f"https://open.spotify.com/search/{quote_plus(query)}/{search_type}"
+            html = await self.async_http.get_html(url)
+            return self._build_search_result(html, url, max_results)
+        raise ValueError("Provide either query or playlist_url")
+
     def _scrape_search(
         self, query: str, search_type: str, max_results: int, render_js: bool
     ) -> ScrapeResult:
         url = f"https://open.spotify.com/search/{quote_plus(query)}/{search_type}"
-        errors: list[ScrapeError] = []
 
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle")
         else:
             html = self.http.get_html(url)
 
+        return self._build_search_result(html, url, max_results)
+
+    def _build_search_result(self, html: str, url: str, max_results: int) -> ScrapeResult:
+        errors: list[ScrapeError] = []
         items = self._extract_items(html, max_results)
 
         if not items:
@@ -95,13 +115,15 @@ class SpotifyScraper(BaseScraper):
     def _scrape_playlist(
         self, url: str, max_results: int, render_js: bool, scroll_pages: int
     ) -> ScrapeResult:
-        errors: list[ScrapeError] = []
-
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
+        return self._build_playlist_result(html, url, max_results)
+
+    def _build_playlist_result(self, html: str, url: str, max_results: int) -> ScrapeResult:
+        errors: list[ScrapeError] = []
         tracks = self._extract_playlist_tracks(html, max_results)
 
         if not tracks:

--- a/src/pyscrappy/scrapers/stock.py
+++ b/src/pyscrappy/scrapers/stock.py
@@ -69,11 +69,35 @@ class StockScraper(BaseScraper):
         else:
             return self._scrape_quote(symbol)
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        symbol: str,
+        mode: str = "quote",
+        period: str = "1mo",
+        interval: str = "1d",
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        symbol = symbol.upper().strip()
+
+        if mode == "history":
+            url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range={period}&interval={interval}"
+            data = await self._fetch_json_async(url)
+            return self._build_history(symbol, url, data)
+        elif mode == "profile":
+            url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range=1d&interval=1d"
+            data = await self._fetch_json_async(url)
+            return self._build_profile(symbol, url, data)
+        else:
+            url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range=1d&interval=1d"
+            data = await self._fetch_json_async(url)
+            return self._build_quote(symbol, url, data)
+
     def _scrape_quote(self, symbol: str) -> ScrapeResult:
         """Fetch current quote data via the v8 finance endpoint."""
         url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range=1d&interval=1d"
-        data = self._fetch_json(url)
+        return self._build_quote(symbol, url, self._fetch_json(url))
 
+    def _build_quote(self, symbol: str, url: str, data: dict[str, Any]) -> ScrapeResult:
         result_data: list[dict[str, Any]] = []
         chart = data.get("chart", {}).get("result", [])
         if chart:
@@ -101,8 +125,9 @@ class StockScraper(BaseScraper):
     def _scrape_history(self, symbol: str, period: str, interval: str) -> ScrapeResult:
         """Fetch historical OHLCV data."""
         url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range={period}&interval={interval}"
-        data = self._fetch_json(url)
+        return self._build_history(symbol, url, self._fetch_json(url))
 
+    def _build_history(self, symbol: str, url: str, data: dict[str, Any]) -> ScrapeResult:
         result_data: list[dict[str, Any]] = []
         chart = data.get("chart", {}).get("result", [])
         if chart:
@@ -136,8 +161,9 @@ class StockScraper(BaseScraper):
     def _scrape_profile(self, symbol: str) -> ScrapeResult:
         """Fetch company profile data."""
         url = f"{_YF_BASE}/v8/finance/chart/{symbol}?range=1d&interval=1d"
-        data = self._fetch_json(url)
+        return self._build_profile(symbol, url, self._fetch_json(url))
 
+    def _build_profile(self, symbol: str, url: str, data: dict[str, Any]) -> ScrapeResult:
         result_data: list[dict[str, Any]] = []
         chart = data.get("chart", {}).get("result", [])
         if chart:
@@ -184,6 +210,25 @@ class StockScraper(BaseScraper):
                 self._crumb = crumb
                 self.logger.debug("Obtained Yahoo Finance crumb")
 
+    async def _ensure_crumb_async(self) -> None:
+        """Async counterpart to :meth:`_ensure_crumb`."""
+        if self._crumb:
+            return
+
+        resp = await self.async_http.get_raw("https://finance.yahoo.com/quote/AAPL/")
+        for name, value in resp.cookies.items():
+            self._cookies[name] = value
+
+        crumb_resp = await self.async_http.get_raw(
+            f"{_YF_BASE}/v1/test/getcrumb",
+            cookies=self._cookies,
+        )
+        if crumb_resp.status_code == 200:
+            crumb = crumb_resp.text.strip()
+            if crumb and len(crumb) < 50:
+                self._crumb = crumb
+                self.logger.debug("Obtained Yahoo Finance crumb")
+
     def _fetch_json(self, url: str) -> dict[str, Any]:
         """Fetch JSON from Yahoo Finance with crumb authentication and retry."""
         self._ensure_crumb()
@@ -214,6 +259,40 @@ class StockScraper(BaseScraper):
                 delay = backoff_delay(self.config, attempt + 1)
                 self.logger.warning("Rate-limited by Yahoo Finance, retrying in %.1fs", delay)
                 time.sleep(delay)
+                continue
+
+            raise NetworkError(f"Yahoo Finance returned HTTP {resp.status_code} for {url}")
+
+        raise NetworkError(f"Failed to fetch {url} after {self.config.max_retries} attempts")
+
+    async def _fetch_json_async(self, url: str) -> dict[str, Any]:
+        """Async counterpart to :meth:`_fetch_json`."""
+        import asyncio
+
+        await self._ensure_crumb_async()
+
+        for attempt in range(self.config.max_retries):
+            fetch_url = self._append_crumb(url)
+            resp = await self.async_http.get_raw(fetch_url, cookies=self._cookies)
+
+            if resp.status_code == 200:
+                try:
+                    return resp.json()
+                except Exception as exc:
+                    raise NetworkError(f"Failed to parse JSON from {url}") from exc
+
+            if resp.status_code in (401, 403):
+                self._crumb = None
+                self._cookies = {}
+                await self._ensure_crumb_async()
+                continue
+
+            if resp.status_code == 429:
+                from pyscrappy.core.http import backoff_delay
+
+                delay = backoff_delay(self.config, attempt + 1)
+                self.logger.warning("Rate-limited by Yahoo Finance, retrying in %.1fs", delay)
+                await asyncio.sleep(delay)
                 continue
 
             raise NetworkError(f"Yahoo Finance returned HTTP {resp.status_code} for {url}")

--- a/src/pyscrappy/scrapers/twitter.py
+++ b/src/pyscrappy/scrapers/twitter.py
@@ -62,19 +62,43 @@ class TwitterScraper(BaseScraper):
 
         return self._scrape_search(query, max_tweets, render_js, scroll_pages)
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str | None = None,
+        hashtag: str | None = None,
+        max_tweets: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if hashtag:
+            query = f"#{hashtag}"
+        if not query:
+            raise ValueError("Provide either query or hashtag")
+
+        url = self._search_url(query)
+        html = await self.async_http.get_html(url)
+        return self._build_search_result(html, url, max_tweets)
+
+    @staticmethod
+    def _search_url(query: str) -> str:
+        from urllib.parse import quote_plus
+
+        return f"https://x.com/search?q={quote_plus(query)}&src=typed_query&f=live"
+
     def _scrape_search(
         self, query: str, max_tweets: int, render_js: bool, scroll_pages: int
     ) -> ScrapeResult:
-        from urllib.parse import quote_plus
-
-        url = f"https://x.com/search?q={quote_plus(query)}&src=typed_query&f=live"
-        errors: list[ScrapeError] = []
+        url = self._search_url(query)
 
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
 
+        return self._build_search_result(html, url, max_tweets)
+
+    def _build_search_result(self, html: str, url: str, max_tweets: int) -> ScrapeResult:
+        """Shared post-fetch tweet extraction for the sync and async paths."""
+        errors: list[ScrapeError] = []
         tweets = self._extract_tweets(html, max_tweets)
 
         if not tweets:

--- a/src/pyscrappy/scrapers/ubereats.py
+++ b/src/pyscrappy/scrapers/ubereats.py
@@ -118,6 +118,66 @@ class UberEatsScraper(BaseScraper):
         except Exception as exc:
             return self._err(feed_url, str(exc))
 
+        return self._build_feed_result(payload, feed_url, place, city, max_results)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        city: str,
+        max_results: int = 50,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        lat, lng, place = await self._geocode_async(city)
+        if lat is None:
+            return self._err(_GEOCODE, f"City {city!r} not found.")
+
+        home = "https://www.ubereats.com/"
+        try:
+            await self.async_http.get_html(home)
+        except Exception as exc:
+            return self._err(home, str(exc))
+
+        loc = {
+            "address": {"title": place or city},
+            "latitude": lat,
+            "longitude": lng,
+            "type": "google_places",
+            "source": "manual_auto_complete",
+        }
+        self.async_http.set_cookie("uev2.loc", quote(json.dumps(loc)), domain=".ubereats.com")
+
+        feed_url = _FEED.format(locale=self.locale)
+        headers = {
+            "x-csrf-token": "x",
+            "content-type": "application/json",
+            "Origin": "https://www.ubereats.com",
+            "Referer": "https://www.ubereats.com/feed",
+            "x-uber-target-location-latitude": str(lat),
+            "x-uber-target-location-longitude": str(lng),
+        }
+        body = {
+            "cacheKey": _CACHE_KEY,
+            "feedSessionCount": {"announcementCount": 0, "announcementLabel": ""},
+            "userQuery": "",
+            "sortAndFilters": [],
+        }
+
+        try:
+            raw = await self.async_http.post_json(feed_url, headers=headers, json=body)
+            payload = json.loads(raw)
+        except Exception as exc:
+            return self._err(feed_url, str(exc))
+
+        return self._build_feed_result(payload, feed_url, place, city, max_results)
+
+    def _build_feed_result(
+        self,
+        payload: dict[str, Any],
+        feed_url: str,
+        place: str | None,
+        city: str,
+        max_results: int,
+    ) -> ScrapeResult:
+        """Shared feed-payload handling for the sync and async scrape paths."""
         data = payload.get("data", {})
         stores = [
             self._parse(fi["store"])
@@ -128,8 +188,6 @@ class UberEatsScraper(BaseScraper):
 
         errors: list[ScrapeError] = []
         if not stores:
-            # The feed tells us directly whether it serves this location, so we
-            # can distinguish "Uber Eats doesn't deliver here" from a parse issue.
             if data.get("isInServiceArea") is False:
                 message = (
                     f"Uber Eats does not deliver to {place or city!r} "
@@ -238,6 +296,18 @@ class UberEatsScraper(BaseScraper):
             results = json.loads(self.http.get_html(url)).get("results") or []
         except Exception:
             return None, None, None
+        return self._pick_geocode(results)
+
+    async def _geocode_async(self, city: str) -> tuple[float | None, float | None, str | None]:
+        url = f"{_GEOCODE}?name={quote_plus(city)}&count=1"
+        try:
+            results = json.loads(await self.async_http.get_html(url)).get("results") or []
+        except Exception:
+            return None, None, None
+        return self._pick_geocode(results)
+
+    @staticmethod
+    def _pick_geocode(results: list) -> tuple[float | None, float | None, str | None]:
         if not results:
             return None, None, None
         r = results[0]

--- a/src/pyscrappy/scrapers/weather.py
+++ b/src/pyscrappy/scrapers/weather.py
@@ -80,26 +80,66 @@ class WeatherScraper(BaseScraper):
             return self._err(geo_url, f"Location {location!r} not found.")
 
         place = results[0]
-        lat, lon = place.get("latitude"), place.get("longitude")
-        fc_url = (
-            f"{_FORECAST}?latitude={lat}&longitude={lon}"
-            "&current=temperature_2m,relative_humidity_2m,"
-            "wind_speed_10m,weather_code"
-        )
+        fc_url = self._forecast_url(place)
 
         try:
             fc = json.loads(self.http.get_html(fc_url))
         except Exception as exc:
             return self._err(fc_url, str(exc))
 
+        return self._build_result(place, geo_url, fc_url, fc)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        location: str,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        geo_url = f"{_GEOCODE}?name={quote_plus(location)}&count=1"
+
+        try:
+            geo = json.loads(await self.async_http.get_html(geo_url))
+        except Exception as exc:
+            return self._err(geo_url, str(exc))
+
+        results = geo.get("results") or []
+        if not results:
+            return self._err(geo_url, f"Location {location!r} not found.")
+
+        place = results[0]
+        fc_url = self._forecast_url(place)
+
+        try:
+            fc = json.loads(await self.async_http.get_html(fc_url))
+        except Exception as exc:
+            return self._err(fc_url, str(exc))
+
+        return self._build_result(place, geo_url, fc_url, fc)
+
+    @staticmethod
+    def _forecast_url(place: dict) -> str:
+        lat, lon = place.get("latitude"), place.get("longitude")
+        return (
+            f"{_FORECAST}?latitude={lat}&longitude={lon}"
+            "&current=temperature_2m,relative_humidity_2m,"
+            "wind_speed_10m,weather_code"
+        )
+
+    def _build_result(
+        self,
+        place: dict,
+        geo_url: str,
+        fc_url: str,
+        fc: dict,
+    ) -> ScrapeResult:
+        """Build the weather ScrapeResult from a forecast payload (shared)."""
         current = fc.get("current") or {}
         units = fc.get("current_units") or {}
         code = current.get("weather_code")
         record = {
             "location": place.get("name"),
             "country": place.get("country"),
-            "latitude": lat,
-            "longitude": lon,
+            "latitude": place.get("latitude"),
+            "longitude": place.get("longitude"),
             "time": current.get("time"),
             "temperature": current.get("temperature_2m"),
             "temperature_unit": units.get("temperature_2m"),

--- a/src/pyscrappy/scrapers/wikipedia.py
+++ b/src/pyscrappy/scrapers/wikipedia.py
@@ -59,6 +59,20 @@ class WikipediaScraper(BaseScraper):
         """
         url = self._base + quote(query.replace(" ", "_"))
         html = self.fetch_html(url)
+        return self._build_result(html, url, mode)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        mode: str = "full",
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        url = self._base + quote(query.replace(" ", "_"))
+        html = await self.fetch_html_async(url)
+        return self._build_result(html, url, mode)
+
+    def _build_result(self, html: str, url: str, mode: str) -> ScrapeResult:
+        """Shared HTML-parsing and dispatch for the sync and async scrape paths."""
         soup = self.parse_html(html)
 
         # Check for disambiguation or missing page

--- a/src/pyscrappy/scrapers/youtube.py
+++ b/src/pyscrappy/scrapers/youtube.py
@@ -60,9 +60,32 @@ class YouTubeScraper(BaseScraper):
             return self._scrape_search(query, max_results, render_js)
         raise ValueError("Provide either query or channel_url")
 
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str | None = None,
+        channel_url: str | None = None,
+        max_results: int = 20,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if channel_url:
+            return await self._scrape_channel_async(channel_url, max_results)
+        if query:
+            return await self._scrape_search_async(query, max_results)
+        raise ValueError("Provide either query or channel_url")
+
     def _scrape_search(self, query: str, max_results: int, render_js: bool) -> ScrapeResult:
         url = f"https://www.youtube.com/results?search_query={quote_plus(query)}"
         html = self.fetch_html(url, render_js=render_js)
+        videos = self._extract_from_html(html, max_results)
+
+        return ScrapeResult(
+            data=videos,
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+        )
+
+    async def _scrape_search_async(self, query: str, max_results: int) -> ScrapeResult:
+        url = f"https://www.youtube.com/results?search_query={quote_plus(query)}"
+        html = await self.fetch_html_async(url)
         videos = self._extract_from_html(html, max_results)
 
         return ScrapeResult(
@@ -82,6 +105,15 @@ class YouTubeScraper(BaseScraper):
         else:
             html = self.http.get_html(channel_url)
 
+        videos = self._extract_from_html(html, max_results)
+
+        return ScrapeResult(
+            data=videos,
+            metadata=ScrapeMetadata(source_urls=[channel_url], scraper=self.name),
+        )
+
+    async def _scrape_channel_async(self, channel_url: str, max_results: int) -> ScrapeResult:
+        html = await self.async_http.get_html(channel_url)
         videos = self._extract_from_html(html, max_results)
 
         return ScrapeResult(

--- a/src/pyscrappy/scrapers/zomato.py
+++ b/src/pyscrappy/scrapers/zomato.py
@@ -57,12 +57,34 @@ class ZomatoScraper(BaseScraper):
         else:
             url = f"https://www.zomato.com/{city_slug}/delivery"
 
-        errors: list[ScrapeError] = []
-
         if render_js:
             html = self.browser.get_html(url, wait_for="networkidle", scroll_pages=scroll_pages)
         else:
             html = self.http.get_html(url)
+
+        return self._build_result(html, url, max_results)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        city: str,
+        query: str | None = None,
+        max_results: int = 50,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        city_slug = city.lower().replace(" ", "-")
+
+        if query:
+            url = f"https://www.zomato.com/{city_slug}/search?q={quote_plus(query)}"
+        else:
+            url = f"https://www.zomato.com/{city_slug}/delivery"
+
+        html = await self.async_http.get_html(url)
+
+        return self._build_result(html, url, max_results)
+
+    def _build_result(self, html: str, url: str, max_results: int) -> ScrapeResult:
+        """Extract restaurants from fetched HTML and build the result."""
+        errors: list[ScrapeError] = []
 
         restaurants = self._extract_restaurants(html, max_results)
 

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -1,0 +1,114 @@
+"""Tests for the async HTTP client and scrape_async (issue #65).
+
+Mock the underlying httpx.AsyncClient so no real network is used. The sync API
+is exercised elsewhere; here we confirm the async path works and mirrors the
+sync behavior (retries, caching, header handling).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from pyscrappy import scrape_async
+from pyscrappy.core.async_http import AsyncHttpClient
+from pyscrappy.core.config import ScraperConfig
+from pyscrappy.core.http import HttpClient
+
+
+@pytest.fixture
+def anyio_backend():
+    # Run @pytest.mark.anyio tests on asyncio only (avoids needing trio).
+    return "asyncio"
+
+
+def _mock_async_client(config, responses):
+    """An AsyncHttpClient whose underlying client returns the given responses in
+    order (each a MagicMock httpx.Response)."""
+    client = AsyncHttpClient(config)
+    mock = MagicMock()
+    mock.get = AsyncMock(side_effect=responses)
+    mock.aclose = AsyncMock()  # aclose is awaited on cleanup
+    client._client = mock
+    return client, mock
+
+
+def _resp(status=200, text="<html>OK</html>"):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.text = text
+    r.headers = {}
+    r.raise_for_status = MagicMock()
+    return r
+
+
+@pytest.mark.anyio
+async def test_async_get_returns_response():
+    client, mock = _mock_async_client(ScraperConfig(rate_limit=0), [_resp(text="hi")])
+    resp = await client.get("https://example.com")
+    assert resp.text == "hi"
+    assert mock.get.call_count == 1
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_get_html_returns_text():
+    client, _ = _mock_async_client(ScraperConfig(rate_limit=0), [_resp(text="<h1>Hi</h1>")])
+    html = await client.get_html("https://example.com")
+    assert html == "<h1>Hi</h1>"
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_retries_on_server_error():
+    err = _resp(status=500)
+    err.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=err)
+    )
+    client, mock = _mock_async_client(
+        ScraperConfig(rate_limit=0, retry_delay=0, max_retries=2), [err, _resp(text="ok")]
+    )
+    resp = await client.get("https://example.com")
+    assert resp.text == "ok"
+    assert mock.get.call_count == 2  # retried once
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_shares_cache_with_sync_client():
+    # A value cached by the async client is visible to the sync client (shared store).
+    HttpClient.clear_cache()
+    cfg = ScraperConfig(rate_limit=0, cache_ttl=60)
+    client, mock = _mock_async_client(cfg, [_resp(text="cached")])
+    r1 = await client.get("https://example.com/x")
+    r2 = await client.get("https://example.com/x")  # served from cache, no 2nd call
+    assert r1.text == r2.text == "cached"
+    assert mock.get.call_count == 1
+    await client.aclose()
+    HttpClient.clear_cache()
+
+
+@pytest.mark.anyio
+async def test_async_config_headers_and_user_agent_applied():
+    cfg = ScraperConfig(rate_limit=0, user_agent="Custom/1.0", headers={"X-Test": "1"})
+    client, mock = _mock_async_client(cfg, [_resp()])
+    await client.get("https://example.com")
+    sent = mock.get.call_args.kwargs["headers"]
+    assert sent["User-Agent"] == "Custom/1.0"
+    assert sent["X-Test"] == "1"
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_scrape_async_extracts_page_data(monkeypatch):
+    # Stub the async fetch so scrape_async parses a known HTML doc without network.
+    html = "<html><head><title>T</title></head><body><a href='/p'>link</a></body></html>"
+
+    async def fake_get_html(self, url, **kwargs):
+        return html
+
+    monkeypatch.setattr(AsyncHttpClient, "get_html", fake_get_html)
+    result = await scrape_async("https://example.com")
+    assert result.metadata.scraper == "generic"
+    assert result.data  # extracted a page
+    assert result.metadata.source_urls == ["https://example.com"]

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -250,6 +250,35 @@ class TestHttpClientUserAgentRotation:
         # At least 2 different agents should be picked in 50 tries
         assert len(picked) >= 2
 
+    def test_config_user_agent_overrides_rotation(self):
+        # A single configured user_agent wins over user_agents rotation.
+        config = ScraperConfig(user_agent="Custom/9.9", user_agents=["A", "B", "C"])
+        client = HttpClient(config)
+        assert {client._pick_ua() for _ in range(20)} == {"Custom/9.9"}
+
+
+class TestHttpClientCustomHeaders:
+    def test_config_headers_are_sent(self):
+        config = ScraperConfig(headers={"Accept-Language": "en-US", "X-Test": "1"})
+        client = HttpClient(config)
+        merged = client._merge_headers({})
+        assert merged["Accept-Language"] == "en-US"
+        assert merged["X-Test"] == "1"
+        assert "User-Agent" in merged
+
+    def test_per_call_headers_override_config(self):
+        config = ScraperConfig(headers={"X-Test": "config"})
+        client = HttpClient(config)
+        merged = client._merge_headers({"X-Test": "call"})
+        assert merged["X-Test"] == "call"  # per-call wins
+
+    def test_config_user_agent_flows_through_merge(self):
+        config = ScraperConfig(user_agent="Custom/1.0", headers={"X": "y"})
+        client = HttpClient(config)
+        merged = client._merge_headers({})
+        assert merged["User-Agent"] == "Custom/1.0"
+        assert merged["X"] == "y"
+
 
 class TestHttpClientBuildClient:
     def test_build_client_with_proxy(self):

--- a/tests/test_scrapers/test_async_scrapers.py
+++ b/tests/test_scrapers/test_async_scrapers.py
@@ -1,0 +1,212 @@
+"""Async-path tests for the site scrapers (issue #65, native async).
+
+Every scraper exposes a native ``scrape_async`` that mirrors ``scrape`` but fetches
+over a non-blocking ``AsyncHttpClient``, reusing the same parsing/extraction. These
+tests inject a mocked ``_async_http`` (so no real network is used) and assert that
+the async path produces the same structured data as the sync path — covering one
+scraper per fetch pattern: plain JSON, ID-resolution + JSON, paginated HTML, a
+browser scraper's plain-HTTP fallback, ``post_json`` + ``set_cookie``, and the
+Yahoo crumb/cookie flow.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from pyscrappy.core.config import ScraperConfig
+from pyscrappy.core.http import HttpClient
+from pyscrappy.scrapers.amazon import AmazonScraper
+from pyscrappy.scrapers.crypto import CryptoScraper
+from pyscrappy.scrapers.stock import StockScraper
+from pyscrappy.scrapers.twitter import TwitterScraper
+from pyscrappy.scrapers.ubereats import UberEatsScraper
+
+
+@pytest.fixture
+def anyio_backend():
+    # Run @pytest.mark.anyio tests on asyncio only (avoids needing trio).
+    return "asyncio"
+
+
+def _mock_async_http(scraper, *html_responses):
+    """Inject a mocked async client whose get_html returns the given strings in order."""
+    mock = MagicMock()
+    mock.get_html = AsyncMock(side_effect=list(html_responses))
+    mock.aclose = AsyncMock()
+    scraper._async_http = mock
+    return scraper, mock
+
+
+@pytest.mark.anyio
+async def test_crypto_scrape_async_top_coins():
+    payload = json.dumps(
+        [
+            {
+                "id": "bitcoin",
+                "name": "Bitcoin",
+                "symbol": "btc",
+                "current_price": 64000,
+                "market_cap": 1200000000000,
+                "market_cap_rank": 1,
+                "price_change_percentage_24h": 1.5,
+            }
+        ]
+    )
+    s, _ = _mock_async_http(CryptoScraper(), payload)
+    r = await s.scrape_async(max_results=1)
+    assert len(r.data) == 1
+    c = r.data[0]
+    # Same extraction as the sync path.
+    assert c["name"] == "Bitcoin"
+    assert c["symbol"] == "BTC"
+    assert c["price"] == 64000
+    assert c["currency"] == "USD"
+    assert c["change_24h_pct"] == 1.5
+
+
+@pytest.mark.anyio
+async def test_crypto_scrape_async_resolves_ids():
+    # query -> a search fetch (id resolution) -> a markets fetch, both awaited.
+    search = json.dumps({"coins": [{"id": "ethereum"}]})
+    markets = json.dumps(
+        [{"id": "ethereum", "name": "Ethereum", "symbol": "eth", "current_price": 1800}]
+    )
+    s, mock = _mock_async_http(CryptoScraper(), search, markets)
+    r = await s.scrape_async(query="eth")
+    assert r.data[0]["name"] == "Ethereum"
+    # The second (markets) fetch carries the resolved id.
+    assert "ids=ethereum" in mock.get_html.call_args_list[-1][0][0]
+
+
+@pytest.mark.anyio
+async def test_amazon_scrape_async_paginates():
+    page1 = """
+    <html><body>
+      <div data-component-type="s-search-result" data-asin="A1">
+        <h2><span>Widget One</span></h2>
+        <span class="a-price"><span class="a-offscreen">$9.99</span></span>
+      </div>
+    </body></html>
+    """
+    s, mock = _mock_async_http(AmazonScraper(), page1)
+    r = await s.scrape_async(query="widget", max_pages=1)
+    assert r.data, "expected at least one product from the async paginated fetch"
+    assert any("Widget One" in (d.get("title") or "") for d in r.data)
+    # Fetched over the async client with the scraper's headers.
+    assert mock.get_html.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_twitter_scrape_async_falls_back_to_plain_http():
+    # Browser scraper: async has no render_js and must fetch over plain HTTP.
+    # With non-tweet HTML, it degrades to the documented "use render_js=True" error
+    # rather than raising — same behavior as the sync render_js=False path.
+    s, mock = _mock_async_http(TwitterScraper(), "<html><body>nothing here</body></html>")
+    r = await s.scrape_async(query="python")
+    assert mock.get_html.await_count == 1
+    # No browser was ever created for the async path.
+    assert s._browser is None
+    # Either no tweets with a guiding error, or empty data — never a crash.
+    assert r.data == [] or r.metadata.scraper == "twitter"
+
+
+@pytest.mark.anyio
+async def test_ubereats_scrape_async_uses_post_json_and_set_cookie():
+    geocode = json.dumps({"results": [{"latitude": 51.5, "longitude": -0.12, "name": "London"}]})
+    feed = json.dumps(
+        {
+            "data": {
+                "feedItems": [
+                    {
+                        "type": "REGULAR_STORE",
+                        "store": {"title": {"text": "Testaurant"}, "storeUuid": "u1"},
+                    }
+                ]
+            }
+        }
+    )
+    s = UberEatsScraper()
+    mock = MagicMock()
+    mock.get_html = AsyncMock(return_value=geocode)  # geocode + homepage share get_html
+    mock.get_html.side_effect = [geocode, "<html>home</html>"]
+    mock.post_json = AsyncMock(return_value=feed)
+    mock.set_cookie = MagicMock()
+    mock.aclose = AsyncMock()
+    s._async_http = mock
+
+    r = await s.scrape_async(city="London")
+    assert [d["name"] for d in r.data] == ["Testaurant"]
+    # The location cookie was set (sync call, no await) and the feed was POSTed.
+    assert mock.set_cookie.called
+    assert mock.post_json.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_stock_scrape_async_quote_with_crumb():
+    quote_json = {
+        "chart": {
+            "result": [
+                {
+                    "meta": {
+                        "symbol": "AAPL",
+                        "currency": "USD",
+                        "exchangeName": "NMS",
+                        "regularMarketPrice": 175.5,
+                        "regularMarketVolume": 50000000,
+                    }
+                }
+            ]
+        }
+    }
+
+    def _raw(*_a, **_k):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = "crumb123"
+        resp.cookies = {}
+        resp.json.return_value = quote_json
+        return resp
+
+    s = StockScraper()
+    mock = MagicMock()
+    mock.get_raw = AsyncMock(side_effect=_raw)
+    mock.aclose = AsyncMock()
+    s._async_http = mock
+
+    r = await s.scrape_async(symbol="aapl", mode="quote")
+    assert len(r.data) == 1
+    assert r.data[0]["symbol"] == "AAPL"
+    assert r.data[0]["price"] == 175.5
+    # symbol was uppercased before the request (same as sync path)
+    assert "AAPL" in mock.get_raw.call_args_list[-1][0][0]
+
+
+@pytest.mark.anyio
+async def test_scrape_async_shares_cache_with_sync_client():
+    # A response cached during an async scrape is visible to the sync HttpClient
+    # (both use the same process-wide store), proving the shared cache wiring.
+    HttpClient.clear_cache()
+    from pyscrappy.core.async_http import AsyncHttpClient
+
+    cfg = ScraperConfig(rate_limit=0, cache_ttl=60)
+    client = AsyncHttpClient(cfg)
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.text = "cached-body"
+    resp.headers = {}
+    resp.raise_for_status = MagicMock()
+    inner = MagicMock()
+    inner.get = AsyncMock(return_value=resp)
+    inner.aclose = AsyncMock()
+    client._client = inner
+
+    await client.get("https://example.com/shared")
+    # Now a sync client with the same config sees it without a network call.
+    with HttpClient(cfg) as sync_client:
+        cached = sync_client._cache_get(sync_client._cache_key("https://example.com/shared", None))
+    assert cached is not None
+    assert cached.text == "cached-body"
+    await client.aclose()
+    HttpClient.clear_cache()


### PR DESCRIPTION
## Summary
Adds a native async API to **every** PyScrappy scraper. Alongside the existing
synchronous `scrape()`, all 24 scrapers (the generic scraper + 23 site-specific
ones) now expose an `async def scrape_async()` backed by a real
`httpx.AsyncClient` — no thread pools, genuine concurrency for asyncio callers
(FastAPI services, async agents, `asyncio.gather` fan-out).

Closes #65. Also lands #66 (config `user_agent` / `headers` overrides).

## What's new
- **`AsyncHttpClient`** — asyncio counterpart to `HttpClient`, mirroring its
  retries, rate-limiting, User-Agent/header handling, and **sharing the same
  process-wide response cache** (a value fetched by either client is visible to
  the other). Supports `get` / `get_raw` / `get_html` / `post_json` / `set_cookie`.
- **`BaseScraper` async layer** — `async_http`, `fetch_html_async`,
  `fetch_and_parse_async`, `aclose`, and `async with` support. A default
  `scrape_async` raises `NotImplementedError` so an unported scraper is explicit,
  never silently blocking the event loop.
- **`scrape_async()` on all 24 scrapers** — mirrors each sync `scrape()` but
  awaits its fetches and **reuses the exact same parsing/extraction** (no
  duplicated logic). Includes the tricky paths: Yahoo Finance's crumb/cookie flow
  (stock), `post_json` + location cookie (ubereats), multi-page pagination
  (amazon/newegg/linkedin/image_search), and id-resolution (crypto/imdb).
- **Top-level `scrape_async(url)`** convenience function.

## Behavior notes
- **Sync API is unchanged.** Where shared post-fetch logic was extracted into a
  helper so both paths could use it, the sync output is byte-identical — verified
  by the full existing test suite passing.
- **JS rendering is sync-only.** The browser backend has no async equivalent, so
  `scrape_async` always fetches over plain HTTP. For JS-heavy scrapers
  (twitter/spotify/soundcloud/zomato, etc.) the async path degrades to the same
  documented "use render_js=True" guidance as the sync no-render path — it never
  crashes and never touches the browser.

## Testing
- **351 passed, 2 skipped** (skips are MCP tests needing `fastmcp`, unrelated).
- 7 new async tests cover each fetch pattern: plain JSON, id-resolution+JSON,
  paginated HTML, browser→plain-HTTP fallback, `post_json`+`set_cookie`, and the
  crumb flow, plus shared-cache-with-sync-client.
- **Live-verified**: real async fetch of example.com, a site-specific async scrape
  (Wikipedia via `async with`), and 3 scrapers running concurrently over 3 domains
  via `asyncio.gather`.

## Usage
```python
import asyncio
from pyscrappy import scrape_async, WikipediaScraper

async def main():
    result = await scrape_async("https://example.com")

    async with WikipediaScraper() as ws:
        r = await ws.scrape_async(query="Python (programming language)", mode="summary")

asyncio.run(main())