### PR TITLE
Fix retry client rebuilding and proxy rotation

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -117,7 +117,7 @@ class AsyncHttpClient:
             except httpx.HTTPStatusError as exc:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
-                    self._client = None
+                    await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
                     await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
@@ -125,7 +125,7 @@ class AsyncHttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
-                    self._client = None
+                    await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
                     await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
 

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -87,7 +87,6 @@ class AsyncHttpClient:
         extra_headers = kwargs.pop("headers", None) or {}
         user_agent = extra_headers.get("User-Agent") or self._pick_ua()
 
-        
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_async

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -47,6 +47,7 @@ class AsyncHttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.AsyncClient | None = None
         self._last_request_time: dict[str, float] = {}
+        self._current_proxy: str | None = None
         # Per-client cache of RobotFileParser keyed by host (per #73). Crawl-delay
         # is computed per request from the parser, so the UA-specific value stays
         # correct even when the client rotates User-Agents.
@@ -184,7 +185,8 @@ class AsyncHttpClient:
 
     def _build_client(self) -> httpx.AsyncClient:
         transport_kwargs: dict[str, Any] = {}
-        proxy = self.config.pick_proxy()
+        proxy = self.config.pick_proxy(exclude=self._current_proxy)
+        self._current_proxy = proxy
         if proxy:
             transport_kwargs["proxy"] = proxy
         return httpx.AsyncClient(

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -86,7 +86,7 @@ class AsyncHttpClient:
         extra_headers = kwargs.pop("headers", None) or {}
         user_agent = extra_headers.get("User-Agent") or self._pick_ua()
 
-        client = self._ensure_client()
+        
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_async
@@ -98,6 +98,7 @@ class AsyncHttpClient:
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
+                client = self._ensure_client()
                 headers = self._merge_headers(extra_headers, user_agent=user_agent)
                 resp = await client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
@@ -116,6 +117,7 @@ class AsyncHttpClient:
             except httpx.HTTPStatusError as exc:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
+                    self._client = None
                     await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
@@ -123,6 +125,7 @@ class AsyncHttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
+                    self._client = None
                     await asyncio.sleep(backoff_delay(self.config, attempt))
                     continue
 

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -77,7 +77,7 @@ class ScraperConfig:
     verify_ssl: bool = True
     cache_ttl: float = 0.0
 
-    def pick_proxy(self) -> str | None:
+    def pick_proxy(self, exclude: str | None = None) -> str | None:
         """Return a single proxy URL (rotating if a list was configured)."""
         import random
 
@@ -85,4 +85,8 @@ class ScraperConfig:
             return None
         if isinstance(self.proxy, str):
             return self.proxy
-        return random.choice(self.proxy) if self.proxy else None
+
+        choices = [proxy for proxy in self.proxy if proxy != exclude]
+        if not choices:
+            return random.choice(self.proxy) if self.proxy else None
+        return random.choice(choices)

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -55,6 +55,7 @@ class HttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.Client | None = None
         self._last_request_time: dict[str, float] = {}
+        self._current_proxy: str | None = None
         # Per-client cache of RobotFileParser keyed by host (per #73). Crawl-delay
         # is computed per request from the parser, so the UA-specific value stays
         # correct even when the client rotates User-Agents.
@@ -216,7 +217,8 @@ class HttpClient:
 
     def _build_client(self) -> httpx.Client:
         transport_kwargs: dict[str, Any] = {}
-        proxy = self.config.pick_proxy()
+        proxy = self.config.pick_proxy(exclude=self._current_proxy)
+        self._current_proxy = proxy
         if proxy:
             transport_kwargs["proxy"] = proxy
         return httpx.Client(

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -104,7 +104,7 @@ class HttpClient:
         extra_headers = kwargs.pop("headers", None) or {}
         user_agent = extra_headers.get("User-Agent") or self._pick_ua()
 
-        client = self._ensure_client()
+        
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_sync
@@ -116,6 +116,7 @@ class HttpClient:
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
+                client = self._ensure_client()
                 headers = self._merge_headers(extra_headers, user_agent=user_agent)
                 resp = client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
@@ -142,6 +143,7 @@ class HttpClient:
                         attempt,
                         delay,
                     )
+                    self._client = None
                     time.sleep(delay)
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
@@ -151,6 +153,7 @@ class HttpClient:
                 if attempt < self.config.max_retries:
                     delay = self._backoff_delay(attempt)
                     logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
+                    self._client = None
                     time.sleep(delay)
                     continue
 

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -105,7 +105,6 @@ class HttpClient:
         extra_headers = kwargs.pop("headers", None) or {}
         user_agent = extra_headers.get("User-Agent") or self._pick_ua()
 
-        
         crawl_delay: float | None = None
         if self.config.obey_robots and not skip_robots_check:
             from pyscrappy.core.robots import check_robots_sync

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -143,7 +143,7 @@ class HttpClient:
                         attempt,
                         delay,
                     )
-                    self._client = None
+                    self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
@@ -153,7 +153,7 @@ class HttpClient:
                 if attempt < self.config.max_retries:
                     delay = self._backoff_delay(attempt)
                     logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
-                    self._client = None
+                    self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue
 

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -65,12 +65,20 @@ async def test_async_retries_on_server_error():
     err.raise_for_status = MagicMock(
         side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=err)
     )
