### PR TITLE
fix(hackernews): docs say num_comments, matching the emitted key (#106)

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -400,7 +400,7 @@ async def search_hackernews(
     by: str = "relevance",
     tags: str = "story",
 ) -> ScrapeToolResult:
-    """Search Hacker News stories and return a list of matching story dicts, each with title, url, points, author (username), and comments (comment count).
+    """Search Hacker News stories and return a list of matching story dicts, each with title, url, points, author (username), and num_comments (comment count).
 
     Queries the public Hacker News search index (Algolia HN API) over the network; makes no local changes. Returns an empty list when nothing matches or the query is empty.
 
@@ -410,7 +410,7 @@ async def search_hackernews(
         by: Result ordering; type: string; one of "relevance" or "date" ("date" sorts most recent first); example: "date"; default: "relevance".
         tags: Algolia HN tag filter; type: string; common values "story", "comment", "show_hn", "ask_hn", "poll", "job"; example: "show_hn"; default: "story".
 
-    Use this to pull real Hacker News discussion for a topic; prefer by="date" for breaking or time-sensitive topics and by="relevance" (default) otherwise, and use the returned url and comments fields to link out or gauge engagement. Set tags to narrow to Show HN, Ask HN, comments, etc.
+    Use this to pull real Hacker News discussion for a topic; prefer by="date" for breaking or time-sensitive topics and by="relevance" (default) otherwise, and use the returned url and num_comments fields to link out or gauge engagement. Set tags to narrow to Show HN, Ask HN, comments, etc.
     """
     with HackerNewsScraper(_config()) as hn:
         return await _run(hn.scrape, query=query, max_results=max_results, by=by, tags=tags)

--- a/src/pyscrappy/scrapers/hackernews.py
+++ b/src/pyscrappy/scrapers/hackernews.py
@@ -49,7 +49,7 @@ class HackerNewsScraper(BaseScraper):
             tags: HN tag filter, e.g. ``"story"``, ``"comment"``, ``"show_hn"``.
 
         Returns:
-            ScrapeResult with story data (title, url, points, author, comments, …).
+            ScrapeResult with story data (title, url, points, author, num_comments, …).
         """
         url = self._build_url(query, max_results, by, tags)
 

--- a/tests/test_scrapers/test_api_scrapers.py
+++ b/tests/test_scrapers/test_api_scrapers.py
@@ -85,6 +85,10 @@ class TestHackerNews:
         assert story["title"] == "Show HN: PyScrappy"
         assert story["points"] == 42
         assert story["hn_url"] == "https://news.ycombinator.com/item?id=12345"
+        # The comment count is emitted under "num_comments" (the Algolia field
+        # name the docstrings promise), not "comments". #106
+        assert story["num_comments"] == 7
+        assert "comments" not in story
 
     def test_by_date_uses_date_endpoint(self):
         s = _with(HackerNewsScraper(), json.dumps({"hits": []}))


### PR DESCRIPTION
The scraper emits the comment count under 'num_comments' (the Algolia HN field name), but the sync docstring, the MCP tool description, and its usage hint all called the field 'comments'. Anyone reading the docs would look for a key that isn't there.

Align the three doc sites to the real key. Left the 'comment' tags filter value alone (that one is correct). Added assertions to the HN parse test that lock the key to 'num_comments' and that 'comments' is absent.

Closes #106 