### PR TITLE
fix: correct scrape_stock MCP field docs

### DIFF
--- a/src/pyscrappy/mcp/server.py
+++ b/src/pyscrappy/mcp/server.py
@@ -201,9 +201,9 @@ async def scrape_stock(
     """Fetch stock market data from Yahoo Finance and return it as a dict.
 
     The returned shape depends on `mode`:
-      - "quote": {"symbol", "price", "currency", "change", "change_percent", "market_time"}.
-      - "history": {"symbol", "period", "rows": [{"date", "open", "high", "low", "close", "volume"}, ...]}.
-      - "profile": {"symbol", "name", "sector", "industry", "country", "website", "summary"}.
+        - "quote": {"symbol", "currency", "exchange", "price", "previous_close", "volume", "day_high", "day_low", "fifty_two_week_high", "fifty_two_week_low"}.
+        - "history": {"symbol", "period", "rows": [{"date", "open", "high", "low", "close", "volume"}, ...]}.
+        - "profile": {"symbol", "name", "currency", "exchange", "market", "timezone", "instrument_type"}.
 
     Behavior:
         Makes a live network request to Yahoo Finance on each call; no browser is

--- a/tests/test_mcp/test_tool_params.py
+++ b/tests/test_mcp/test_tool_params.py
@@ -57,6 +57,19 @@ async def test_scrape_stock_forwards_interval():
     assert kwargs.get("interval") == "1wk"
 
 
+def test_scrape_stock_doc_matches_output_fields():
+    doc = server.scrape_stock.__doc__ or ""
+
+    assert (
+        '"quote": {"symbol", "currency", "exchange", "price", "previous_close", "volume", "day_high", "day_low", "fifty_two_week_high", "fifty_two_week_low"}'
+        in doc
+    )
+    assert (
+        '"profile": {"symbol", "name", "currency", "exchange", "market", "timezone", "instrument_type"}'
+        in doc
+    )
+
+
 def test_search_images_doc_does_not_advertise_duckduckgo():
     doc = server.search_images.__doc__ or ""
     assert "duckduckgo" not in doc.lower()


### PR DESCRIPTION
## Summary

- Corrected the documented `quote` fields to match `StockScraper`.
- Corrected the documented `profile` fields to match `StockScraper`.
- Added a regression test for the documented field names.

## Testing

- `py -m pytest tests/test_mcp/test_tool_params.py -q`
- `py -m ruff format --check src tests`

Closes #112