### PR TITLE
fix(mcp): stop advertising unsupported duckduckgo image engine

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -263,7 +263,7 @@ async def search_images(query: str, max_images: int = 20, engine: str = "bing") 
     Args:
         query: Search terms as a string, e.g. "golden gate bridge". Required, no default.
         max_images: Integer cap on the number of results returned, e.g. 10. Defaults to 20.
-        engine: String naming the search engine, one of "bing", "google", or "duckduckgo", e.g. "google". Defaults to "bing".
+        engine: String naming the search engine, one of "bing" or "google", e.g. "google". Defaults to "bing".
 
     Usage Guidelines:
         Use when you need image URLs or dimensions rather than a downloaded file; the returned "image_url" values can be fetched or passed to a downloader tool afterward. Raise max_images cautiously since larger values are slower and some engines cap the total available results.

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -1,0 +1,16 @@
+"""MCP tools must advertise only engines the scrapers actually support."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from pyscrappy.mcp import server  # noqa: E402
+
+
+def test_search_images_doc_does_not_advertise_duckduckgo():
+    doc = server.search_images.__doc__ or ""
+    assert "duckduckgo" not in doc.lower()
+    assert "bing" in doc.lower()
+    assert "google" in doc.lower()


### PR DESCRIPTION
## Summary
The `search_images` MCP tool docstring advertised `engine="duckduckgo"`, but the scraper only implements `bing` and `google`. Requesting duckduckgo silently returned Bing results with no error.

## Changes
- Drop `duckduckgo` from the documented engines (small, honest contract fix)
- Test asserts the docstring no longer lists duckduckgo

Went with the doc fix rather than implementing a DuckDuckGo path — keeps this a tight first-issue fix. Happy to follow up with a real `_search_duckduckgo` if wanted.

## Test plan
- [x] Docstring lists only `bing` and `google`
- [ ] Calling with `engine="google"` / `"bing"` still works as before

Fixes #88