### PR TITLE
fix(mcp): forward tags filter on search_hackernews

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -389,7 +389,10 @@ async def search_github(
 
 @mcp.tool()
 async def search_hackernews(
-    query: str, max_results: int = 20, by: str = "relevance"
+    query: str,
+    max_results: int = 20,
+    by: str = "relevance",
+    tags: str = "story",
 ) -> ScrapeToolResult:
     """Search Hacker News stories and return a list of matching story dicts, each with title, url, points, author (username), and comments (comment count).
 
@@ -399,11 +402,12 @@ async def search_hackernews(
         query: Search terms to match against story titles and text; type: string; example: "rust async runtime"; no default (required).
         max_results: Maximum number of stories to return; type: integer; example: 10; default: 20.
         by: Result ordering; type: string; one of "relevance" or "date" ("date" sorts most recent first); example: "date"; default: "relevance".
+        tags: Algolia HN tag filter; type: string; common values "story", "comment", "show_hn", "ask_hn", "poll", "job"; example: "show_hn"; default: "story".
 
-    Use this to pull real Hacker News discussion for a topic; prefer by="date" for breaking or time-sensitive topics and by="relevance" (default) otherwise, and use the returned url and comments fields to link out or gauge engagement.
+    Use this to pull real Hacker News discussion for a topic; prefer by="date" for breaking or time-sensitive topics and by="relevance" (default) otherwise, and use the returned url and comments fields to link out or gauge engagement. Set tags to narrow to Show HN, Ask HN, comments, etc.
     """
     with HackerNewsScraper(_config()) as hn:
-        return await _run(hn.scrape, query=query, max_results=max_results, by=by)
+        return await _run(hn.scrape, query=query, max_results=max_results, by=by, tags=tags)
 
 
 @mcp.tool()

--- a/src/pyscrappy/scrapers/hackernews.py
+++ b/src/pyscrappy/scrapers/hackernews.py
@@ -92,7 +92,7 @@ class HackerNewsScraper(BaseScraper):
         endpoint = "search_by_date" if by == "date" else "search"
         base = _API.replace("/search", f"/{endpoint}")
         hits = min(max_results, 1000)
-        return f"{base}?query={quote_plus(query)}&tags={tags}&hitsPerPage={hits}"
+        return f"{base}?query={quote_plus(query)}&tags={quote_plus(tags)}&hitsPerPage={hits}"
 
     def _build_result(self, url: str, payload: dict[str, Any]) -> ScrapeResult:
         stories = [self._parse(hit) for hit in payload.get("hits", []) if isinstance(hit, dict)]

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -1,12 +1,38 @@
-"""MCP tools must advertise only engines the scrapers actually support."""
+"""MCP tools must expose/forward the scraper parameters they document, and only
+advertise engines the scrapers actually support."""
 
 from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 pytest.importorskip("fastmcp")
 
 from pyscrappy.mcp import server  # noqa: E402
+
+
+@pytest.mark.anyio
+async def test_search_hackernews_forwards_tags():
+    sig = inspect.signature(server.search_hackernews)
+    assert "tags" in sig.parameters
+    assert sig.parameters["tags"].default == "story"
+
+    mock_scraper = MagicMock()
+    mock_scraper.scrape.return_value = MagicMock(
+        data=[],
+        metadata=MagicMock(scraper="hackernews", source_urls=[]),
+        errors=[],
+    )
+    mock_scraper.__enter__ = MagicMock(return_value=mock_scraper)
+    mock_scraper.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(server, "HackerNewsScraper", return_value=mock_scraper):
+        await server.search_hackernews(query="python", tags="show_hn")
+
+    kwargs = mock_scraper.scrape.call_args.kwargs
+    assert kwargs.get("tags") == "show_hn"
 
 
 def test_search_images_doc_does_not_advertise_duckduckgo():

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -95,8 +95,18 @@ class TestHackerNews:
     def test_tags_filter_flows_into_request_url(self):
         s = _with(HackerNewsScraper(), json.dumps({"hits": []}))
         s.scrape(query="python", tags="show_hn")
-        url = s._http.get_html.call_args[0][0]
-        assert "tags=show_hn" in url
+        url = s._http.get_html.call_args.args[0]
+        assert parse_qs(urlparse(url).query).get("tags") == ["show_hn"]
+
+    def test_tags_is_url_encoded_no_param_injection(self):
+        # A tags value with query-string delimiters must be encoded, not injected
+        # as extra params (it's interpolated into the Algolia URL).
+        s = _with(HackerNewsScraper(), json.dumps({"hits": []}))
+        s.scrape(query="python", tags="story&hitsPerPage=999999")
+        url = s._http.get_html.call_args.args[0]
+        params = parse_qs(urlparse(url).query)
+        assert params.get("tags") == ["story&hitsPerPage=999999"]  # one value, encoded
+        assert params.get("hitsPerPage") == ["20"]  # the injected override did NOT take effect
 
 
 class TestOpenLibrary:

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -92,6 +92,12 @@ class TestHackerNews:
         url = s._http.get_html.call_args[0][0]
         assert "search_by_date" in url
 
+    def test_tags_filter_flows_into_request_url(self):
+        s = _with(HackerNewsScraper(), json.dumps({"hits": []}))
+        s.scrape(query="python", tags="show_hn")
+        url = s._http.get_html.call_args[0][0]
+        assert "tags=show_hn" in url
+
 
 class TestOpenLibrary:
     def test_parse(self):


### PR DESCRIPTION
## Summary
`HackerNewsScraper.scrape` already supports a `tags` filter, but the MCP `search_hackernews` tool never exposed it — agents could only ever get `story` results.

## Changes
- Add `tags: str = "story"` to `search_hackernews` and forward it to `hn.scrape(...)`
- Document common tag values in the tool docstring
- Test that `tags=show_hn` reaches the Algolia request URL
- MCP-level test that the tool forwards `tags`

## Test plan
- [x] Unit test: `tags=show_hn` appears in the request URL
- [ ] `search_hackernews(query="python", tags="show_hn")` returns Show HN hits

Fixes #90