### PR TITLE
fix(mcp): forward interval on scrape_stock history

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -214,7 +214,7 @@ async def scrape_stock(
 
     Args:
         symbol: Ticker symbol as a string. Example: "AAPL". No default (required).
-        mode: String selecting what to fetch; one of "quote", "history", "profile". Example: "quote". No default (required).
+        mode: String selecting what to fetch; one of "quote", "history", "profile". Example: "quote". Default: "quote".
         period: String history window, used only when mode="history" and ignored otherwise; one of "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max". Example: "1y". Default: "1mo".
         interval: Candle size for history bars, used only when mode="history"; one of "1d", "1wk", "1mo". Example: "1wk". Default: "1d".
 
@@ -225,9 +225,7 @@ async def scrape_stock(
         requests, prefer the dedicated batch scraper instead.
     """
     with StockScraper(_config()) as ss:
-        return await _run(
-            ss.scrape, symbol=symbol, mode=mode, period=period, interval=interval
-        )
+        return await _run(ss.scrape, symbol=symbol, mode=mode, period=period, interval=interval)
 
 
 @mcp.tool()

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -192,7 +192,12 @@ async def scrape_wikipedia(query: str, mode: str = "full") -> ScrapeToolResult:
 
 
 @mcp.tool()
-async def scrape_stock(symbol: str, mode: str = "quote", period: str = "1mo") -> ScrapeToolResult:
+async def scrape_stock(
+    symbol: str,
+    mode: str = "quote",
+    period: str = "1mo",
+    interval: str = "1d",
+) -> ScrapeToolResult:
     """Fetch stock market data from Yahoo Finance and return it as a dict.
 
     The returned shape depends on `mode`:
@@ -211,6 +216,7 @@ async def scrape_stock(symbol: str, mode: str = "quote", period: str = "1mo") ->
         symbol: Ticker symbol as a string. Example: "AAPL". No default (required).
         mode: String selecting what to fetch; one of "quote", "history", "profile". Example: "quote". No default (required).
         period: String history window, used only when mode="history" and ignored otherwise; one of "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max". Example: "1y". Default: "1mo".
+        interval: Candle size for history bars, used only when mode="history"; one of "1d", "1wk", "1mo". Example: "1wk". Default: "1d".
 
     Usage:
         Use for a single ticker's live quote, OHLCV history, or company profile;
@@ -219,7 +225,9 @@ async def scrape_stock(symbol: str, mode: str = "quote", period: str = "1mo") ->
         requests, prefer the dedicated batch scraper instead.
     """
     with StockScraper(_config()) as ss:
-        return await _run(ss.scrape, symbol=symbol, mode=mode, period=period)
+        return await _run(
+            ss.scrape, symbol=symbol, mode=mode, period=period, interval=interval
+        )
 
 
 @mcp.tool()

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -35,6 +35,28 @@ async def test_search_hackernews_forwards_tags():
     assert kwargs.get("tags") == "show_hn"
 
 
+@pytest.mark.anyio
+async def test_scrape_stock_forwards_interval():
+    sig = inspect.signature(server.scrape_stock)
+    assert "interval" in sig.parameters
+    assert sig.parameters["interval"].default == "1d"
+
+    mock_scraper = MagicMock()
+    mock_scraper.scrape.return_value = MagicMock(
+        data=[],
+        metadata=MagicMock(scraper="stock", source_urls=[]),
+        errors=[],
+    )
+    mock_scraper.__enter__ = MagicMock(return_value=mock_scraper)
+    mock_scraper.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(server, "StockScraper", return_value=mock_scraper):
+        await server.scrape_stock(symbol="AAPL", mode="history", period="1mo", interval="1wk")
+
+    kwargs = mock_scraper.scrape.call_args.kwargs
+    assert kwargs.get("interval") == "1wk"
+
+
 def test_search_images_doc_does_not_advertise_duckduckgo():
     doc = server.search_images.__doc__ or ""
     assert "duckduckgo" not in doc.lower()


### PR DESCRIPTION
## Summary
`StockScraper.scrape` already supports an `interval` parameter for historical data, but the MCP `scrape_stock` tool never exposed it — every history request through MCP was locked to daily bars.

## Changes
- Add `interval: str = "1d"` to `scrape_stock` (valid: `1d`, `1wk`, `1mo`; history mode only)
- Forward it to `ss.scrape(...)`
- Document the param in the tool docstring
- MCP-level test that `interval` is forwarded

## Test plan
- [x] Unit test asserts `interval="1wk"` reaches the scraper
- [ ] `scrape_stock(symbol="AAPL", mode="history", period="1mo", interval="1wk")` returns weekly candles

Fixes #89