### PR TITLE
feat(core): add opt-in robots.txt and Crawl-delay politeness support (fixes #73)

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -47,7 +47,10 @@ class AsyncHttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.AsyncClient | None = None
         self._last_request_time: dict[str, float] = {}
-        self._robots_cache: dict[str, tuple[Any, float | None]] = {}
+        # Per-client cache of RobotFileParser keyed by host (per #73). Crawl-delay
+        # is computed per request from the parser, so the UA-specific value stays
+        # correct even when the client rotates User-Agents.
+        self._robots_cache: dict[str, Any] = {}
 
     async def __aenter__(self) -> AsyncHttpClient:
         self._client = self._build_client()
@@ -87,6 +90,7 @@ class AsyncHttpClient:
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_async
+
             crawl_delay = await check_robots_async(self, url, user_agent=user_agent)
 
         await self._rate_limit(url, min_delay=crawl_delay)
@@ -196,7 +200,9 @@ class AsyncHttpClient:
             return self.config.user_agent
         return random.choice(self.config.user_agents)
 
-    def _merge_headers(self, extra: dict[str, str], user_agent: str | None = None) -> dict[str, str]:
+    def _merge_headers(
+        self, extra: dict[str, str], user_agent: str | None = None
+    ) -> dict[str, str]:
         ua = user_agent or self._pick_ua()
         return {**self.config.headers, "User-Agent": ua, **extra}
 
@@ -228,9 +234,6 @@ class AsyncHttpClient:
         if self.config.cache_ttl > 0:
             with _CACHE_LOCK:
                 _SHARED_CACHE[key] = (time.monotonic(), resp)
-
-    def _get_current_user_agent(self) -> str:
-        return self._pick_ua()
 
     async def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         domain = urlparse(url).netloc

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -47,6 +47,7 @@ class AsyncHttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.AsyncClient | None = None
         self._last_request_time: dict[str, float] = {}
+        self._robots_cache: dict[str, tuple[Any, float | None]] = {}
 
     async def __aenter__(self) -> AsyncHttpClient:
         self._client = self._build_client()
@@ -62,7 +63,7 @@ class AsyncHttpClient:
 
     # -- public API --
 
-    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+    async def get(self, url: str, skip_robots_check: bool = False, **kwargs: Any) -> httpx.Response:
         """GET with retries, rate-limiting, and optional caching (see HttpClient.get)."""
         cache_key = self._cache_key(url, kwargs.get("params"))
         cached = self._cache_get(cache_key)
@@ -79,19 +80,21 @@ class AsyncHttpClient:
             url = endpoint
             kwargs["params"] = api_params
 
+        extra_headers = kwargs.pop("headers", None) or {}
+        user_agent = extra_headers.get("User-Agent") or self._pick_ua()
+
         client = self._ensure_client()
         crawl_delay: float | None = None
-        if self.config.obey_robots:
+        if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_async
-            crawl_delay = await check_robots_async(self, url)
+            crawl_delay = await check_robots_async(self, url, user_agent=user_agent)
 
         await self._rate_limit(url, min_delay=crawl_delay)
-        extra_headers = kwargs.pop("headers", None) or {}
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
-                headers = self._merge_headers(extra_headers)
+                headers = self._merge_headers(extra_headers, user_agent=user_agent)
                 resp = await client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
                 if resp.status_code == 429:
@@ -193,8 +196,9 @@ class AsyncHttpClient:
             return self.config.user_agent
         return random.choice(self.config.user_agents)
 
-    def _merge_headers(self, extra: dict[str, str]) -> dict[str, str]:
-        return {**self.config.headers, "User-Agent": self._pick_ua(), **extra}
+    def _merge_headers(self, extra: dict[str, str], user_agent: str | None = None) -> dict[str, str]:
+        ua = user_agent or self._pick_ua()
+        return {**self.config.headers, "User-Agent": ua, **extra}
 
     # Cache is shared with the sync client (same module-level store + lock).
 

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -80,7 +80,12 @@ class AsyncHttpClient:
             kwargs["params"] = api_params
 
         client = self._ensure_client()
-        await self._rate_limit(url)
+        crawl_delay: float | None = None
+        if self.config.obey_robots:
+            from pyscrappy.core.robots import check_robots_async
+            crawl_delay = await check_robots_async(self, url)
+
+        await self._rate_limit(url, min_delay=crawl_delay)
         extra_headers = kwargs.pop("headers", None) or {}
 
         last_exc: Exception | None = None
@@ -220,11 +225,17 @@ class AsyncHttpClient:
             with _CACHE_LOCK:
                 _SHARED_CACHE[key] = (time.monotonic(), resp)
 
-    async def _rate_limit(self, url: str) -> None:
+    def _get_current_user_agent(self) -> str:
+        return self._pick_ua()
+
+    async def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         domain = urlparse(url).netloc
         now = time.monotonic()
         last = self._last_request_time.get(domain, 0.0)
-        wait = self.config.rate_limit - (now - last)
+        delay_target = self.config.rate_limit
+        if min_delay is not None:
+            delay_target = max(delay_target, min_delay)
+        wait = delay_target - (now - last)
         if wait > 0:
             logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
             await asyncio.sleep(wait)

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -32,6 +32,8 @@ class ScraperConfig:
         backoff_max: Upper bound (seconds) on a single retry delay, so backoff
             can't grow without limit. ``None`` (the default) means no cap.
         rate_limit: Minimum seconds between requests to the same domain.
+        obey_robots: Whether to respect host robots.txt rules and Crawl-delay.
+            ``False`` (the default) does not fetch robots.txt at all.
         user_agent: A single User-Agent string to use for every request. When set,
             it overrides ``user_agents`` rotation (some sites block the default
             UAs or require a specific one). ``None`` (the default) rotates through
@@ -64,6 +66,7 @@ class ScraperConfig:
     backoff_factor: float = 2.0
     backoff_max: float | None = None
     rate_limit: float = 1.0
+    obey_robots: bool = False
     user_agent: str | None = None
     headers: dict[str, str] = field(default_factory=dict)
     user_agents: list[str] = field(default_factory=lambda: list(_DEFAULT_USER_AGENTS))

--- a/src/pyscrappy/core/exceptions.py
+++ b/src/pyscrappy/core/exceptions.py
@@ -13,6 +13,10 @@ class RateLimitError(NetworkError):
     """Raised when the target site returns a rate-limit response (429)."""
 
 
+class RobotsDisallowedError(PyScrappyError):
+    """Raised when a URL is disallowed by the host's robots.txt."""
+
+
 class ScraperTimeoutError(PyScrappyError):
     """Raised when a scraping operation exceeds the configured timeout."""
 

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -55,6 +55,7 @@ class HttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.Client | None = None
         self._last_request_time: dict[str, float] = {}
+        self._robots_cache: dict[str, tuple[Any, float | None]] = {}
 
     # -- context manager --
 
@@ -72,7 +73,7 @@ class HttpClient:
 
     # -- public API --
 
-    def get(self, url: str, **kwargs: Any) -> httpx.Response:
+    def get(self, url: str, skip_robots_check: bool = False, **kwargs: Any) -> httpx.Response:
         """Perform a GET request with retries and rate-limiting.
 
         When ``config.cache_ttl > 0``, a successful response is cached in memory
@@ -97,23 +98,21 @@ class HttpClient:
             url = endpoint
             kwargs["params"] = api_params
 
+        extra_headers = kwargs.pop("headers", None) or {}
+        user_agent = extra_headers.get("User-Agent") or self._pick_ua()
+
         client = self._ensure_client()
         crawl_delay: float | None = None
-        if self.config.obey_robots:
+        if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_sync
-            crawl_delay = check_robots_sync(self, url)
+            crawl_delay = check_robots_sync(self, url, user_agent=user_agent)
 
         self._rate_limit(url, min_delay=crawl_delay)
-
-        # Merge any caller-supplied headers on top of a rotated User-Agent,
-        # so scrapers can add site-specific headers (e.g. Referer) without
-        # colliding with the headers kwarg httpx expects.
-        extra_headers = kwargs.pop("headers", None) or {}
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
-                headers = self._merge_headers(extra_headers)
+                headers = self._merge_headers(extra_headers, user_agent=user_agent)
                 resp = client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
                 if resp.status_code == 429:
@@ -230,10 +229,11 @@ class HttpClient:
             return self.config.user_agent
         return random.choice(self.config.user_agents)
 
-    def _merge_headers(self, extra: dict[str, str]) -> dict[str, str]:
+    def _merge_headers(self, extra: dict[str, str], user_agent: str | None = None) -> dict[str, str]:
         """Build the request headers: config.headers (lowest priority), then the
         chosen User-Agent, then per-call headers (highest priority)."""
-        return {**self.config.headers, "User-Agent": self._pick_ua(), **extra}
+        ua = user_agent or self._pick_ua()
+        return {**self.config.headers, "User-Agent": ua, **extra}
 
     def _backoff_delay(self, attempt: int) -> float:
         """Retry delay for this client's config (see module-level backoff_delay)."""

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -55,7 +55,10 @@ class HttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.Client | None = None
         self._last_request_time: dict[str, float] = {}
-        self._robots_cache: dict[str, tuple[Any, float | None]] = {}
+        # Per-client cache of RobotFileParser keyed by host (per #73). Crawl-delay
+        # is computed per request from the parser, so the UA-specific value stays
+        # correct even when the client rotates User-Agents.
+        self._robots_cache: dict[str, Any] = {}
 
     # -- context manager --
 
@@ -105,6 +108,7 @@ class HttpClient:
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_sync
+
             crawl_delay = check_robots_sync(self, url, user_agent=user_agent)
 
         self._rate_limit(url, min_delay=crawl_delay)
@@ -229,7 +233,9 @@ class HttpClient:
             return self.config.user_agent
         return random.choice(self.config.user_agents)
 
-    def _merge_headers(self, extra: dict[str, str], user_agent: str | None = None) -> dict[str, str]:
+    def _merge_headers(
+        self, extra: dict[str, str], user_agent: str | None = None
+    ) -> dict[str, str]:
         """Build the request headers: config.headers (lowest priority), then the
         chosen User-Agent, then per-call headers (highest priority)."""
         ua = user_agent or self._pick_ua()
@@ -274,9 +280,6 @@ class HttpClient:
         """Empty the process-wide response cache."""
         with _CACHE_LOCK:
             _SHARED_CACHE.clear()
-
-    def _get_current_user_agent(self) -> str:
-        return self._pick_ua()
 
     def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         from urllib.parse import urlparse

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -98,7 +98,12 @@ class HttpClient:
             kwargs["params"] = api_params
 
         client = self._ensure_client()
-        self._rate_limit(url)
+        crawl_delay: float | None = None
+        if self.config.obey_robots:
+            from pyscrappy.core.robots import check_robots_sync
+            crawl_delay = check_robots_sync(self, url)
+
+        self._rate_limit(url, min_delay=crawl_delay)
 
         # Merge any caller-supplied headers on top of a rotated User-Agent,
         # so scrapers can add site-specific headers (e.g. Referer) without
@@ -270,13 +275,19 @@ class HttpClient:
         with _CACHE_LOCK:
             _SHARED_CACHE.clear()
 
-    def _rate_limit(self, url: str) -> None:
+    def _get_current_user_agent(self) -> str:
+        return self._pick_ua()
+
+    def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         from urllib.parse import urlparse
 
         domain = urlparse(url).netloc
         now = time.monotonic()
         last = self._last_request_time.get(domain, 0.0)
-        wait = self.config.rate_limit - (now - last)
+        delay_target = self.config.rate_limit
+        if min_delay is not None:
+            delay_target = max(delay_target, min_delay)
+        wait = delay_target - (now - last)
         if wait > 0:
             logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
             time.sleep(wait)

--- a/src/pyscrappy/core/robots.py
+++ b/src/pyscrappy/core/robots.py
@@ -25,105 +25,100 @@ def get_host_and_robots_url(url: str) -> tuple[str, str]:
     return netloc.lower(), robots_url
 
 
-def _parse_robots(text: str, user_agent: str) -> tuple[RobotFileParser, float | None]:
-    """Parse robots.txt content and extract crawl_delay for the user_agent."""
+def _parse_robots(text: str) -> RobotFileParser:
+    """Parse robots.txt content into a RobotFileParser."""
     parser = RobotFileParser()
     parser.parse(text.splitlines())
+    return parser
 
-    delay: float | None = None
+
+def _crawl_delay_for(parser: RobotFileParser, user_agent: str) -> float | None:
+    """Crawl-delay this parser advertises for ``user_agent`` (None if absent).
+
+    Computed per request rather than cached as a single value, since robots.txt
+    can set different Crawl-delay values for different User-Agent groups and the
+    client may rotate UAs.
+    """
     try:
         raw_delay = parser.crawl_delay(user_agent)
-        if raw_delay is not None:
-            delay = float(raw_delay)
+        return float(raw_delay) if raw_delay is not None else None
     except Exception:
-        delay = None
-
-    return parser, delay
+        return None
 
 
 def check_robots_sync(client: HttpClient, url: str, user_agent: str) -> float | None:
     """Sync check: fetch and parse robots.txt for URL host if needed, evaluate
-    permissions, and return any Crawl-delay using per-client cache.
+    permissions, and return the Crawl-delay for ``user_agent`` using the per-client
+    cache.
 
     Raises:
         RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
     """
     host, robots_url = get_host_and_robots_url(url)
 
-    if host in client._robots_cache:
-        parser, delay = client._robots_cache[host]
-    else:
-        parser, delay = _fetch_and_cache_sync(client, host, robots_url, user_agent)
+    parser = client._robots_cache.get(host)
+    if parser is None:
+        parser = _fetch_and_cache_sync(client, host, robots_url, user_agent)
 
     if not parser.can_fetch(user_agent, url):
         raise RobotsDisallowedError(
             f"URL '{url}' is disallowed for user-agent '{user_agent}' by robots.txt at {robots_url}"
         )
 
-    return delay
+    return _crawl_delay_for(parser, user_agent)
 
 
 def _fetch_and_cache_sync(
     client: HttpClient, host: str, robots_url: str, user_agent: str
-) -> tuple[RobotFileParser, float | None]:
-    """Fetch robots.txt via sync client (skipping robots check recursively) and store in per-client cache."""
-    parser = RobotFileParser()
-
+) -> RobotFileParser:
+    """Fetch robots.txt via the sync client (skipping the robots check recursively,
+    and sending the same User-Agent being enforced) and cache the parser per-client."""
     try:
