### PR TITLE
fix(github): default max_results to 20 to match the MCP tool

### DIFF
--- a/src/pyscrappy/scrapers/github.py
+++ b/src/pyscrappy/scrapers/github.py
@@ -44,7 +44,7 @@ class GitHubScraper(BaseScraper):
     def scrape(  # type: ignore[override]
         self,
         query: str,
-        max_results: int = 30,
+        max_results: int = 20,
         sort: str = "best-match",
     ) -> ScrapeResult:
         """Search GitHub repositories.
@@ -81,7 +81,7 @@ class GitHubScraper(BaseScraper):
     async def scrape_async(  # type: ignore[override]
         self,
         query: str,
-        max_results: int = 30,
+        max_results: int = 20,
         sort: str = "best-match",
     ) -> ScrapeResult:
         """Async counterpart to :meth:`scrape` (same args/returns)."""

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -2,6 +2,7 @@
 
 import json
 from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
 
 from pyscrappy.scrapers.github import GitHubScraper
 from pyscrappy.scrapers.hackernews import HackerNewsScraper
@@ -56,7 +57,8 @@ class TestGitHub:
         s = _with(GitHubScraper(), json.dumps({"items": []}))
         s.scrape(query="x")
         url = s._http.get_html.call_args.args[0]
-        assert "per_page=20" in url
+        # exact param match, so per_page=200 can't false-positive on a substring
+        assert parse_qs(urlparse(url).query).get("per_page") == ["20"]
 
 
 class TestHackerNews:

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -50,6 +50,14 @@ class TestGitHub:
         assert r.data == []
         assert "rate limited" in r.errors[0].message
 
+    def test_default_max_results_matches_mcp_tool(self):
+        """The default page size must match the MCP search_github tool (20), so
+        calling either surfaces the same number of repositories (issue #79)."""
+        s = _with(GitHubScraper(), json.dumps({"items": []}))
+        s.scrape(query="x")
+        url = s._http.get_html.call_args.args[0]
+        assert "per_page=20" in url
+
 
 class TestHackerNews:
     def test_parse(self):


### PR DESCRIPTION
## What & why

Fixes #79.

`GitHubScraper.scrape` and `GitHubScraper.scrape_async` defaulted `max_results` to **30**, while the `search_github` MCP tool (`src/pyscrappy/mcp/server.py`) defaults to **20** — as does every other scraper (`crypto`, `hackernews`, `openlibrary`, …) and every other MCP tool in the project. Calling the GitHub scraper directly therefore returned a different number of repositories than calling it through MCP, for no documented reason.

## Change

- Default `max_results` to `20` in both `GitHubScraper.scrape` and `GitHubScraper.scrape_async`, matching the MCP tool and the rest of the library.

`per_page = min(max_results, 100)` still caps requests, and callers can pass any explicit value as before — only the default changes. `20` is the established convention (GitHub was the sole outlier at 30).

## Test

Adds `TestGitHub::test_default_max_results_matches_mcp_tool`, which calls `scrape(query="x")` with no explicit `max_results` and asserts the requested URL carries `per_page=20`.

Verified: `pytest tests/test_scrapers` — **138 passed**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
