### PR TITLE
fix: escape Markdown table cells

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -100,13 +100,23 @@ class ScrapeResult:
     def _table_to_markdown(rows: list[dict[str, Any]]) -> str:
         if not rows:
             return ""
+
+        def escape_cell(value: Any) -> str:
+            return (
+                str(value)
+                .replace("\\", "\\\\")
+                .replace("|", "\\|")
+                .replace("\n", "<br>")
+                .replace("\r", "")
+            )
+
         headers = list(rows[0].keys())
         lines = [
-            "| " + " | ".join(headers) + " |",
+            "| " + " | ".join(escape_cell(header) for header in headers) + " |",
             "| " + " | ".join("---" for _ in headers) + " |",
         ]
         for row in rows:
-            lines.append("| " + " | ".join(str(row.get(h, "")) for h in headers) + " |")
+            lines.append("| " + " | ".join(escape_cell(row.get(h, "")) for h in headers) + " |")
         return "\n".join(lines)
 
     def to_json(self, indent: int = 2) -> str:

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -145,6 +145,20 @@ class TestScrapeResult:
         assert "| Name | Age |" in md
         assert "| Alice | 30 |" in md
 
+    def test_to_markdown_escapes_table_cells(self):
+        result = ScrapeResult(
+            data=[
+                {
+                    "text": {"text": "", "headings": []},
+                    "tables": [[{"Name|Path": "Alice|C:\\Users\r\nAdmin"}]],
+                }
+            ]
+        )
+
+        assert result.to_markdown() == (
+            "| Name\\|Path |\n| --- |\n| Alice\\|C:\\\\Users<br>Admin |"
+        )
+
     def test_to_markdown_separates_items(self):
         result = ScrapeResult(data=[{"a": "1"}, {"a": "2"}])
         assert "\n\n---\n\n" in result.to_markdown()


### PR DESCRIPTION
## Summary

- escape literal backslashes and Markdown pipe delimiters in table headers and values
- convert embedded newlines to `<br>` and remove carriage returns so each record stays on one physical Markdown row
- add an exact regression test covering header pipes, value pipes, a literal path separator, and CRLF input

Fixes #115.

## Testing

- `pytest tests/test_core/test_models.py -v` (24 passed)
- `pytest tests/ -v` (421 passed, 19 integration tests deselected)
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `git diff --check`
