### PR TITLE
feat: add async concurrency helpers

### DIFF
--- a/src/pyscrappy/concurrent.py
+++ b/src/pyscrappy/concurrent.py
@@ -21,11 +21,12 @@ Example::
         lambda: NewsScraper().scrape(feed_url="https://..."),
     ])
 """
-
 from __future__ import annotations
 
+import asyncio
+
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.config import ScraperConfig
@@ -64,6 +65,25 @@ def scrape_many(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         return list(pool.map(_one, calls))
 
+async def scrape_many_async(
+    scraper_cls: type[BaseScraper],
+    calls: list[dict[str, Any]],
+    *,
+    config: ScraperConfig | None = None,
+    max_concurrency: int = _DEFAULT_WORKERS,
+) -> list[ScrapeResult]:
+    """Run ``scraper_cls.scrape_async(**call)`` for each call concurrently."""
+
+    workers = max(1, min(max_concurrency, len(calls))) if calls else 1
+    semaphore = asyncio.Semaphore(workers)
+
+    async def _one(call: dict[str, Any]) -> ScrapeResult:
+        async with semaphore:
+            async with scraper_cls(config) as scraper:
+                return await scraper.scrape_async(**call)
+
+    tasks = [asyncio.create_task(_one(call)) for call in calls]
+    return await asyncio.gather(*tasks)
 
 def scrape_all(
     funcs: list[Callable[[], ScrapeResult]],
@@ -85,3 +105,20 @@ def scrape_all(
     workers = max(1, min(max_workers, len(funcs))) if funcs else 1
     with ThreadPoolExecutor(max_workers=workers) as pool:
         return list(pool.map(lambda f: f(), funcs))
+
+async def scrape_all_async(
+    funcs: list[Callable[[], Awaitable[ScrapeResult]]],
+    *,
+    max_concurrency: int = _DEFAULT_WORKERS,
+) -> list[ScrapeResult]:
+    """Run several independent async scrape callables concurrently."""
+
+    workers = max(1, min(max_concurrency, len(funcs))) if funcs else 1
+    semaphore = asyncio.Semaphore(workers)
+
+    async def _one(func: Callable[[], Awaitable[ScrapeResult]]) -> ScrapeResult:
+        async with semaphore:
+            return await func()
+
+    tasks = [asyncio.create_task(_one(f)) for f in funcs]
+    return await asyncio.gather(*tasks)

--- a/src/pyscrappy/concurrent.py
+++ b/src/pyscrappy/concurrent.py
@@ -21,10 +21,10 @@ Example::
         lambda: NewsScraper().scrape(feed_url="https://..."),
     ])
 """
+
 from __future__ import annotations
 
 import asyncio
-
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Awaitable, Callable
 
