### PR TITLE
fix(generic): pagination silently stops on offset=/start=//p/ URLs

### DIFF
--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -12,8 +12,12 @@ _NEXT_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
-_PAGE_URL_PATTERNS = re.compile(
-    r"[?&](page|p|pg|offset|start)=\d+|/page/\d+|/p/\d+",
+# Single source of truth for numbered-pagination URLs: the capture groups yield
+# the page number, and the same pattern is used both to *detect* a paginated URL
+# and to *extract* its number — so the two can't drift apart (which was the bug
+# behind #77, where detection matched offset=/start=//p/ but extraction didn't).
+_PAGE_NUMBER = re.compile(
+    r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)",
     re.IGNORECASE,
 )
 
@@ -44,7 +48,7 @@ def find_next_page_url(soup: BeautifulSoup, current_url: str) -> str | None:
         if _NEXT_PATTERNS.search(text) or _NEXT_PATTERNS.search(aria):
             return urljoin(current_url, str(a["href"]))
 
-        if "next" in classes.lower() and _PAGE_URL_PATTERNS.search(str(a["href"])):
+        if "next" in classes.lower() and _PAGE_NUMBER.search(str(a["href"])):
             return urljoin(current_url, str(a["href"]))
 
     # 3. Look for numbered pagination links and pick the next number
@@ -65,17 +69,12 @@ def _find_page_number_links(soup: BeautifulSoup, base_url: str) -> list[tuple[in
     results: list[tuple[int, str]] = []
     for a in soup.find_all("a", href=True):
         href = str(a["href"])
-        if not _PAGE_URL_PATTERNS.search(href):
+        if not _PAGE_NUMBER.search(href):
             continue
         num = _extract_page_number(href)
         if num is not None:
             results.append((num, urljoin(base_url, href)))
     return results
-
-
-# Same shapes as _PAGE_URL_PATTERNS, kept in sync so anything detected as
-# paginated also yields a number.
-_PAGE_NUMBER = re.compile(r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)", re.IGNORECASE)
 
 
 def _extract_page_number(url: str) -> int | None:

--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -73,12 +73,16 @@ def _find_page_number_links(soup: BeautifulSoup, base_url: str) -> list[tuple[in
     return results
 
 
+# Same shapes as _PAGE_URL_PATTERNS, kept in sync so anything detected as
+# paginated also yields a number.
+_PAGE_NUMBER = re.compile(
+    r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)", re.IGNORECASE
+)
+
+
 def _extract_page_number(url: str) -> int | None:
-    """Try to extract a page number from a URL."""
-    match = re.search(r"[?&](?:page|p|pg)=(\d+)", url, re.IGNORECASE)
-    if match:
-        return int(match.group(1))
-    match = re.search(r"/page/(\d+)", url, re.IGNORECASE)
-    if match:
-        return int(match.group(1))
-    return None
+    """Extract a page number from a URL, or None if it isn't paginated."""
+    match = _PAGE_NUMBER.search(url)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))

--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -75,9 +75,7 @@ def _find_page_number_links(soup: BeautifulSoup, base_url: str) -> list[tuple[in
 
 # Same shapes as _PAGE_URL_PATTERNS, kept in sync so anything detected as
 # paginated also yields a number.
-_PAGE_NUMBER = re.compile(
-    r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)", re.IGNORECASE
-)
+_PAGE_NUMBER = re.compile(r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)", re.IGNORECASE)
 
 
 def _extract_page_number(url: str) -> int | None:

--- a/tests/test_generic/test_pagination.py
+++ b/tests/test_generic/test_pagination.py
@@ -94,11 +94,7 @@ class TestFindNextPageUrl:
 
     def test_numbered_pagination_p_path(self):
         soup = _soup(
-            "<html><body>"
-            '<a href="/p/1">1</a>'
-            '<a href="/p/2">2</a>'
-            '<a href="/p/3">3</a>'
-            "</body></html>"
+            '<html><body><a href="/p/1">1</a><a href="/p/2">2</a><a href="/p/3">3</a></body></html>'
         )
         result = find_next_page_url(soup, "https://example.com/p/1")
         assert result == "https://example.com/p/2"

--- a/tests/test_generic/test_pagination.py
+++ b/tests/test_generic/test_pagination.py
@@ -70,6 +70,39 @@ class TestFindNextPageUrl:
         result = find_next_page_url(soup, "https://example.com?page=1")
         assert result == "https://example.com?page=2"
 
+    def test_numbered_pagination_offset_param(self):
+        soup = _soup(
+            "<html><body>"
+            '<a href="?offset=1">1</a>'
+            '<a href="?offset=2">2</a>'
+            '<a href="?offset=3">3</a>'
+            "</body></html>"
+        )
+        result = find_next_page_url(soup, "https://example.com?offset=2")
+        assert result == "https://example.com?offset=3"
+
+    def test_numbered_pagination_start_param(self):
+        soup = _soup(
+            "<html><body>"
+            '<a href="?start=1">1</a>'
+            '<a href="?start=2">2</a>'
+            '<a href="?start=3">3</a>'
+            "</body></html>"
+        )
+        result = find_next_page_url(soup, "https://example.com?start=1")
+        assert result == "https://example.com?start=2"
+
+    def test_numbered_pagination_p_path(self):
+        soup = _soup(
+            "<html><body>"
+            '<a href="/p/1">1</a>'
+            '<a href="/p/2">2</a>'
+            '<a href="/p/3">3</a>'
+            "</body></html>"
+        )
+        result = find_next_page_url(soup, "https://example.com/p/1")
+        assert result == "https://example.com/p/2"
+
 
 class TestExtractPageNumber:
     def test_page_param(self):
@@ -83,6 +116,15 @@ class TestExtractPageNumber:
 
     def test_page_path(self):
         assert _extract_page_number("https://example.com/page/7") == 7
+
+    def test_offset_param(self):
+        assert _extract_page_number("https://example.com?offset=4") == 4
+
+    def test_start_param(self):
+        assert _extract_page_number("https://example.com?start=6") == 6
+
+    def test_p_path(self):
+        assert _extract_page_number("https://example.com/p/8") == 8
 
     def test_no_page_number(self):
         assert _extract_page_number("https://example.com/about") is None


### PR DESCRIPTION
Fixes #77.

`_extract_page_number` only handled `page|p|pg` query params and `/page/N`
paths, while `_PAGE_URL_PATTERNS` (the detector used to decide a URL *is*
paginated) also matched `offset=`, `start=`, and `/p/N`. URLs using those
shapes got flagged as paginated but extraction returned `None`, so
`find_next_page_url` silently gave up after page 1.

Merged both regexes into one compiled pattern (`_PAGE_NUMBER`) so
detection and extraction can't drift apart again.

## Testing

- Added 6 new tests: 3 unit (`_extract_page_number` on `offset=`, `start=`,
  `/p/N`), 3 end-to-end (`find_next_page_url` following each shape across
  mock HTML pagination links).
- Confirmed all 6 fail against the pre-fix code (reproduces the bug), pass
  after the fix.
- Full suite: `389 passed, 19 deselected` (integration tests excluded per
  repo convention).
- `ruff check src/`: clean.
- No behavior change for existing `page=`/`p=`/`pg=`/`/page/N` shapes —
  all pre-existing pagination tests still pass unmodified.