### PR TITLE
feat: add to_csv() and save(path) to ScrapeResult

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -158,7 +158,11 @@ class ScrapeResult:
                         seen.add(key)
                         fieldnames.append(key)
             buf = io.StringIO()
-            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            # lineterminator="\n" so the stdlib fallback matches pandas' "\n"
+            # output (DictWriter defaults to "\r\n"); output is identical either way.
+            writer = csv.DictWriter(
+                buf, fieldnames=fieldnames, extrasaction="ignore", lineterminator="\n"
+            )
             writer.writeheader()
             for row in self.data:
                 writer.writerow({k: row.get(k, "") for k in fieldnames})

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -138,14 +138,16 @@ class ScrapeResult:
         Nested / non-scalar cell values are stringified. Falls back to the
         stdlib ``csv`` module when pandas is not installed.
         """
+        # Empty data is "" in both paths (pandas' DataFrame([]).to_csv() would
+        # otherwise return a lone newline), so guard before either branch.
+        if not self.data:
+            return ""
         try:
             return self.to_dataframe().to_csv(index=False)
         except ImportError:
             import csv
             import io
 
-            if not self.data:
-                return ""
             # Union of keys preserves column order from the first row, then
             # appends any later keys in encounter order.
             fieldnames: list[str] = []
@@ -179,7 +181,6 @@ class ScrapeResult:
             content = self.to_markdown()
         else:
             raise ValueError(
-                f"Unsupported extension {suffix!r} for save(); "
-                "use .json, .csv, or .md"
+                f"Unsupported extension {suffix!r} for save(); use .json, .csv, or .md"
             )
         _Path(path).write_text(content, encoding="utf-8")

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -32,7 +32,8 @@ class ScrapeResult:
 
     ``data`` is always a list of dicts — one dict per scraped item.
     Call ``.to_dataframe()`` for a pandas DataFrame, ``.to_json()`` for
-    JSON, or ``.to_markdown()`` for clean, LLM-ready Markdown.
+    JSON, ``.to_csv()`` for CSV text, ``.to_markdown()`` for clean,
+    LLM-ready Markdown, or ``.save(path)`` to write by file extension.
     """
 
     data: list[dict[str, Any]]
@@ -129,3 +130,56 @@ class ScrapeResult:
             indent=indent,
             default=str,
         )
+
+    def to_csv(self) -> str:
+        """Return ``data`` as CSV text.
+
+        Uses pandas when available (``to_dataframe().to_csv(index=False)``).
+        Nested / non-scalar cell values are stringified. Falls back to the
+        stdlib ``csv`` module when pandas is not installed.
+        """
+        try:
+            return self.to_dataframe().to_csv(index=False)
+        except ImportError:
+            import csv
+            import io
+
+            if not self.data:
+                return ""
+            # Union of keys preserves column order from the first row, then
+            # appends any later keys in encounter order.
+            fieldnames: list[str] = []
+            seen: set[str] = set()
+            for row in self.data:
+                for key in row:
+                    if key not in seen:
+                        seen.add(key)
+                        fieldnames.append(key)
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in self.data:
+                writer.writerow({k: row.get(k, "") for k in fieldnames})
+            return buf.getvalue()
+
+    def save(self, path: str) -> None:
+        """Write the result to ``path``, choosing format from the extension.
+
+        Supported extensions: ``.json`` → :meth:`to_json`, ``.csv`` →
+        :meth:`to_csv`, ``.md`` → :meth:`to_markdown`.
+        """
+        from pathlib import Path as _Path
+
+        suffix = _Path(path).suffix.lower()
+        if suffix == ".json":
+            content = self.to_json()
+        elif suffix == ".csv":
+            content = self.to_csv()
+        elif suffix == ".md":
+            content = self.to_markdown()
+        else:
+            raise ValueError(
+                f"Unsupported extension {suffix!r} for save(); "
+                "use .json, .csv, or .md"
+            )
+        _Path(path).write_text(content, encoding="utf-8")

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -160,3 +160,31 @@ class TestScrapeResult:
         result = ScrapeResult(data=[], errors=errors)
         assert len(result.errors) == 2
         assert result.errors[1].selector == ".x"
+
+    def test_to_csv(self):
+        result = ScrapeResult(data=[{"name": "a", "price": 1}, {"name": "b", "price": 2}])
+        csv_text = result.to_csv()
+        assert "name,price" in csv_text.replace(" ", "")
+        assert "a,1" in csv_text.replace(" ", "")
+        assert "b,2" in csv_text.replace(" ", "")
+
+    def test_to_csv_empty(self):
+        assert ScrapeResult(data=[]).to_csv() == ""
+
+    def test_save_json_csv_md(self, tmp_path):
+        result = ScrapeResult(data=[{"title": "x", "n": 1}])
+        json_path = tmp_path / "out.json"
+        csv_path = tmp_path / "out.csv"
+        md_path = tmp_path / "out.md"
+        result.save(str(json_path))
+        result.save(str(csv_path))
+        result.save(str(md_path))
+        assert json.loads(json_path.read_text())["data"] == [{"title": "x", "n": 1}]
+        assert "title,n" in csv_path.read_text().replace(" ", "")
+        assert "**title:** x" in md_path.read_text()
+
+    def test_save_unsupported_extension(self, tmp_path):
+        result = ScrapeResult(data=[{"a": 1}])
+        with pytest.raises(ValueError, match="Unsupported extension"):
+            result.save(str(tmp_path / "out.txt"))
+

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -187,4 +187,3 @@ class TestScrapeResult:
         result = ScrapeResult(data=[{"a": 1}])
         with pytest.raises(ValueError, match="Unsupported extension"):
             result.save(str(tmp_path / "out.txt"))
-

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -171,6 +171,23 @@ class TestScrapeResult:
     def test_to_csv_empty(self):
         assert ScrapeResult(data=[]).to_csv() == ""
 
+    def test_to_csv_stdlib_fallback_without_pandas(self, monkeypatch):
+        """Force the stdlib csv path (pandas unavailable) and confirm it produces
+        the same header/rows and "\n" line endings as the pandas path."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "pandas":
+                raise ImportError("no pandas")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = ScrapeResult(data=[{"name": "a", "price": 1}, {"name": "b", "price": 2}])
+        csv_text = result.to_csv()
+        assert csv_text == "name,price\na,1\nb,2\n"  # "\n", not "\r\n"
+
     def test_save_json_csv_md(self, tmp_path):
         result = ScrapeResult(data=[{"title": "x", "n": 1}])
         json_path = tmp_path / "out.json"


### PR DESCRIPTION
## Summary
`ScrapeResult` could export DataFrame/JSON/Markdown but not CSV, and had no one-call file write helper.

- Add `to_csv()` (pandas path when available, stdlib `csv` fallback)
- Add `save(path)` that writes `.json` / `.csv` / `.md` by extension and raises a clear error otherwise
- Cover both helpers in unit tests

Fixes #72