### PR TITLE
Handle NewsScraper transport errors

### DIFF
--- a/src/pyscrappy/scrapers/news.py
+++ b/src/pyscrappy/scrapers/news.py
@@ -79,7 +79,10 @@ class NewsScraper(BaseScraper):
 
     def _scrape_feed(self, url: str, max_articles: int) -> ScrapeResult:
         """Parse an RSS or Atom feed."""
-        xml_text = self.http.get_html(url)
+        try:
+            xml_text = self.http.get_html(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
         articles = self._parse_feed_xml(xml_text, max_articles)
 
         return ScrapeResult(
@@ -89,7 +92,10 @@ class NewsScraper(BaseScraper):
 
     async def _scrape_feed_async(self, url: str, max_articles: int) -> ScrapeResult:
         """Async counterpart to :meth:`_scrape_feed`."""
-        xml_text = await self.async_http.get_html(url)
+        try:
+            xml_text = await self.async_http.get_html(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
         articles = self._parse_feed_xml(xml_text, max_articles)
 
         return ScrapeResult(
@@ -99,7 +105,10 @@ class NewsScraper(BaseScraper):
 
     def _scrape_site(self, url: str, max_articles: int) -> ScrapeResult:
         """Auto-discover an RSS feed from a website, then parse it."""
-        html = self.http.get_html(url)
+        try:
+            html = self.http.get_html(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
         soup = self.parse_html(html)
 
         feed_url = self._discover_feed(soup, url)
@@ -110,7 +119,10 @@ class NewsScraper(BaseScraper):
 
     async def _scrape_site_async(self, url: str, max_articles: int) -> ScrapeResult:
         """Async counterpart to :meth:`_scrape_site`."""
-        html = await self.async_http.get_html(url)
+        try:
+            html = await self.async_http.get_html(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
         soup = self.parse_html(html)
 
         feed_url = self._discover_feed(soup, url)
@@ -135,13 +147,29 @@ class NewsScraper(BaseScraper):
 
     def _scrape_article(self, url: str) -> ScrapeResult:
         """Extract the full text of a single news article."""
-        soup = self.fetch_and_parse(url)
+        try:
+            html = self.fetch_html(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
+        soup = self.parse_html(html)
         return self._build_article(soup, url)
 
     async def _scrape_article_async(self, url: str) -> ScrapeResult:
         """Async counterpart to :meth:`_scrape_article`."""
-        soup = await self.fetch_and_parse_async(url)
+        try:
+            html = await self.fetch_html_async(url)
+        except Exception as exc:
+            return self._fetch_error_result(url, exc)
+        soup = self.parse_html(html)
         return self._build_article(soup, url)
+
+    def _fetch_error_result(self, url: str, exc: Exception) -> ScrapeResult:
+        """Build a structured result for a transport failure."""
+        return ScrapeResult(
+            data=[],
+            metadata=ScrapeMetadata(source_urls=[url], scraper=self.name),
+            errors=[ScrapeError(url=url, message=str(exc))],
+        )
 
     def _build_article(self, soup: Any, url: str) -> ScrapeResult:
         """Extract article fields from a parsed page (pure, no fetching)."""

--- a/tests/test_scrapers/test_news.py
+++ b/tests/test_scrapers/test_news.py
@@ -1,6 +1,6 @@
 """Tests for pyscrappy.scrapers.news."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -77,6 +77,22 @@ SITE_WITHOUT_RSS = """
 """
 
 
+@pytest.fixture
+def anyio_backend():
+    """Run async tests on asyncio only (avoids needing trio)."""
+    return "asyncio"
+
+
+def assert_fetch_error(result, url, message):
+    """Assert the standard result returned for a transport failure."""
+    assert result.data == []
+    assert result.metadata.source_urls == [url]
+    assert result.metadata.scraper == "news"
+    assert len(result.errors) == 1
+    assert result.errors[0].url == url
+    assert result.errors[0].message == message
+
+
 class TestNewsScraperInit:
     def test_name(self):
         scraper = NewsScraper()
@@ -139,6 +155,34 @@ class TestNewsScraperFeed:
         assert result.data == []
         scraper.close()
 
+    def test_feed_transport_error_returns_structured_result(self):
+        url = "https://example.com/rss"
+        scraper = NewsScraper()
+        mock_http = MagicMock()
+        mock_http.get_html.side_effect = RuntimeError("feed unavailable")
+        scraper._http = mock_http
+
+        result = scraper.scrape(feed_url=url)
+
+        assert_fetch_error(result, url, "feed unavailable")
+        mock_http.get_html.assert_called_once_with(url)
+        scraper.close()
+
+    @pytest.mark.anyio
+    async def test_feed_async_transport_error_returns_structured_result(self):
+        url = "https://example.com/rss"
+        scraper = NewsScraper()
+        mock_http = MagicMock()
+        mock_http.get_html = AsyncMock(side_effect=RuntimeError("feed unavailable"))
+        mock_http.aclose = AsyncMock()
+        scraper._async_http = mock_http
+
+        result = await scraper.scrape_async(feed_url=url)
+
+        assert_fetch_error(result, url, "feed unavailable")
+        mock_http.get_html.assert_awaited_once_with(url)
+        await scraper.aclose()
+
 
 class TestNewsScraperArticle:
     def test_scrape_article(self):
@@ -169,6 +213,44 @@ class TestNewsScraperArticle:
         # "Short" paragraph should be filtered out
         assert "Short" not in result.data[0]["text"]
         scraper.close()
+
+    def test_article_transport_error_returns_structured_result(self):
+        url = "https://example.com/article/1"
+        scraper = NewsScraper()
+        scraper.fetch_html = MagicMock(side_effect=RuntimeError("article unavailable"))
+
+        result = scraper.scrape(article_url=url)
+
+        assert_fetch_error(result, url, "article unavailable")
+        scraper.fetch_html.assert_called_once_with(url)
+
+    @pytest.mark.anyio
+    async def test_article_async_transport_error_returns_structured_result(self):
+        url = "https://example.com/article/1"
+        scraper = NewsScraper()
+        scraper.fetch_html_async = AsyncMock(side_effect=RuntimeError("article unavailable"))
+
+        result = await scraper.scrape_async(article_url=url)
+
+        assert_fetch_error(result, url, "article unavailable")
+        scraper.fetch_html_async.assert_awaited_once_with(url)
+
+    def test_article_parse_error_propagates(self):
+        scraper = NewsScraper()
+        scraper.fetch_html = MagicMock(return_value=ARTICLE_HTML)
+        scraper.parse_html = MagicMock(side_effect=ValueError("invalid article markup"))
+
+        with pytest.raises(ValueError, match="invalid article markup"):
+            scraper.scrape(article_url="https://example.com/article/1")
+
+    @pytest.mark.anyio
+    async def test_article_async_parse_error_propagates(self):
+        scraper = NewsScraper()
+        scraper.fetch_html_async = AsyncMock(return_value=ARTICLE_HTML)
+        scraper.parse_html = MagicMock(side_effect=ValueError("invalid article markup"))
+
+        with pytest.raises(ValueError, match="invalid article markup"):
+            await scraper.scrape_async(article_url="https://example.com/article/1")
 
 
 class TestNewsScraperSite:
@@ -207,6 +289,34 @@ class TestNewsScraperSite:
         assert len(result.errors) == 1
         assert "No RSS feed or article links found" in result.errors[0].message
         scraper.close()
+
+    def test_site_transport_error_returns_structured_result(self):
+        url = "https://example.com"
+        scraper = NewsScraper()
+        mock_http = MagicMock()
+        mock_http.get_html.side_effect = RuntimeError("site unavailable")
+        scraper._http = mock_http
+
+        result = scraper.scrape(site_url=url)
+
+        assert_fetch_error(result, url, "site unavailable")
+        mock_http.get_html.assert_called_once_with(url)
+        scraper.close()
+
+    @pytest.mark.anyio
+    async def test_site_async_transport_error_returns_structured_result(self):
+        url = "https://example.com"
+        scraper = NewsScraper()
+        mock_http = MagicMock()
+        mock_http.get_html = AsyncMock(side_effect=RuntimeError("site unavailable"))
+        mock_http.aclose = AsyncMock()
+        scraper._async_http = mock_http
+
+        result = await scraper.scrape_async(site_url=url)
+
+        assert_fetch_error(result, url, "site unavailable")
+        mock_http.get_html.assert_awaited_once_with(url)
+        await scraper.aclose()
 
 
 class TestNewsScraperHelpers:


### PR DESCRIPTION
## Summary

- convert NewsScraper transport failures into structured `ScrapeResult` errors
- cover feed, site, and article paths in both sync and async APIs
- keep HTML/XML parsing outside the transport guards so programming defects still propagate

## Why

NewsScraper was the outlier among the API scrapers: failed HTTP requests escaped as exceptions and could crash callers instead of returning the library's normal `ScrapeError` representation. The article path also required separating fetch from parse so the fix would not hide parser failures.

## Impact

Callers now receive empty data plus one `ScrapeError` containing the failed URL and transport message. Successful scraping, route priority, invalid XML behavior, and public method signatures are unchanged.

Closes #87.

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_scrapers/test_news.py -q` — 21 passed
- `PYTHONPATH=src python3 -m pytest tests/ -q` — 384 passed, 5 skipped, 19 deselected
- `ruff check src/` — all checks passed
- `git diff --check` — clean
