### PR TITLE
fix(image_search): validate engine parameter and raise ValueError for unsupported values

### DIFF
--- a/src/pyscrappy/scrapers/image_search.py
+++ b/src/pyscrappy/scrapers/image_search.py
@@ -54,6 +54,9 @@ class ImageSearchScraper(BaseScraper):
         Returns:
             ScrapeResult with image URLs and metadata.
         """
+        if engine not in ("bing", "google"):
+            raise ValueError(f"unsupported engine {engine!r}; use 'bing' or 'google'")
+
         if engine == "google":
             images, url = self._search_google(query, max_images)
         else:
@@ -75,6 +78,9 @@ class ImageSearchScraper(BaseScraper):
         download_to: str | None = None,
     ) -> ScrapeResult:
         """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if engine not in ("bing", "google"):
+            raise ValueError(f"unsupported engine {engine!r}; use 'bing' or 'google'")
+
         if engine == "google":
             images, url = await self._search_google_async(query, max_images)
         else:

--- a/src/pyscrappy/scrapers/image_search.py
+++ b/src/pyscrappy/scrapers/image_search.py
@@ -55,7 +55,7 @@ class ImageSearchScraper(BaseScraper):
             ScrapeResult with image URLs and metadata.
         """
         if engine not in ("bing", "google"):
-            raise ValueError(f"unsupported engine {engine!r}; use 'bing' or 'google'")
+            raise ValueError(f"Unsupported engine {engine!r}; use 'bing' or 'google'")
 
         if engine == "google":
             images, url = self._search_google(query, max_images)
@@ -79,7 +79,7 @@ class ImageSearchScraper(BaseScraper):
     ) -> ScrapeResult:
         """Async counterpart to :meth:`scrape` (same args/returns)."""
         if engine not in ("bing", "google"):
-            raise ValueError(f"unsupported engine {engine!r}; use 'bing' or 'google'")
+            raise ValueError(f"Unsupported engine {engine!r}; use 'bing' or 'google'")
 
         if engine == "google":
             images, url = await self._search_google_async(query, max_images)

--- a/tests/test_scrapers/test_other.py
+++ b/tests/test_scrapers/test_other.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from pyscrappy.scrapers.image_search import ImageSearchScraper
 from pyscrappy.scrapers.linkedin import LinkedInJobsScraper
 
@@ -217,3 +219,15 @@ class TestImageSearchScraper:
         url = mock_http.get_html.call_args[0][0]
         assert "bing.com" in url
         scraper.close()
+
+    def test_unsupported_engine_raises_value_error(self):
+        scraper = ImageSearchScraper()
+        with pytest.raises(ValueError, match="unsupported engine 'googel'"):
+            scraper.scrape(query="test", engine="googel")
+
+    @pytest.mark.anyio
+    async def test_unsupported_engine_raises_value_error_async(self):
+        scraper = ImageSearchScraper()
+        with pytest.raises(ValueError, match="unsupported engine 'googel'"):
+            await scraper.scrape_async(query="test", engine="googel")
+

--- a/tests/test_scrapers/test_other.py
+++ b/tests/test_scrapers/test_other.py
@@ -222,12 +222,11 @@ class TestImageSearchScraper:
 
     def test_unsupported_engine_raises_value_error(self):
         scraper = ImageSearchScraper()
-        with pytest.raises(ValueError, match="unsupported engine 'googel'"):
+        with pytest.raises(ValueError, match="Unsupported engine 'googel'"):
             scraper.scrape(query="test", engine="googel")
 
     @pytest.mark.anyio
     async def test_unsupported_engine_raises_value_error_async(self):
         scraper = ImageSearchScraper()
-        with pytest.raises(ValueError, match="unsupported engine 'googel'"):
+        with pytest.raises(ValueError, match="Unsupported engine 'googel'"):
             await scraper.scrape_async(query="test", engine="googel")
-


### PR DESCRIPTION
Fixes #94

### Changes
- Updated `ImageSearchScraper.scrape` and `ImageSearchScraper.scrape_async` to validate that `engine` is either `"bing"` or `"google"`.
- Raises a descriptive `ValueError` if an unsupported engine string (e.g., `"googel"`) is provided instead of silently defaulting to Bing.
- Added unit tests for both sync and async paths in `tests/test_scrapers/test_other.py` to verify `ValueError` is raised as expected.