### PR TITLE
fix(image_search): return one consistent result schema across engines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.4.4"
+version = "1.4.5"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.4.4",
+  "version": "1.4.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -102,7 +102,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -261,7 +261,7 @@ async def scrape_news(
 async def search_images(query: str, max_images: int = 20, engine: str = "bing") -> ScrapeToolResult:
     """Search the web for images and return a list of result objects with image URLs and metadata.
 
-    Each result is a dict with keys: "image_url" (direct link to the image), "thumbnail_url" (small preview), "source_url" (page the image was found on), "title" (caption or alt text), "width", and "height" (pixels). Results are returned in the engine's relevance order.
+    Each result is a dict with keys: "url" (direct link to the image), "thumbnail" (small preview), "title" (caption or alt text), "source_page" (page the image was found on), "width", and "height" (pixels). Every engine returns this same key set; fields a given engine can't provide are empty ("" for text, null for width/height — e.g. the Google path fills only "url", "title", and "source_page"). Results are returned in the engine's relevance order.
 
     Behavior:
         Issues a live query to the chosen search engine over the network, so results vary by engine, region, and time. No files are downloaded and no browser is launched; only metadata and URLs are returned. Returns an empty list if the query matches nothing or the engine returns no results.
@@ -272,7 +272,7 @@ async def search_images(query: str, max_images: int = 20, engine: str = "bing") 
         engine: String naming the search engine, one of "bing" or "google", e.g. "google". Defaults to "bing".
 
     Usage Guidelines:
-        Use when you need image URLs or dimensions rather than a downloaded file; the returned "image_url" values can be fetched or passed to a downloader tool afterward. Raise max_images cautiously since larger values are slower and some engines cap the total available results.
+        Use when you need image URLs or dimensions rather than a downloaded file; the returned "url" values can be fetched or passed to a downloader tool afterward. Raise max_images cautiously since larger values are slower and some engines cap the total available results.
     """
     with ImageSearchScraper(_config()) as iss:
         return await _run(iss.scrape, query=query, max_images=max_images, engine=engine)

--- a/src/pyscrappy/scrapers/image_search.py
+++ b/src/pyscrappy/scrapers/image_search.py
@@ -14,6 +14,30 @@ from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
 logger = logging.getLogger("pyscrappy.image_search")
 
 
+def _image_record(
+    url: str,
+    *,
+    title: str = "",
+    thumbnail: str = "",
+    source_page: str = "",
+    width: Any = None,
+    height: Any = None,
+) -> dict[str, Any]:
+    """Build one image result with the canonical key set.
+
+    Every engine/path returns this same shape so callers can rely on it; fields a
+    particular path can't populate are left empty ("" for text, None for numbers).
+    """
+    return {
+        "url": url,
+        "thumbnail": thumbnail,
+        "title": title,
+        "source_page": source_page,
+        "width": width,
+        "height": height,
+    }
+
+
 class ImageSearchScraper(BaseScraper):
     """Search for images and optionally download them.
 
@@ -133,14 +157,14 @@ class ImageSearchScraper(BaseScraper):
                 continue
 
             images.append(
-                {
-                    "url": img_url,
-                    "thumbnail": m_data.get("turl", ""),
-                    "title": m_data.get("t", ""),
-                    "source_page": m_data.get("purl", ""),
-                    "width": m_data.get("mw"),
-                    "height": m_data.get("mh"),
-                }
+                _image_record(
+                    img_url,
+                    thumbnail=m_data.get("turl", ""),
+                    title=m_data.get("t", ""),
+                    source_page=m_data.get("purl", ""),
+                    width=m_data.get("mw"),
+                    height=m_data.get("mh"),
+                )
             )
 
             if len(images) >= max_images:
@@ -151,12 +175,7 @@ class ImageSearchScraper(BaseScraper):
             for img in soup.find_all("img", src=True):
                 src = str(img["src"])
                 if src.startswith("http") and "bing.com/th" not in src:
-                    images.append(
-                        {
-                            "url": src,
-                            "alt": img.get("alt", ""),
-                        }
-                    )
+                    images.append(_image_record(src, title=img.get("alt", ""), source_page=url))
                     if len(images) >= max_images:
                         break
 
@@ -187,12 +206,7 @@ class ImageSearchScraper(BaseScraper):
             # Skip Google's tracking pixel and logo
             if not src.startswith("http") or "google.com/images" in src:
                 continue
-            images.append(
-                {
-                    "url": src,
-                    "alt": img.get("alt", ""),
-                }
-            )
+            images.append(_image_record(src, title=img.get("alt", ""), source_page=url))
             if len(images) >= max_images:
                 break
 

--- a/tests/test_scrapers/test_other.py
+++ b/tests/test_scrapers/test_other.py
@@ -158,6 +158,31 @@ class TestImageSearchScraper:
         assert all("example.com" in d["url"] for d in result.data)
         scraper.close()
 
+    def test_both_engines_return_the_same_key_set(self):
+        """Every engine emits the canonical schema, so callers can rely on the
+        same keys regardless of engine (the Google path just leaves some empty)."""
+        expected = {"url", "thumbnail", "title", "source_page", "width", "height"}
+
+        bing = ImageSearchScraper()
+        bing._http = MagicMock()
+        bing._http.get_html.return_value = BING_HTML
+        bing_result = bing.scrape(query="q", engine="bing")
+        bing.close()
+
+        google = ImageSearchScraper()
+        google._http = MagicMock()
+        google._http.get_html.return_value = GOOGLE_HTML
+        google_result = google.scrape(query="q", engine="google")
+        google.close()
+
+        assert bing_result.data and google_result.data
+        for item in bing_result.data + google_result.data:
+            assert set(item.keys()) == expected
+
+        # the Google path can't populate every field, but the keys still exist
+        g = google_result.data[0]
+        assert g["url"] and g["thumbnail"] == "" and g["width"] is None
+
     def test_max_images_limit(self):
         scraper = ImageSearchScraper()
         mock_http = MagicMock()


### PR DESCRIPTION
search_images emitted different dict shapes per engine — Bing-primary had url/thumbnail/title/source_page/width/height, while Google and the Bing fallback returned only url/alt. The MCP docstring described a third set (image_url/thumbnail_url/source_url) that no path emitted. Normalize every path through a shared _image_record() helper so all engines return the same keys, fold the undocumented alt into title, rewrite the docstring, and bump to 1.4.5. Closes #104.