-    client, mock = _mock_async_client(
-        ScraperConfig(rate_limit=0, retry_delay=0, max_retries=2), [err, _resp(text="ok")]
-    )
+    ok = _resp(text="ok")
+    client = AsyncHttpClient(ScraperConfig(rate_limit=0, retry_delay=0, max_retries=2))
+    mock_1 = MagicMock()
+    mock_1.get = AsyncMock(return_value=err)
+    mock_1.aclose = AsyncMock()
+    mock_2 = MagicMock()
+    mock_2.get = AsyncMock(return_value=ok)
+    mock_2.aclose = AsyncMock()
+    client._client = mock_1
+    client._build_client = MagicMock(side_effect=[mock_2])
     resp = await client.get("https://example.com")
     assert resp.text == "ok"
-    assert mock.get.call_count == 2  # retried once
+    assert mock_1.get.call_count == 1
+    assert mock_2.get.call_count == 1
     await client.aclose()
 
 
@@ -97,6 +105,18 @@ async def test_async_config_headers_and_user_agent_applied():
     assert sent["User-Agent"] == "Custom/1.0"
     assert sent["X-Test"] == "1"
     await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_build_client_rotates_away_from_previous_proxy_when_possible(monkeypatch):
+    cfg = ScraperConfig(proxy=["http://proxy-a:8080", "http://proxy-b:8080"])
+    client = AsyncHttpClient(cfg)
+    client._current_proxy = "http://proxy-a:8080"
+    monkeypatch.setattr("random.choice", lambda seq: seq[0])
+
+    async_client = client._build_client()
+    assert client._current_proxy == "http://proxy-b:8080"
+    await async_client.aclose()
 
 
 @pytest.mark.anyio

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -178,13 +178,17 @@ class TestHttpClientGet:
         ok_response.status_code = 200
         ok_response.raise_for_status = MagicMock()
 
-        mock_httpx = MagicMock()
-        mock_httpx.get.side_effect = [error_response, ok_response]
+        mock_httpx_1 = MagicMock()
+        mock_httpx_1.get.return_value = error_response
+        mock_httpx_2 = MagicMock()
+        mock_httpx_2.get.return_value = ok_response
 
-        client._client = mock_httpx
+        client._client = mock_httpx_1
+        client._build_client = MagicMock(side_effect=[mock_httpx_2])
         resp = client.get("https://example.com")
         assert resp.status_code == 200
-        assert mock_httpx.get.call_count == 2
+        assert mock_httpx_1.get.call_count == 1
+        assert mock_httpx_2.get.call_count == 1
         client.close()
 
     def test_get_retries_on_request_error(self):
@@ -210,13 +214,17 @@ class TestHttpClientGet:
         config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=0)
         client = HttpClient(config)
 
-        mock_httpx = MagicMock()
-        mock_httpx.get.side_effect = httpx.ConnectError("refused")
+        mock_httpx_1 = MagicMock()
+        mock_httpx_1.get.side_effect = httpx.ConnectError("refused")
+        mock_httpx_2 = MagicMock()
+        mock_httpx_2.get.side_effect = httpx.ConnectError("refused")
 
-        client._client = mock_httpx
+        client._client = mock_httpx_1
+        client._build_client = MagicMock(side_effect=[mock_httpx_2])
         with pytest.raises(NetworkError, match="Failed to fetch"):
             client.get("https://example.com")
-        assert mock_httpx.get.call_count == 2
+        assert mock_httpx_1.get.call_count == 1
+        assert mock_httpx_2.get.call_count == 1
         client.close()
 
 
@@ -286,6 +294,16 @@ class TestHttpClientBuildClient:
         client = HttpClient(config)
         httpx_client = client._build_client()
         assert httpx_client is not None
+        httpx_client.close()
+
+    def test_build_client_rotates_away_from_previous_proxy_when_possible(self, monkeypatch):
+        config = ScraperConfig(proxy=["http://proxy-a:8080", "http://proxy-b:8080"])
+        client = HttpClient(config)
+        client._current_proxy = "http://proxy-a:8080"
+        monkeypatch.setattr("random.choice", lambda seq: seq[0])
+
+        httpx_client = client._build_client()
+        assert client._current_proxy == "http://proxy-b:8080"
         httpx_client.close()
 
     def test_build_client_default(self):

--- a/tests/test_core/test_proxy.py
+++ b/tests/test_core/test_proxy.py
@@ -18,6 +18,12 @@ class TestProxyRotation:
         cfg = ScraperConfig(proxy="http://host:8080")
         assert cfg.pick_proxy() == "http://host:8080"
 
+    def test_exclude_skips_previous_proxy_when_possible(self, monkeypatch):
+        cfg = ScraperConfig(proxy=["http://a:1", "http://b:2"])
+        monkeypatch.setattr("random.choice", lambda seq: seq[0])
+
+        assert cfg.pick_proxy(exclude="http://a:1") == "http://b:2"
+
     def test_rotating_proxy_picks_from_list(self):
         proxies = ["http://a:1", "http://b:2", "http://c:3"]
         cfg = ScraperConfig(proxy=proxies)


### PR DESCRIPTION
This PR improves retry behavior in the HTTP clients by rebuilding the cached client before retrying and avoiding reuse of the same proxy when a retry happens. It applies the same behavior to both sync and async clients so they stay consistent.

It also updates the related tests to match the real retry flow, including:

- retrying with a fresh client instance
- async awaits using [AsyncMock]
- proxy rotation behavior when multiple proxies are configured

Validation:

- .python -m pytest -q test_http.py test_async_http.py tests/test_core/test_proxy.py