-        resp = client.get(robots_url, skip_robots_check=True)
-        if resp.status_code == 200:
-            parser, delay = _parse_robots(resp.text, user_agent)
-        else:
-            parser.parse([])
-            delay = None
+        resp = client.get(robots_url, skip_robots_check=True, headers={"User-Agent": user_agent})
+        parser = _parse_robots(resp.text) if resp.status_code == 200 else _parse_robots("")
     except Exception as exc:
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
-        parser.parse([])
-        delay = None
+        parser = _parse_robots("")
 
-    client._robots_cache[host] = (parser, delay)
-    return parser, delay
+    client._robots_cache[host] = parser
+    return parser
 
 
 async def check_robots_async(client: AsyncHttpClient, url: str, user_agent: str) -> float | None:
     """Async check: fetch and parse robots.txt for URL host if needed, evaluate
-    permissions, and return any Crawl-delay using per-client cache.
+    permissions, and return the Crawl-delay for ``user_agent`` using the per-client
+    cache.
 
     Raises:
         RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
     """
     host, robots_url = get_host_and_robots_url(url)
 
-    if host in client._robots_cache:
-        parser, delay = client._robots_cache[host]
-    else:
-        parser, delay = await _fetch_and_cache_async(client, host, robots_url, user_agent)
+    parser = client._robots_cache.get(host)
+    if parser is None:
+        parser = await _fetch_and_cache_async(client, host, robots_url, user_agent)
 
     if not parser.can_fetch(user_agent, url):
         raise RobotsDisallowedError(
             f"URL '{url}' is disallowed for user-agent '{user_agent}' by robots.txt at {robots_url}"
         )
 
