### PR TITLE
fix: update scrape_stock docstring to match actual scraper output keys

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -201,9 +201,9 @@ async def scrape_stock(
     """Fetch stock market data from Yahoo Finance and return it as a dict.
 
     The returned shape depends on `mode`:
-      - "quote": {"symbol", "price", "currency", "change", "change_percent", "market_time"}.
+      - "quote":   {"symbol", "currency", "exchange", "price", "previous_close", "volume", "day_high", "day_low", "fifty_two_week_high", "fifty_two_week_low"}.
       - "history": {"symbol", "period", "rows": [{"date", "open", "high", "low", "close", "volume"}, ...]}.
-      - "profile": {"symbol", "name", "sector", "industry", "country", "website", "summary"}.
+      - "profile": {"symbol", "name", "currency", "exchange", "market", "timezone", "instrument_type"}.
 
     Behavior:
         Makes a live network request to Yahoo Finance on each call; no browser is

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -73,27 +73,60 @@ def test_scrape_stock_docstring_fields_match_actual_output():
 
     QUOTE_JSON = {
         "chart": {
-            "result": [{
-                "meta": {
-                    "symbol": "AAPL", "currency": "USD", "exchangeName": "NMS",
-                    "regularMarketPrice": 175.50, "chartPreviousClose": 174.20,
-                    "regularMarketVolume": 50000000, "regularMarketDayHigh": 176.00,
-                    "regularMarketDayLow": 173.80, "fiftyTwoWeekHigh": 199.62,
-                    "fiftyTwoWeekLow": 124.17,
+            "result": [
+                {
+                    "meta": {
+                        "symbol": "AAPL",
+                        "currency": "USD",
+                        "exchangeName": "NMS",
+                        "regularMarketPrice": 175.50,
+                        "chartPreviousClose": 174.20,
+                        "regularMarketVolume": 50000000,
+                        "regularMarketDayHigh": 176.00,
+                        "regularMarketDayLow": 173.80,
+                        "fiftyTwoWeekHigh": 199.62,
+                        "fiftyTwoWeekLow": 124.17,
+                    }
                 }
-            }]
+            ]
         }
     }
     PROFILE_JSON = {
         "chart": {
-            "result": [{
-                "meta": {
-                    "symbol": "AAPL", "longName": "Apple Inc.", "currency": "USD",
-                    "exchangeName": "NMS", "market": "us_market",
-                    "exchangeTimezoneName": "America/New_York",
-                    "instrumentType": "EQUITY",
+            "result": [
+                {
+                    "meta": {
+                        "symbol": "AAPL",
+                        "longName": "Apple Inc.",
+                        "currency": "USD",
+                        "exchangeName": "NMS",
+                        "market": "us_market",
+                        "exchangeTimezoneName": "America/New_York",
+                        "instrumentType": "EQUITY",
+                    }
                 }
-            }]
+            ]
+        }
+    }
+    HISTORY_JSON = {
+        "chart": {
+            "result": [
+                {
+                    "meta": {"symbol": "AAPL"},
+                    "timestamp": [1704067200],
+                    "indicators": {
+                        "quote": [
+                            {
+                                "open": [174.0],
+                                "high": [176.0],
+                                "low": [173.0],
+                                "close": [175.0],
+                                "volume": [50000000],
+                            }
+                        ]
+                    },
+                }
+            ]
         }
     }
 
@@ -119,7 +152,11 @@ def test_scrape_stock_docstring_fields_match_actual_output():
     actual_profile_keys = set(result2.data[0].keys())
     scraper2.close()
 
-    history_result_keys = {"date", "open", "high", "low", "close", "volume"}
+    scraper3 = StockScraper()
+    scraper3._http = _mock_http(HISTORY_JSON)
+    result3 = scraper3.scrape(symbol="AAPL", mode="history")
+    actual_history_keys = set(result3.data[0].keys())
+    scraper3.close()
 
     doc = server.scrape_stock.__doc__ or ""
     quote_match = re.search(r'"quote":\s*(\{[^}]+\})', doc)
@@ -143,6 +180,6 @@ def test_scrape_stock_docstring_fields_match_actual_output():
     doc_history_keys = {
         k.strip().strip('"') for k in doc_history_match.group(1).strip("{}").split(",")
     }
-    assert doc_history_keys == history_result_keys, (
-        f"docstring history row keys {sorted(doc_history_keys)} != expected {sorted(history_result_keys)}"
+    assert doc_history_keys == actual_history_keys, (
+        f"docstring history row keys {sorted(doc_history_keys)} != actual {sorted(actual_history_keys)}"
     )

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -62,3 +62,87 @@ def test_search_images_doc_does_not_advertise_duckduckgo():
     assert "duckduckgo" not in doc.lower()
     assert "bing" in doc.lower()
     assert "google" in doc.lower()
+
+
+def test_scrape_stock_docstring_fields_match_actual_output():
+    """The quote/profile field lists in scrape_stock's docstring must match
+    what _build_quote and _build_profile actually return."""
+    import re
+
+    from pyscrappy.scrapers.stock import StockScraper
+
+    QUOTE_JSON = {
+        "chart": {
+            "result": [{
+                "meta": {
+                    "symbol": "AAPL", "currency": "USD", "exchangeName": "NMS",
+                    "regularMarketPrice": 175.50, "chartPreviousClose": 174.20,
+                    "regularMarketVolume": 50000000, "regularMarketDayHigh": 176.00,
+                    "regularMarketDayLow": 173.80, "fiftyTwoWeekHigh": 199.62,
+                    "fiftyTwoWeekLow": 124.17,
+                }
+            }]
+        }
+    }
+    PROFILE_JSON = {
+        "chart": {
+            "result": [{
+                "meta": {
+                    "symbol": "AAPL", "longName": "Apple Inc.", "currency": "USD",
+                    "exchangeName": "NMS", "market": "us_market",
+                    "exchangeTimezoneName": "America/New_York",
+                    "instrumentType": "EQUITY",
+                }
+            }]
+        }
+    }
+
+    def _mock_http(json_data):
+        mock_http = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = json_data
+        mock_response.text = "crumb"
+        mock_response.cookies = {}
+        mock_http.get_raw.return_value = mock_response
+        return mock_http
+
+    scraper = StockScraper()
+    scraper._http = _mock_http(QUOTE_JSON)
+    result = scraper.scrape(symbol="AAPL", mode="quote")
+    actual_quote_keys = set(result.data[0].keys())
+    scraper.close()
+
+    scraper2 = StockScraper()
+    scraper2._http = _mock_http(PROFILE_JSON)
+    result2 = scraper2.scrape(symbol="AAPL", mode="profile")
+    actual_profile_keys = set(result2.data[0].keys())
+    scraper2.close()
+
+    history_result_keys = {"date", "open", "high", "low", "close", "volume"}
+
+    doc = server.scrape_stock.__doc__ or ""
+    quote_match = re.search(r'"quote":\s*(\{[^}]+\})', doc)
+    profile_match = re.search(r'"profile":\s*(\{[^}]+\})', doc)
+    assert quote_match, "docstring missing quote field list"
+    assert profile_match, "docstring missing profile field list"
+
+    doc_quote_keys = {k.strip().strip('"') for k in quote_match.group(1).strip("{}").split(",")}
+    doc_profile_keys = {k.strip().strip('"') for k in profile_match.group(1).strip("{}").split(",")}
+
+    assert doc_quote_keys == actual_quote_keys, (
+        f"docstring quote keys {sorted(doc_quote_keys)} != actual {sorted(actual_quote_keys)}"
+    )
+    assert doc_profile_keys == actual_profile_keys, (
+        f"docstring profile keys {sorted(doc_profile_keys)} != actual {sorted(actual_profile_keys)}"
+    )
+    # Verify history shape is also listed as expected.
+    assert "history" in doc.lower()
+    doc_history_match = re.search(r'"rows":\s*\[(\{[^}]+\})', doc)
+    assert doc_history_match is not None
+    doc_history_keys = {
+        k.strip().strip('"') for k in doc_history_match.group(1).strip("{}").split(",")
+    }
+    assert doc_history_keys == history_result_keys, (
+        f"docstring history row keys {sorted(doc_history_keys)} != expected {sorted(history_result_keys)}"
+    )


### PR DESCRIPTION
Fixes #112.

The `scrape_stock` MCP tool docstring advertised `quote` and `profile` field lists that didn't match what `_build_quote` and `_build_profile` actually return:

**Quote** (spec/actual):
- `symbol`, `currency`, `exchange`, `price`, `previous_close`, `volume`, `day_high`, `day_low`, `fifty_two_week_high`, `fifty_two_week_low`

**Profile** (spec/actual):
- `symbol`, `name`, `currency`, `exchange`, `market`, `timezone`, `instrument_type`

**Changes:**
- Updated `quote` and `profile` field lists in `scrape_stock`'s docstring to match the keys the scraper emits.
- Added a regression test that extracts the documented field sets from the docstring and compares them against the actual output of `_build_quote` / `_build_profile`, including the history row shape.

**Verification:**
- `ruff check src/` — all checks passed
- `python -m pytest tests/test_mcp/ tests/test_scrapers/test_stock.py -v` — 34 passed