### PR TITLE
fix: document async YouTube scraper limitations

### DIFF
--- a/src/pyscrappy/scrapers/youtube.py
+++ b/src/pyscrappy/scrapers/youtube.py
@@ -66,7 +66,12 @@ class YouTubeScraper(BaseScraper):
         channel_url: str | None = None,
         max_results: int = 20,
     ) -> ScrapeResult:
-        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        """Async counterpart to :meth:`scrape`.
+
+        The async path uses plain HTTP and does not support JavaScript rendering
+        or scrolling. Use :meth:`scrape` with ``render_js=True`` and
+        ``scroll_pages`` for JS-rendered channel pages.
+        """
         if channel_url:
             return await self._scrape_channel_async(channel_url, max_results)
         if query:

--- a/tests/test_scrapers/test_async_scrapers.py
+++ b/tests/test_scrapers/test_async_scrapers.py
@@ -22,6 +22,7 @@ from pyscrappy.scrapers.crypto import CryptoScraper
 from pyscrappy.scrapers.stock import StockScraper
 from pyscrappy.scrapers.twitter import TwitterScraper
 from pyscrappy.scrapers.ubereats import UberEatsScraper
+from pyscrappy.scrapers.youtube import YouTubeScraper
 
 
 @pytest.fixture
@@ -38,6 +39,20 @@ def _mock_async_http(scraper, *html_responses):
     scraper._async_http = mock
     return scraper, mock
 
+@pytest.mark.anyio
+async def test_youtube_scrape_async_uses_plain_http():
+    s, mock = _mock_async_http(
+        YouTubeScraper(),
+        "<html><body>nothing here</body></html>",
+    )
+
+    result = await s.scrape_async(
+        channel_url="https://www.youtube.com/@example/videos",
+        max_results=5,
+    )
+
+    assert mock.get_html.await_count == 1
+    assert result.metadata.scraper == "youtube"
 
 @pytest.mark.anyio
 async def test_crypto_scrape_async_top_coins():

--- a/tests/test_scrapers/test_async_scrapers.py
+++ b/tests/test_scrapers/test_async_scrapers.py
@@ -39,6 +39,7 @@ def _mock_async_http(scraper, *html_responses):
     scraper._async_http = mock
     return scraper, mock
 
+
 @pytest.mark.anyio
 async def test_youtube_scrape_async_uses_plain_http():
     s, mock = _mock_async_http(
@@ -53,6 +54,7 @@ async def test_youtube_scrape_async_uses_plain_http():
 
     assert mock.get_html.await_count == 1
     assert result.metadata.scraper == "youtube"
+
 
 @pytest.mark.anyio
 async def test_crypto_scrape_async_top_coins():

--- a/tests/test_scrapers/test_async_scrapers.py
+++ b/tests/test_scrapers/test_async_scrapers.py
@@ -41,19 +41,28 @@ def _mock_async_http(scraper, *html_responses):
 
 
 @pytest.mark.anyio
-async def test_youtube_scrape_async_uses_plain_http():
-    s, mock = _mock_async_http(
-        YouTubeScraper(),
-        "<html><body>nothing here</body></html>",
+async def test_youtube_scrape_async_extracts_from_plain_http():
+    # The async path fetches over plain HTTP (no browser) and still extracts
+    # videos from the ytInitialData embedded in the returned HTML (#113). A
+    # minimal payload with one videoRenderer is enough to prove extraction works
+    # and doesn't silently return empty.
+    channel_url = "https://www.youtube.com/@example/videos"
+    yt_data = json.dumps(
+        {"videoRenderer": {"videoId": "abc123", "title": {"runs": [{"text": "Hello World"}]}}}
     )
+    html = f"<html><body><script>var ytInitialData = {yt_data};</script></body></html>"
+    s, mock = _mock_async_http(YouTubeScraper(), html)
 
-    result = await s.scrape_async(
-        channel_url="https://www.youtube.com/@example/videos",
-        max_results=5,
-    )
+    result = await s.scrape_async(channel_url=channel_url, max_results=5)
 
+    # Fetched exactly the channel URL over the async HTTP client (no browser).
     assert mock.get_html.await_count == 1
+    assert mock.get_html.await_args.args[0] == channel_url
     assert result.metadata.scraper == "youtube"
+    # Extraction actually produced the video, rather than an empty list.
+    assert len(result.data) == 1
+    assert result.data[0]["title"] == "Hello World"
+    assert result.data[0]["url"] == "https://www.youtube.com/watch?v=abc123"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Clarify that `scrape_async` uses plain HTTP only.
- Document that JavaScript rendering and scrolling are not supported in the async path.
- Add a small regression test for async YouTube channel scraping.

## Testing

- `py -m pytest tests/test_scrapers/test_async_scrapers.py -q`
- 8 passed

Closes #113 