-    return delay
+    return _crawl_delay_for(parser, user_agent)
 
 
 async def _fetch_and_cache_async(
     client: AsyncHttpClient, host: str, robots_url: str, user_agent: str
-) -> tuple[RobotFileParser, float | None]:
-    """Fetch robots.txt via async client (skipping robots check recursively) and store in per-client cache."""
-    parser = RobotFileParser()
-
+) -> RobotFileParser:
+    """Fetch robots.txt via the async client (skipping the robots check recursively,
+    and sending the same User-Agent being enforced) and cache the parser per-client."""
     try:
-        resp = await client.get(robots_url, skip_robots_check=True)
-        if resp.status_code == 200:
-            parser, delay = _parse_robots(resp.text, user_agent)
-        else:
-            parser.parse([])
-            delay = None
+        resp = await client.get(
+            robots_url, skip_robots_check=True, headers={"User-Agent": user_agent}
+        )
+        parser = _parse_robots(resp.text) if resp.status_code == 200 else _parse_robots("")
     except Exception as exc:
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
-        parser.parse([])
-        delay = None
+        parser = _parse_robots("")
 
-    client._robots_cache[host] = (parser, delay)
-    return parser, delay
+    client._robots_cache[host] = parser
+    return parser

--- a/src/pyscrappy/core/robots.py
+++ b/src/pyscrappy/core/robots.py
@@ -1,0 +1,153 @@
+"""Robots.txt fetching, caching, and politeness enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+from pyscrappy.core.exceptions import RobotsDisallowedError
+
+if TYPE_CHECKING:
+    import httpx
+
+    from pyscrappy.core.async_http import AsyncHttpClient
+    from pyscrappy.core.http import HttpClient
+
+logger = logging.getLogger("pyscrappy.robots")
+
+# Per-host cache of (RobotFileParser, crawl_delay)
+_ROBOTS_CACHE: dict[str, tuple[RobotFileParser, float | None]] = {}
+_ROBOTS_LOCK = threading.Lock()
+_ASYNC_ROBOTS_LOCK = asyncio.Lock()
+
+
+def get_host_and_robots_url(url: str) -> tuple[str, str]:
+    """Extract (host, robots_url) for a given target URL."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme or "http"
+    netloc = parsed.netloc or parsed.path.split("/")[0]
+    robots_url = f"{scheme}://{netloc}/robots.txt"
+    return netloc.lower(), robots_url
+
+
+def _parse_robots(text: str, user_agent: str) -> tuple[RobotFileParser, float | None]:
+    """Parse robots.txt content and extract crawl_delay for the user_agent."""
+    parser = RobotFileParser()
+    parser.parse(text.splitlines())
+
+    # Get crawl_delay if present
+    delay: float | None = None
+    try:
+        raw_delay = parser.crawl_delay(user_agent)
+        if raw_delay is not None:
+            delay = float(raw_delay)
+    except Exception:
+        delay = None
+
+    return parser, delay
+
+
+def check_robots_sync(client: HttpClient, url: str) -> float | None:
+    """Sync check: fetch and parse robots.txt for URL host if needed, evaluate
+    permissions, and return any Crawl-delay.
+
+    Raises:
+        RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
+    """
+    host, robots_url = get_host_and_robots_url(url)
+    user_agent = client._get_current_user_agent()
+
+    with _ROBOTS_LOCK:
+        if host in _ROBOTS_CACHE:
+            parser, delay = _ROBOTS_CACHE[host]
+        else:
+            parser, delay = _fetch_and_cache_sync(client, host, robots_url, user_agent)
+
+    if not parser.can_fetch(user_agent, url):
+        raise RobotsDisallowedError(
+            f"URL '{url}' is disallowed for user-agent '{user_agent}' by robots.txt at {robots_url}"
+        )
+
+    return delay
+
+
+def _fetch_and_cache_sync(
+    client: HttpClient, host: str, robots_url: str, user_agent: str
+) -> tuple[RobotFileParser, float | None]:
+    """Fetch robots.txt via sync client and store in cache."""
+    parser = RobotFileParser()
+
+    # Prevent recursive obey_robots check when fetching robots.txt itself
+    orig_obey = client.config.obey_robots
+    client.config.obey_robots = False
+    try:
+        resp = client.get(robots_url)
+        if resp.status_code == 200:
+            parser, delay = _parse_robots(resp.text, user_agent)
+        else:
+            parser.parse([])
+            delay = None
+    except Exception as exc:
+        logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
+        parser.parse([])
+        delay = None
+    finally:
+        client.config.obey_robots = orig_obey
+
+    _ROBOTS_CACHE[host] = (parser, delay)
+    return parser, delay
+
+
+async def check_robots_async(client: AsyncHttpClient, url: str) -> float | None:
+    """Async check: fetch and parse robots.txt for URL host if needed, evaluate
+    permissions, and return any Crawl-delay.
+
+    Raises:
+        RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
+    """
+    host, robots_url = get_host_and_robots_url(url)
+    user_agent = client._get_current_user_agent()
+
+    async with _ASYNC_ROBOTS_LOCK:
+        if host in _ROBOTS_CACHE:
+            parser, delay = _ROBOTS_CACHE[host]
+        else:
+            parser, delay = await _fetch_and_cache_async(client, host, robots_url, user_agent)
+
+    if not parser.can_fetch(user_agent, url):
+        raise RobotsDisallowedError(
+            f"URL '{url}' is disallowed for user-agent '{user_agent}' by robots.txt at {robots_url}"
+        )
+
+    return delay
+
+
+async def _fetch_and_cache_async(
+    client: AsyncHttpClient, host: str, robots_url: str, user_agent: str
+) -> tuple[RobotFileParser, float | None]:
+    """Fetch robots.txt via async client and store in cache."""
+    parser = RobotFileParser()
+
+    orig_obey = client.config.obey_robots
+    client.config.obey_robots = False
+    try:
+        resp = await client.get(robots_url)
+        if resp.status_code == 200:
+            parser, delay = _parse_robots(resp.text, user_agent)
+        else:
+            parser.parse([])
+            delay = None
+    except Exception as exc:
+        logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
+        parser.parse([])
+        delay = None
+    finally:
+        client.config.obey_robots = orig_obey
+
+    with _ROBOTS_LOCK:
+        _ROBOTS_CACHE[host] = (parser, delay)
+    return parser, delay

