### PR TITLE
fix(http): prevent cache-key collision from unescaped param values

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -219,7 +219,7 @@ class AsyncHttpClient:
             items = sorted((str(k), str(v)) for k, v in dict(params).items())
         except (TypeError, ValueError):
             return url
-        return url + "?" + "&".join(f"{k}={v}" for k, v in items)
+        return url + "?" + urlencode(items)
 
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -219,7 +219,8 @@ class AsyncHttpClient:
             items = sorted((str(k), str(v)) for k, v in dict(params).items())
         except (TypeError, ValueError):
             return url
-        return url + "?" + urlencode(items)
+        sep = "&" if "?" in url else "?"
+        return url + sep + urlencode(items)
 
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -259,7 +259,8 @@ class HttpClient:
             items = sorted((str(k), str(v)) for k, v in dict(params).items())
         except (TypeError, ValueError):
             return url
-        return url + "?" + urlencode(items)
+        sep = "&" if "?" in url else "?"
+        return url + sep + urlencode(items)
 
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -259,7 +259,7 @@ class HttpClient:
             items = sorted((str(k), str(v)) for k, v in dict(params).items())
         except (TypeError, ValueError):
             return url
-        return url + "?" + "&".join(f"{k}={v}" for k, v in items)
+        return url + "?" + urlencode(items)
 
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -140,3 +140,13 @@ def test_async_cache_key_does_not_collide_on_special_chars():
     key_a = client._cache_key("http://x", {"a": "1&b=2"})
     key_b = client._cache_key("http://x", {"a": "1", "b": "2"})
     assert key_a != key_b
+
+
+def test_async_cache_key_handles_url_with_existing_query_string():
+    # A URL that already has a "?" must not collide with an equivalent
+    # url+params combination once params are appended (#116 review).
+    client = AsyncHttpClient(ScraperConfig(rate_limit=0))
+    key_a = client._cache_key("http://x?a=1", {"b": "2"})
+    key_b = client._cache_key("http://x?a=1?b=2", None)
+    assert key_a != key_b
+    assert key_a == "http://x?a=1&b=2"

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -132,3 +132,11 @@ async def test_scrape_async_extracts_page_data(monkeypatch):
     assert result.metadata.scraper == "generic"
     assert result.data  # extracted a page
     assert result.metadata.source_urls == ["https://example.com"]
+
+
+def test_async_cache_key_does_not_collide_on_special_chars():
+    # Same collision guard for the async client's _cache_key (#114).
+    client = AsyncHttpClient(ScraperConfig(rate_limit=0))
+    key_a = client._cache_key("http://x", {"a": "1&b=2"})
+    key_b = client._cache_key("http://x", {"a": "1", "b": "2"})
+    assert key_a != key_b

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -388,6 +388,16 @@ class TestHttpClientCaching:
         assert key_a != key_b
         client.close()
 
+    def test_cache_key_handles_url_with_existing_query_string(self):
+        # A URL that already has a "?" must not collide with an equivalent
+        # url+params combination once params are appended (#116 review).
+        client = HttpClient(ScraperConfig(rate_limit=0))
+        key_a = client._cache_key("http://x?a=1", {"b": "2"})
+        key_b = client._cache_key("http://x?a=1?b=2", None)
+        assert key_a != key_b
+        assert key_a == "http://x?a=1&b=2"
+        client.close()
+
     def test_clear_cache_forces_refetch(self):
         client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get("https://example.com")

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -380,6 +380,14 @@ class TestHttpClientCaching:
         assert mock_httpx.get.call_count == 2
         client.close()
 
+    def test_cache_key_does_not_collide_on_special_chars(self):
+        # A value containing & or = must not alias to a different param set (#114).
+        client = HttpClient(ScraperConfig(rate_limit=0))
+        key_a = client._cache_key("http://x", {"a": "1&b=2"})
+        key_b = client._cache_key("http://x", {"a": "1", "b": "2"})
+        assert key_a != key_b
+        client.close()
+
     def test_clear_cache_forces_refetch(self):
         client, mock_httpx = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60))
         client.get("https://example.com")


### PR DESCRIPTION
_cache_key hand-joined params with "&" and "=", so a param value containing those characters could alias a different param set to the same cache key (e.g. {"a": "1&b=2"} vs {"a": "1", "b": "2"}). Use urlencode() instead, which percent-escapes reserved characters.

Fixes #114