@@ -65,6 +65,7 @@ def scrape_many(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         return list(pool.map(_one, calls))
 
+
 async def scrape_many_async(
     scraper_cls: type[BaseScraper],
     calls: list[dict[str, Any]],
@@ -72,7 +73,20 @@ async def scrape_many_async(
     config: ScraperConfig | None = None,
     max_concurrency: int = _DEFAULT_WORKERS,
 ) -> list[ScrapeResult]:
-    """Run ``scraper_cls.scrape_async(**call)`` for each call concurrently."""
+    """Run ``scraper_cls.scrape_async(**call)`` for each call concurrently.
+
+    A fresh scraper instance is created per call (and closed afterwards), so
+    results are returned in the same order as ``calls``.
+
+    Args:
+        scraper_cls: A scraper class.
+        calls: One kwargs dict per scrape.
+        config: Optional shared config.
+        max_concurrency: Maximum concurrent scrapes.
+
+    Returns:
+        A list of ``ScrapeResult`` in the same order as ``calls``.
+    """
 
     workers = max(1, min(max_concurrency, len(calls))) if calls else 1
     semaphore = asyncio.Semaphore(workers)
@@ -84,6 +98,7 @@ async def scrape_many_async(
 
     tasks = [asyncio.create_task(_one(call)) for call in calls]
     return await asyncio.gather(*tasks)
+
 
 def scrape_all(
     funcs: list[Callable[[], ScrapeResult]],
@@ -106,12 +121,26 @@ def scrape_all(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         return list(pool.map(lambda f: f(), funcs))
 
+
 async def scrape_all_async(
     funcs: list[Callable[[], Awaitable[ScrapeResult]]],
     *,
     max_concurrency: int = _DEFAULT_WORKERS,
 ) -> list[ScrapeResult]:
-    """Run several independent async scrape callables concurrently."""
+    """Run several independent async scrape callables concurrently.
+
+    Use this to mix different async scrapers in one batch. Each callable should
+    return an awaitable ``ScrapeResult``. Results are returned in the same order
+    as ``funcs``.
+
+    Args:
+        funcs: Zero-argument callables, each returning an awaitable
+            ``ScrapeResult``.
+        max_concurrency: Maximum number of concurrent scrapes.
+
+    Returns:
+        A list of ``ScrapeResult`` objects in the same order as ``funcs``.
+    """
 
     workers = max(1, min(max_concurrency, len(funcs))) if funcs else 1
     semaphore = asyncio.Semaphore(workers)

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,16 +1,19 @@
 """Tests for pyscrappy.concurrent (scrape_many / scrape_all)."""
 
-import time
 import asyncio
+import time
+
 import pytest
-from pyscrappy.core.base import BaseScraper
-from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+
 from pyscrappy.concurrent import (
     scrape_all,
     scrape_all_async,
     scrape_many,
     scrape_many_async,
 )
+from pyscrappy.core.base import BaseScraper
+from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+
 
 class _FakeScraper(BaseScraper):
     """A scraper that sleeps briefly and echoes its query, for timing tests."""
@@ -24,7 +27,7 @@ class _FakeScraper(BaseScraper):
             data=[{"query": query}],
             metadata=ScrapeMetadata(scraper=self.name),
         )
-    
+
     async def scrape_async(
         self,
         query: str = "",
@@ -60,7 +63,6 @@ class TestScrapeMany:
         elapsed = time.monotonic() - start
         assert len(results) == 4
         assert elapsed < 0.6  # well under the 0.8s serial time
-
 
 
 class TestScrapeAll:
@@ -119,10 +121,7 @@ class TestScrapeAllAsync:
         assert await scrape_all_async([]) == []
 
     async def test_concurrent(self):
-        funcs = [
-            lambda: _FakeScraper().scrape_async(query="q", delay=0.2)
-            for _ in range(4)
-        ]
+        funcs = [lambda: _FakeScraper().scrape_async(query="q", delay=0.2) for _ in range(4)]
         start = time.monotonic()
         await scrape_all_async(funcs, max_concurrency=4)
         assert time.monotonic() - start < 0.6

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -15,6 +15,12 @@ from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
 
 
+@pytest.fixture
+def anyio_backend():
+    # Run @pytest.mark.anyio tests on asyncio only (avoids needing trio).
+    return "asyncio"
+
+
 class _FakeScraper(BaseScraper):
     """A scraper that sleeps briefly and echoes its query, for timing tests."""
 
@@ -105,6 +111,30 @@ class TestScrapeManyAsync:
         elapsed = time.monotonic() - start
         assert len(results) == 4
         assert elapsed < 0.6
+
+    async def test_respects_max_concurrency(self):
+        """max_concurrency must actually cap in-flight scrapes, not just run fast
+        (a timing test with max_concurrency == len(calls) would pass either way)."""
+        in_flight = 0
+        max_seen = 0
+
+        class _CountingScraper(_FakeScraper):
+            async def scrape_async(self, query: str = "", delay: float = 0.05) -> ScrapeResult:
+                nonlocal in_flight, max_seen
+                in_flight += 1
+                max_seen = max(max_seen, in_flight)
+                try:
+                    await asyncio.sleep(delay)
+                    return await super().scrape_async(query=query)
+                finally:
+                    in_flight -= 1
+
+        await scrape_many_async(
+            _CountingScraper,
+            [{"query": str(i)} for i in range(6)],
+            max_concurrency=2,
+        )
+        assert max_seen <= 2  # never more than the cap in flight at once
 
 
 @pytest.mark.anyio

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,11 +1,16 @@
 """Tests for pyscrappy.concurrent (scrape_many / scrape_all)."""
 
 import time
-
-from pyscrappy.concurrent import scrape_all, scrape_many
+import asyncio
+import pytest
 from pyscrappy.core.base import BaseScraper
 from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
-
+from pyscrappy.concurrent import (
+    scrape_all,
+    scrape_all_async,
+    scrape_many,
+    scrape_many_async,
+)
 
 class _FakeScraper(BaseScraper):
     """A scraper that sleeps briefly and echoes its query, for timing tests."""
@@ -15,6 +20,18 @@ class _FakeScraper(BaseScraper):
     def scrape(self, query: str = "", delay: float = 0.0) -> ScrapeResult:  # type: ignore[override]
         if delay:
             time.sleep(delay)
+        return ScrapeResult(
+            data=[{"query": query}],
+            metadata=ScrapeMetadata(scraper=self.name),
+        )
+    
+    async def scrape_async(
+        self,
+        query: str = "",
+        delay: float = 0.0,
+    ) -> ScrapeResult:
+        if delay:
+            await asyncio.sleep(delay)
         return ScrapeResult(
             data=[{"query": query}],
             metadata=ScrapeMetadata(scraper=self.name),
@@ -45,6 +62,7 @@ class TestScrapeMany:
         assert elapsed < 0.6  # well under the 0.8s serial time
 
 
+
 class TestScrapeAll:
     def test_runs_all_and_preserves_order(self):
         funcs = [
@@ -61,4 +79,50 @@ class TestScrapeAll:
         funcs = [lambda: _FakeScraper().scrape(query="q", delay=0.2) for _ in range(4)]
         start = time.monotonic()
         scrape_all(funcs, max_workers=4)
+        assert time.monotonic() - start < 0.6
+
+
+@pytest.mark.anyio
+class TestScrapeManyAsync:
+    async def test_order_preserved(self):
+        calls = [{"query": q} for q in ["x", "y", "z"]]
+        results = await scrape_many_async(_FakeScraper, calls)
+        assert [r.data[0]["query"] for r in results] == ["x", "y", "z"]
+
+    async def test_empty_calls(self):
+        assert await scrape_many_async(_FakeScraper, []) == []
+
+    async def test_actually_concurrent(self):
+        calls = [{"query": str(i), "delay": 0.2} for i in range(4)]
+        start = time.monotonic()
+        results = await scrape_many_async(
+            _FakeScraper,
+            calls,
+            max_concurrency=4,
+        )
+        elapsed = time.monotonic() - start
+        assert len(results) == 4
+        assert elapsed < 0.6
+
+
+@pytest.mark.anyio
+class TestScrapeAllAsync:
+    async def test_runs_all_and_preserves_order(self):
+        funcs = [
+            lambda: _FakeScraper().scrape_async(query="one"),
+            lambda: _FakeScraper().scrape_async(query="two"),
+        ]
+        results = await scrape_all_async(funcs)
+        assert [r.data[0]["query"] for r in results] == ["one", "two"]
+
+    async def test_empty(self):
+        assert await scrape_all_async([]) == []
+
+    async def test_concurrent(self):
+        funcs = [
+            lambda: _FakeScraper().scrape_async(query="q", delay=0.2)
+            for _ in range(4)
+        ]
+        start = time.monotonic()
+        await scrape_all_async(funcs, max_concurrency=4)
         assert time.monotonic() - start < 0.6


### PR DESCRIPTION
## Summary

Adds native async concurrency helpers that mirror the existing synchronous helpers.

### Changes

- Add `scrape_many_async()`
- Add `scrape_all_async()`
- Preserve input order using `asyncio.gather()`
- Bound concurrency using `asyncio.Semaphore`
- Add async tests covering:
  - result ordering
  - concurrent execution
  - empty input handling
- Existing synchronous helpers remain unchanged.

### Validation

- ✅ `python -m pytest`
- ✅ All 413 tests passed

Fixes #71