--- a/src/pyscrappy/core/robots.py
+++ b/src/pyscrappy/core/robots.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import threading
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
@@ -12,17 +10,10 @@ from urllib.robotparser import RobotFileParser
 from pyscrappy.core.exceptions import RobotsDisallowedError
 
 if TYPE_CHECKING:
-    import httpx
-
     from pyscrappy.core.async_http import AsyncHttpClient
     from pyscrappy.core.http import HttpClient
 
 logger = logging.getLogger("pyscrappy.robots")
-
-# Per-host cache of (RobotFileParser, crawl_delay)
-_ROBOTS_CACHE: dict[str, tuple[RobotFileParser, float | None]] = {}
-_ROBOTS_LOCK = threading.Lock()
-_ASYNC_ROBOTS_LOCK = asyncio.Lock()
 
 
 def get_host_and_robots_url(url: str) -> tuple[str, str]:
@@ -39,7 +30,6 @@ def _parse_robots(text: str, user_agent: str) -> tuple[RobotFileParser, float | 
     parser = RobotFileParser()
     parser.parse(text.splitlines())
 
-    # Get crawl_delay if present
     delay: float | None = None
     try:
         raw_delay = parser.crawl_delay(user_agent)
@@ -51,21 +41,19 @@ def _parse_robots(text: str, user_agent: str) -> tuple[RobotFileParser, float | 
     return parser, delay
 
 
-def check_robots_sync(client: HttpClient, url: str) -> float | None:
+def check_robots_sync(client: HttpClient, url: str, user_agent: str) -> float | None:
     """Sync check: fetch and parse robots.txt for URL host if needed, evaluate
-    permissions, and return any Crawl-delay.
+    permissions, and return any Crawl-delay using per-client cache.
 
     Raises:
         RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
     """
     host, robots_url = get_host_and_robots_url(url)
-    user_agent = client._get_current_user_agent()
 
-    with _ROBOTS_LOCK:
-        if host in _ROBOTS_CACHE:
-            parser, delay = _ROBOTS_CACHE[host]
-        else:
-            parser, delay = _fetch_and_cache_sync(client, host, robots_url, user_agent)
+    if host in client._robots_cache:
+        parser, delay = client._robots_cache[host]
+    else:
+        parser, delay = _fetch_and_cache_sync(client, host, robots_url, user_agent)
 
     if not parser.can_fetch(user_agent, url):
         raise RobotsDisallowedError(
@@ -78,14 +66,11 @@ def check_robots_sync(client: HttpClient, url: str) -> float | None:
 def _fetch_and_cache_sync(
     client: HttpClient, host: str, robots_url: str, user_agent: str
 ) -> tuple[RobotFileParser, float | None]:
-    """Fetch robots.txt via sync client and store in cache."""
+    """Fetch robots.txt via sync client (skipping robots check recursively) and store in per-client cache."""
     parser = RobotFileParser()
 
-    # Prevent recursive obey_robots check when fetching robots.txt itself
-    orig_obey = client.config.obey_robots
-    client.config.obey_robots = False
     try:
-        resp = client.get(robots_url)
+        resp = client.get(robots_url, skip_robots_check=True)
         if resp.status_code == 200:
             parser, delay = _parse_robots(resp.text, user_agent)
         else:
@@ -95,28 +80,24 @@ def _fetch_and_cache_sync(
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
         parser.parse([])
         delay = None
-    finally:
-        client.config.obey_robots = orig_obey
 
-    _ROBOTS_CACHE[host] = (parser, delay)
+    client._robots_cache[host] = (parser, delay)
     return parser, delay
 
 
-async def check_robots_async(client: AsyncHttpClient, url: str) -> float | None:
+async def check_robots_async(client: AsyncHttpClient, url: str, user_agent: str) -> float | None:
     """Async check: fetch and parse robots.txt for URL host if needed, evaluate
-    permissions, and return any Crawl-delay.
+    permissions, and return any Crawl-delay using per-client cache.
 
     Raises:
         RobotsDisallowedError: If the URL is disallowed for the client's user-agent.
     """
     host, robots_url = get_host_and_robots_url(url)
-    user_agent = client._get_current_user_agent()
 
-    async with _ASYNC_ROBOTS_LOCK:
-        if host in _ROBOTS_CACHE:
-            parser, delay = _ROBOTS_CACHE[host]
-        else:
-            parser, delay = await _fetch_and_cache_async(client, host, robots_url, user_agent)
+    if host in client._robots_cache:
+        parser, delay = client._robots_cache[host]
+    else:
+        parser, delay = await _fetch_and_cache_async(client, host, robots_url, user_agent)
 
     if not parser.can_fetch(user_agent, url):
         raise RobotsDisallowedError(
@@ -129,13 +110,11 @@ async def check_robots_async(client: AsyncHttpClient, url: str) -> float | None:
 async def _fetch_and_cache_async(
     client: AsyncHttpClient, host: str, robots_url: str, user_agent: str
 ) -> tuple[RobotFileParser, float | None]:
-    """Fetch robots.txt via async client and store in cache."""
+    """Fetch robots.txt via async client (skipping robots check recursively) and store in per-client cache."""
     parser = RobotFileParser()
 
-    orig_obey = client.config.obey_robots
-    client.config.obey_robots = False
     try:
-        resp = await client.get(robots_url)
+        resp = await client.get(robots_url, skip_robots_check=True)
         if resp.status_code == 200:
             parser, delay = _parse_robots(resp.text, user_agent)
         else:
@@ -145,9 +124,6 @@ async def _fetch_and_cache_async(
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
         parser.parse([])
         delay = None
-    finally:
-        client.config.obey_robots = orig_obey
 
-    with _ROBOTS_LOCK:
-        _ROBOTS_CACHE[host] = (parser, delay)
+    client._robots_cache[host] = (parser, delay)
     return parser, delay

--- a/tests/test_core/test_robots.py
+++ b/tests/test_core/test_robots.py
@@ -1,0 +1,159 @@
+"""Tests for robots.txt politeness enforcement and caching."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pyscrappy.core.async_http import AsyncHttpClient
+from pyscrappy.core.config import ScraperConfig
+from pyscrappy.core.exceptions import RobotsDisallowedError
+from pyscrappy.core.http import HttpClient
+from pyscrappy.core.robots import _ROBOTS_CACHE, check_robots_sync, get_host_and_robots_url
+
+
+@pytest.fixture(autouse=True)
+def _clear_robots_cache():
+    """Clear the per-host robots.txt cache before each test."""
+    _ROBOTS_CACHE.clear()
+    yield
+    _ROBOTS_CACHE.clear()
+
+
+def test_get_host_and_robots_url():
+    host, robots_url = get_host_and_robots_url("https://example.com/some/path?query=1")
+    assert host == "example.com"
+    assert robots_url == "https://example.com/robots.txt"
+
+
+def test_obey_robots_disabled_by_default_does_not_fetch_robots():
+    config = ScraperConfig(obey_robots=False)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.text = "<h1>Hello</h1>"
+        resp.headers = {}
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get) as mock_httpx:
+        with HttpClient(config) as client:
+            client.get("https://example.com/page")
+
+        for call_args in mock_httpx.call_args_list:
+            assert "robots.txt" not in str(call_args)
+
+
+def test_obey_robots_allowed_path():
+    robots_txt = """\
+User-agent: *
+Disallow: /admin/
+Allow: /public/
+"""
+    config = ScraperConfig(obey_robots=True)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        if "robots.txt" in str(url):
+            resp.text = robots_txt
+        else:
+            resp.text = "OK"
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            resp = client.get("https://example.com/public/page")
+            assert resp.text == "OK"
+
+
+def test_obey_robots_disallowed_path_raises_error():
+    robots_txt = """\
+User-agent: *
+Disallow: /admin/
+"""
+    config = ScraperConfig(obey_robots=True)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        if "robots.txt" in str(url):
+            resp.text = robots_txt
+        else:
+            resp.text = "OK"
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            with pytest.raises(RobotsDisallowedError) as exc_info:
+                client.get("https://example.com/admin/dashboard")
+            assert "disallowed" in str(exc_info.value).lower()
+
+
+def test_robots_fetched_at_most_once_per_host():
+    robots_txt = "User-agent: *\nDisallow: /secret/\n"
+    config = ScraperConfig(obey_robots=True)
+    robots_fetch_count = 0
+
+    def fake_httpx_get(url, *args, **kwargs):
+        nonlocal robots_fetch_count
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        if "robots.txt" in str(url):
+            robots_fetch_count += 1
+            resp.text = robots_txt
+        else:
+            resp.text = "OK"
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            client.get("https://example.com/page1")
+            client.get("https://example.com/page2")
+            client.get("https://example.com/page3")
+
+    assert robots_fetch_count == 1
+    assert "example.com" in _ROBOTS_CACHE
+
+
+def test_crawl_delay_floor_honored():
+    robots_txt = """\
+User-agent: *
+Crawl-delay: 3
+"""
+    config = ScraperConfig(obey_robots=True, rate_limit=1.0)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = robots_txt if "robots.txt" in str(url) else "OK"
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            delay = check_robots_sync(client, "https://example.com/page")
+            assert delay == 3.0
+
+
+@pytest.mark.anyio
+async def test_async_obey_robots_disallowed():
+    robots_txt = "User-agent: *\nDisallow: /private/\n"
+    config = ScraperConfig(obey_robots=True)
+
+    async def fake_async_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = robots_txt if "robots.txt" in str(url) else "OK"
+        return resp
+
+    with patch("httpx.AsyncClient.get", side_effect=fake_async_get):
+        async with AsyncHttpClient(config) as async_client:
+            with pytest.raises(RobotsDisallowedError):
+                await async_client.get("https://example.com/private/data")

--- a/tests/test_core/test_robots.py
+++ b/tests/test_core/test_robots.py
@@ -44,7 +44,7 @@ User-agent: *
 Disallow: /admin/
 Allow: /public/
 """
-    config = ScraperConfig(obey_robots=True)
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
 
     def fake_httpx_get(url, *args, **kwargs):
         resp = MagicMock(spec=httpx.Response)
@@ -67,7 +67,7 @@ def test_obey_robots_disallowed_path_raises_error():
 User-agent: *
 Disallow: /admin/
 """
-    config = ScraperConfig(obey_robots=True)
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
 
     def fake_httpx_get(url, *args, **kwargs):
         resp = MagicMock(spec=httpx.Response)
@@ -88,7 +88,7 @@ Disallow: /admin/
 
 def test_robots_fetched_at_most_once_per_host_and_cached_per_client():
     robots_txt = "User-agent: *\nDisallow: /secret/\n"
-    config = ScraperConfig(obey_robots=True)
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
     robots_fetch_count = 0
 
     def fake_httpx_get(url, *args, **kwargs):
@@ -113,12 +113,12 @@ def test_robots_fetched_at_most_once_per_host_and_cached_per_client():
     assert robots_fetch_count == 1
 
 
-def test_crawl_delay_floor_honored():
+def test_crawl_delay_parsed_from_robots():
     robots_txt = """\
 User-agent: *
 Crawl-delay: 3
 """
-    config = ScraperConfig(obey_robots=True, rate_limit=1.0)
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
 
     def fake_httpx_get(url, *args, **kwargs):
         resp = MagicMock(spec=httpx.Response)
@@ -133,10 +133,32 @@ Crawl-delay: 3
             assert delay == 3.0
 
 
+def test_crawl_delay_floor_passed_to_rate_limiter():
+    """The parsed Crawl-delay must actually flow into _rate_limit as min_delay,
+    not just be returned by check_robots_sync — that's the behavior that makes
+    scraping slow down for polite hosts."""
+    robots_txt = "User-agent: *\nCrawl-delay: 3\n"
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = robots_txt if "robots.txt" in str(url) else "OK"
+        return resp
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            with patch.object(client, "_rate_limit", wraps=client._rate_limit) as spy:
+                client.get("https://example.com/page")
+    # the page fetch's rate-limit call carries the 3s Crawl-delay floor
+    assert any(call.kwargs.get("min_delay") == 3.0 for call in spy.call_args_list)
+
+
 @pytest.mark.anyio
 async def test_async_obey_robots_disallowed():
     robots_txt = "User-agent: *\nDisallow: /private/\n"
-    config = ScraperConfig(obey_robots=True)
+    config = ScraperConfig(obey_robots=True, rate_limit=0)
 
     async def fake_async_get(url, *args, **kwargs):
         resp = MagicMock(spec=httpx.Response)

--- a/tests/test_core/test_robots.py
+++ b/tests/test_core/test_robots.py
@@ -11,15 +11,7 @@ from pyscrappy.core.async_http import AsyncHttpClient
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import RobotsDisallowedError
 from pyscrappy.core.http import HttpClient
-from pyscrappy.core.robots import _ROBOTS_CACHE, check_robots_sync, get_host_and_robots_url
-
-
-@pytest.fixture(autouse=True)
-def _clear_robots_cache():
-    """Clear the per-host robots.txt cache before each test."""
-    _ROBOTS_CACHE.clear()
-    yield
-    _ROBOTS_CACHE.clear()
+from pyscrappy.core.robots import check_robots_sync, get_host_and_robots_url
 
 
 def test_get_host_and_robots_url():
@@ -94,7 +86,7 @@ Disallow: /admin/
             assert "disallowed" in str(exc_info.value).lower()
 
 
-def test_robots_fetched_at_most_once_per_host():
+def test_robots_fetched_at_most_once_per_host_and_cached_per_client():
     robots_txt = "User-agent: *\nDisallow: /secret/\n"
     config = ScraperConfig(obey_robots=True)
     robots_fetch_count = 0
@@ -116,9 +108,9 @@ def test_robots_fetched_at_most_once_per_host():
             client.get("https://example.com/page1")
             client.get("https://example.com/page2")
             client.get("https://example.com/page3")
+            assert "example.com" in client._robots_cache
 
     assert robots_fetch_count == 1
-    assert "example.com" in _ROBOTS_CACHE
 
 
 def test_crawl_delay_floor_honored():
@@ -137,7 +129,7 @@ Crawl-delay: 3
 
     with patch("httpx.Client.get", side_effect=fake_httpx_get):
         with HttpClient(config) as client:
-            delay = check_robots_sync(client, "https://example.com/page")
+            delay = check_robots_sync(client, "https://example.com/page", user_agent="PyScrappyBot")
             assert delay == 3.0
 
 


### PR DESCRIPTION
…(fixes #73)

Finished opt-in `robots.txt` compliance and `Crawl-delay` politeness support.

- Added `obey_robots: bool = False` flag to `ScraperConfig` maintaining default backward compatibility.
- Added `RobotsDisallowedError` exception for specific disallowed URL reporting.
- Implemented per-host `RobotFileParser` caching.
- Floored domain rate limiting by `Crawl-delay` when present in `robots.txt`.
- Added unit test suite in `tests/test_core/test_robots.py` covering sync/async clients, allowed vs disallowed paths, and `Crawl-delay` handling.

Fixes #73