### PR TITLE
fix(TableExtractor): keep ragged rows instead of silently dropping them (#105)

### DIFF
--- a/src/pyscrappy/generic/extractors.py
+++ b/src/pyscrappy/generic/extractors.py
@@ -191,15 +191,22 @@ class TableExtractor:
             if not headers:
                 continue
 
-            # Parse data rows
+            # Parse data rows. Real tables are ragged: a row may have fewer
+            # cells than the header (missing trailing values) or more (an extra
+            # actions column, colspans). Align by position instead of dropping
+            # the row — missing cells become "", and any surplus cells are kept
+            # under positional keys ("column_N") so no scraped data is lost.
             table_data: list[dict[str, str]] = []
             for row in rows[1:]:
                 cells = row.find_all(["td", "th"])
-                if len(cells) != len(headers):
+                if not cells:
                     continue
+                values = [cell.get_text(strip=True) for cell in cells]
                 row_dict = {}
-                for header, cell in zip(headers, cells):
-                    row_dict[header] = cell.get_text(strip=True)
+                for i, header in enumerate(headers):
+                    row_dict[header] = values[i] if i < len(values) else ""
+                for i in range(len(headers), len(values)):
+                    row_dict[f"column_{i + 1}"] = values[i]
                 table_data.append(row_dict)
 
             if table_data:

--- a/tests/test_generic/test_extractors.py
+++ b/tests/test_generic/test_extractors.py
@@ -314,7 +314,9 @@ class TestTableExtractor:
         result = self.extractor.extract(soup)
         assert len(result) == 2
 
-    def test_skips_rows_with_wrong_column_count(self):
+    def test_keeps_short_rows_padding_missing_cells(self):
+        # A row with fewer cells than the header is kept, not dropped: the
+        # missing trailing columns become "" so the row still appears. #105
         soup = _soup(
             "<html><body><table>"
             "<tr><th>A</th><th>B</th></tr>"
@@ -324,8 +326,22 @@ class TestTableExtractor:
         )
         result = self.extractor.extract(soup)
         assert len(result) == 1
-        assert len(result[0]) == 1
-        assert result[0][0] == {"A": "2", "B": "3"}
+        assert len(result[0]) == 2
+        assert result[0][0] == {"A": "1", "B": ""}
+        assert result[0][1] == {"A": "2", "B": "3"}
+
+    def test_keeps_long_rows_under_positional_keys(self):
+        # A row with more cells than the header keeps the surplus values under
+        # positional keys instead of silently discarding them. #105
+        soup = _soup(
+            "<html><body><table>"
+            "<tr><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td><td>extra</td></tr>"
+            "</table></body></html>"
+        )
+        result = self.extractor.extract(soup)
+        assert len(result) == 1
+        assert result[0][0] == {"A": "1", "B": "2", "column_3": "extra"}
 
     def test_empty_table_skipped(self):
         soup = _soup("<html><body><table></table></body></html>")


### PR DESCRIPTION
Real-world tables are ragged: rows can have fewer cells than the header (missing trailing values) or more (an extra actions column, colspans). The extractor dropped any such row on a cell-count mismatch, so data vanished with no signal.

Align cells to headers by position: short rows pad the missing columns with "", and surplus cells are preserved under positional keys (column_N) so nothing scraped is thrown away. Rewrote the old skip-on-mismatch test into short-row and long-row cases.

Closes #105