### PR TITLE
feat: add `pyscrappy extract` CLI and TLS-fingerprint impersonation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
 [project.optional-dependencies]
 browser = ["playwright>=1.40"]
 dataframe = ["pandas>=1.5"]
+# TLS-fingerprint impersonation for ScraperConfig(impersonate=...), to get past
+# anti-bot filters that block plain HTTP clients. curl_cffi ships a patched
+# libcurl, so it's an opt-in extra rather than a core dependency.
+stealth = ["curl_cffi>=0.6"]
 # The MCP SDK requires Python >=3.10. The core library still supports 3.9, so
 # gate these deps behind a marker: on 3.9 they're skipped, on 3.10+ installed.
 mcp = [
@@ -54,6 +58,7 @@ mcp = [
 all = [
     "playwright>=1.40",
     "pandas>=1.5",
+    "curl_cffi>=0.6",
     "fastmcp>=2.0; python_version >= '3.10'",
     "anyio>=4.0; python_version >= '3.10'",
 ]

--- a/src/pyscrappy/core/_stealth.py
+++ b/src/pyscrappy/core/_stealth.py
@@ -1,0 +1,150 @@
+"""TLS-fingerprint impersonation for the sync HTTP client, via ``curl_cffi``.
+
+A plain HTTP client has a recognizable TLS/JA3 fingerprint that many anti-bot
+systems block outright, before any content is served. ``curl_cffi`` speaks TLS
+the way a real browser does, so ``ScraperConfig(impersonate="chrome")`` gets past
+that class of block without a headless browser.
+
+This is an *adapter*: it wraps ``curl_cffi``'s session so it looks enough like an
+``httpx.Client`` (same ``.get``/``.post`` surface, and it raises the same
+``httpx`` exception types) that the retry/rate-limit/cache/robots machinery in
+``HttpClient`` works unchanged. ``curl_cffi`` is optional; import errors surface a
+clear install hint.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+_INSTALL_HINT = (
+    "TLS impersonation needs the optional 'curl_cffi' dependency. "
+    "Install it with: pip install 'pyscrappy[stealth]'"
+)
+
+
+def stealth_available() -> bool:
+    try:
+        import curl_cffi  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+class _StealthResponse:
+    """Wrap a curl_cffi response with the httpx surface HttpClient relies on
+    (``.text``, ``.status_code``, ``.headers``, ``.cookies``, ``raise_for_status``)."""
+
+    def __init__(self, raw: Any) -> None:
+        self._raw = raw
+
+    @property
+    def text(self) -> str:
+        return self._raw.text
+
+    @property
+    def content(self) -> bytes:
+        return self._raw.content
+
+    @property
+    def status_code(self) -> int:
+        return self._raw.status_code
+
+    @property
+    def headers(self) -> Any:
+        return self._raw.headers
+
+    @property
+    def cookies(self) -> Any:
+        return self._raw.cookies
+
+    def raise_for_status(self) -> None:
+        # Normalize to httpx.HTTPStatusError so HttpClient's except clause catches it.
+        if self.status_code >= 400:
+            request = httpx.Request("GET", str(getattr(self._raw, "url", "")))
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}", request=request, response=response
+            )
+
+
+class StealthClient:
+    """A thin ``curl_cffi`` session presenting an ``httpx.Client``-like interface.
+
+    Only the methods ``HttpClient`` calls are implemented (``get``, ``post``,
+    ``cookies``, ``close``). Connection failures are re-raised as
+    ``httpx.RequestError`` so the existing retry loop treats them identically.
+    """
+
+    def __init__(
+        self,
+        impersonate: str,
+        timeout: float,
+        verify: bool,
+        proxy: str | None = None,
+    ) -> None:
+        from curl_cffi import requests as cffi
+
+        self._cffi_errors = self._import_errors()
+        session_kwargs: dict[str, Any] = {
+            "impersonate": impersonate,
+            "timeout": timeout,
+            "verify": verify,
+        }
+        if proxy:
+            session_kwargs["proxies"] = {"http": proxy, "https": proxy}
+        self._session = cffi.Session(**session_kwargs)
+
+    @staticmethod
+    def _import_errors() -> tuple[type[Exception], ...]:
+        try:
+            from curl_cffi.requests.errors import RequestsError
+
+            return (RequestsError,)
+        except ImportError:  # older/newer curl_cffi layout
+            try:
+                from curl_cffi import CurlError
+
+                return (CurlError,)
+            except ImportError:
+                return ()
+
+    @property
+    def cookies(self) -> Any:
+        return self._session.cookies
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> _StealthResponse:
+        # httpx uses follow_redirects=; curl_cffi uses allow_redirects=.
+        if "follow_redirects" in kwargs:
+            kwargs["allow_redirects"] = kwargs.pop("follow_redirects")
+        try:
+            raw = self._session.request(method, url, **kwargs)
+        except self._cffi_errors as exc:  # network/transport failure
+            request = httpx.Request(method, url)
+            raise httpx.RequestError(str(exc), request=request) from exc
+        return _StealthResponse(raw)
+
+    def get(self, url: str, **kwargs: Any) -> _StealthResponse:
+        return self._request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> _StealthResponse:
+        return self._request("POST", url, **kwargs)
+
+    def close(self) -> None:
+        try:
+            self._session.close()
+        except Exception:  # noqa: BLE001 - closing should never raise upward
+            pass
+
+
+def build_stealth_client(
+    impersonate: str, timeout: float, verify: bool, proxy: str | None = None
+) -> StealthClient:
+    """Build a StealthClient, raising a clear error if curl_cffi isn't installed."""
+    if not stealth_available():
+        from pyscrappy.core.exceptions import PyScrappyError
+
+        raise PyScrappyError(_INSTALL_HINT)
+    return StealthClient(impersonate, timeout, verify, proxy)

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -45,6 +45,12 @@ class AsyncHttpClient:
 
     def __init__(self, config: ScraperConfig | None = None) -> None:
         self.config = config or ScraperConfig()
+        if self.config.impersonate:
+            raise NotImplementedError(
+                "config.impersonate (TLS fingerprint impersonation) is only "
+                "supported on the sync path for now; use the sync scrapers/HttpClient, "
+                "or drop impersonate for async."
+            )
         self._client: httpx.AsyncClient | None = None
         self._last_request_time: dict[str, float] = {}
         self._current_proxy: str | None = None

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -58,6 +58,12 @@ class ScraperConfig:
         cache_ttl: Seconds to cache successful GET responses in memory. ``0``
             (the default) disables caching. When set, repeated requests for the
             same URL within the TTL skip the network and the rate limiter.
+        impersonate: Impersonate a real browser's TLS/JA3 fingerprint on the
+            sync HTTP path, to get past anti-bot filters that block plain clients
+            (e.g. ``"chrome"``, ``"chrome124"``, ``"safari"``, ``"firefox"``).
+            Requires the optional ``curl_cffi`` dependency (``pip install
+            pyscrappy[stealth]``). ``None`` (the default) uses the normal httpx
+            client. Not yet supported on the async path.
     """
 
     timeout: float = 30.0
@@ -76,6 +82,7 @@ class ScraperConfig:
     headless: bool = True
     verify_ssl: bool = True
     cache_ttl: float = 0.0
+    impersonate: str | None = None
 
     def pick_proxy(self, exclude: str | None = None) -> str | None:
         """Return a single proxy URL (rotating if a list was configured)."""

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -215,9 +215,22 @@ class HttpClient:
     # -- internals --
 
     def _build_client(self) -> httpx.Client:
-        transport_kwargs: dict[str, Any] = {}
         proxy = self.config.pick_proxy(exclude=self._current_proxy)
         self._current_proxy = proxy
+        # TLS impersonation: swap httpx for a curl_cffi-backed client that mimics a
+        # real browser's fingerprint. It presents the same interface HttpClient
+        # uses (get/post/cookies/close) and raises httpx exceptions, so the retry,
+        # rate-limit, cache, and robots logic around it is unchanged.
+        if self.config.impersonate:
+            from pyscrappy.core._stealth import build_stealth_client
+
+            return build_stealth_client(
+                self.config.impersonate,
+                timeout=self.config.timeout,
+                verify=self.config.verify_ssl,
+                proxy=proxy,
+            )
+        transport_kwargs: dict[str, Any] = {}
         if proxy:
             transport_kwargs["proxy"] = proxy
         return httpx.Client(

--- a/src/pyscrappy/mcp/agent.py
+++ b/src/pyscrappy/mcp/agent.py
@@ -118,12 +118,70 @@ async def run_agent(
     return stopped
 
 
+def run_extract(
+    url: str,
+    out_path: str,
+    css_selector: str | None = None,
+    render_js: bool = False,
+) -> str:
+    """Scrape ``url`` and write the result to ``out_path``. The output format is
+    chosen from the file extension:
+
+    - ``.md``   -> Markdown (``ScrapeResult.to_markdown``)
+    - ``.json`` -> JSON (``ScrapeResult.to_json``)
+    - ``.txt``  -> extracted page text
+    - ``.html`` -> raw page HTML
+
+    With ``--css-selector`` the matched elements' text is extracted instead of the
+    whole page. Returns a short status line for the CLI to print.
+    """
+    from pyscrappy import GenericScraper, scrape
+
+    ext = out_path.rsplit(".", 1)[-1].lower() if "." in out_path else ""
+    if ext not in {"json", "md", "txt", "html"}:
+        raise ValueError(f"unsupported output extension {ext!r}; use .md, .json, .txt, or .html")
+
+    if ext == "html":
+        # Raw HTML: the structured scrape result doesn't retain the source markup,
+        # so fetch the page's HTML directly.
+        with GenericScraper() as gs:
+            content = gs.http.get_html(url)
+    else:
+        selectors = {"match": css_selector} if css_selector else None
+        result = scrape(url, selectors=selectors, render_js=render_js)
+        if ext == "json":
+            content = result.to_json()
+        elif ext == "md":
+            content = result.to_markdown()
+        else:  # txt
+            if css_selector:
+                content = "\n".join(row.get("match", "") for row in result.data)
+            else:
+                content = "\n\n".join(item.get("text", {}).get("text", "") for item in result.data)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return f"wrote {len(content)} chars to {out_path}"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="pyscrappy",
         description="Let a local LLM use PyScrappy's scrapers as tools (via Ollama).",
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    extract = sub.add_parser(
+        "extract", help="Scrape a URL straight to a file (.md/.json/.txt/.html)."
+    )
+    extract.add_argument("url", help="The URL to scrape.")
+    extract.add_argument("output", help="Output file; format inferred from its extension.")
+    extract.add_argument(
+        "--css-selector", default=None, help="Extract only elements matching this CSS selector."
+    )
+    extract.add_argument(
+        "--render-js", action="store_true", help="Render JavaScript with a browser first."
+    )
 
     chat = sub.add_parser("chat", help="Ask a local model a question it can answer with scrapers.")
     chat.add_argument("prompt", help="What to ask, in plain language.")
@@ -138,6 +196,16 @@ def main() -> None:
     chat.add_argument("--json", action="store_true", help="Print the raw scraper result as JSON.")
 
     args = parser.parse_args()
+
+    if args.command == "extract":
+        status = run_extract(
+            args.url,
+            args.output,
+            css_selector=args.css_selector,
+            render_js=args.render_js,
+        )
+        print(status)
+        return
 
     if args.command == "chat":
         import anyio

--- a/tests/test_cli/test_extract.py
+++ b/tests/test_cli/test_extract.py
@@ -1,0 +1,67 @@
+"""Tests for the `pyscrappy extract` CLI command (URL -> file)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+from pyscrappy.mcp.agent import run_extract
+
+
+def _result(data):
+    return ScrapeResult(data=data, metadata=ScrapeMetadata(source_urls=["u"], scraper="generic"))
+
+
+def test_extract_json(tmp_path):
+    out = tmp_path / "out.json"
+    with patch("pyscrappy.scrape", return_value=_result([{"a": 1}])):
+        status = run_extract("http://x", str(out))
+    text = out.read_text()
+    assert '"a": 1' in text
+    assert "wrote" in status and str(out) in status
+
+
+def test_extract_markdown(tmp_path):
+    out = tmp_path / "out.md"
+    with patch("pyscrappy.scrape", return_value=_result([{"name": "Alice", "age": "30"}])):
+        run_extract("http://x", str(out))
+    md = out.read_text()
+    assert "Alice" in md  # rendered as markdown, not JSON
+    assert "{" not in md
+
+
+def test_extract_txt_whole_page(tmp_path):
+    out = tmp_path / "out.txt"
+    data = [{"text": {"text": "hello world", "paragraphs": [], "word_count": 2}}]
+    with patch("pyscrappy.scrape", return_value=_result(data)):
+        run_extract("http://x", str(out))
+    assert out.read_text() == "hello world"
+
+
+def test_extract_txt_with_css_selector(tmp_path):
+    out = tmp_path / "out.txt"
+    # With a selector, run_extract passes selectors={"match": ...}; each row's
+    # "match" is joined by newline.
+    data = [{"match": "one"}, {"match": "two"}]
+    with patch("pyscrappy.scrape", return_value=_result(data)) as m:
+        run_extract("http://x", str(out), css_selector=".item")
+    assert out.read_text() == "one\ntwo"
+    assert m.call_args.kwargs["selectors"] == {"match": ".item"}
+
+
+def test_extract_html_fetches_raw_markup(tmp_path):
+    out = tmp_path / "out.html"
+    fake_gs = MagicMock()
+    fake_gs.__enter__.return_value = fake_gs
+    fake_gs.__exit__.return_value = False
+    fake_gs.http.get_html.return_value = "<html><body>raw</body></html>"
+    with patch("pyscrappy.GenericScraper", return_value=fake_gs):
+        run_extract("http://x", str(out))
+    assert out.read_text() == "<html><body>raw</body></html>"
+    fake_gs.http.get_html.assert_called_once_with("http://x")
+
+
+def test_extract_rejects_unknown_extension(tmp_path):
+    out = tmp_path / "out.pdf"
+    with pytest.raises(ValueError, match="unsupported output extension"):
+        run_extract("http://x", str(out))

--- a/tests/test_core/test_stealth.py
+++ b/tests/test_core/test_stealth.py
@@ -1,0 +1,100 @@
+"""Tests for TLS-impersonation wiring (ScraperConfig.impersonate).
+
+These don't require curl_cffi to be installed: the not-installed path and the
+async guard are tested directly, and the adapter wiring is tested by mocking the
+curl_cffi session the StealthClient builds.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pyscrappy.core._stealth import StealthClient, build_stealth_client, stealth_available
+from pyscrappy.core.async_http import AsyncHttpClient
+from pyscrappy.core.config import ScraperConfig
+from pyscrappy.core.exceptions import PyScrappyError
+from pyscrappy.core.http import HttpClient
+
+
+def test_build_stealth_client_errors_when_curl_cffi_missing():
+    if stealth_available():
+        pytest.skip("curl_cffi is installed; not-installed path can't be exercised")
+    with pytest.raises(PyScrappyError, match="pyscrappy\\[stealth\\]"):
+        build_stealth_client("chrome", timeout=10, verify=True)
+
+
+def test_async_client_rejects_impersonate():
+    # Async path doesn't support impersonation yet; constructing must fail loudly
+    # rather than silently ignore the setting.
+    with pytest.raises(NotImplementedError, match="sync path"):
+        AsyncHttpClient(ScraperConfig(impersonate="chrome"))
+
+
+def test_httpclient_builds_stealth_client_when_impersonate_set():
+    # When impersonate is set, HttpClient._build_client routes through the stealth
+    # adapter instead of httpx. Patch the adapter so no curl_cffi is needed.
+    cfg = ScraperConfig(impersonate="chrome", rate_limit=0)
+    client = HttpClient(cfg)
+    sentinel = MagicMock(name="stealth_client")
+    with patch("pyscrappy.core._stealth.build_stealth_client", return_value=sentinel) as b:
+        built = client._build_client()
+    assert built is sentinel
+    b.assert_called_once()
+    # impersonate value is forwarded
+    assert b.call_args.args[0] == "chrome" or b.call_args.kwargs.get("impersonate") == "chrome"
+
+
+def test_httpclient_uses_httpx_when_impersonate_unset():
+    client = HttpClient(ScraperConfig(rate_limit=0))
+    built = client._build_client()
+    assert isinstance(built, httpx.Client)
+    built.close()
+
+
+class _FakeCffiResponse:
+    def __init__(self, status_code=200, text="ok", url="http://x"):
+        self.status_code = status_code
+        self.text = text
+        self.content = text.encode()
+        self.headers = {}
+        self.cookies = {}
+        self.url = url
+
+
+def _stealth_with_fake_session(fake_session):
+    """Build a StealthClient with its curl_cffi Session swapped for a fake."""
+    sc = StealthClient.__new__(StealthClient)
+    sc._session = fake_session
+    sc._cffi_errors = (RuntimeError,)  # pretend RuntimeError is curl_cffi's error
+    return sc
+
+
+def test_stealth_response_raise_for_status_maps_to_httpx():
+    fake = MagicMock()
+    fake.request.return_value = _FakeCffiResponse(status_code=403)
+    sc = _stealth_with_fake_session(fake)
+
+    resp = sc.get("http://x", headers={}, follow_redirects=True)
+    assert resp.status_code == 403
+    with pytest.raises(httpx.HTTPStatusError):
+        resp.raise_for_status()
+
+
+def test_stealth_connection_error_maps_to_httpx_request_error():
+    fake = MagicMock()
+    fake.request.side_effect = RuntimeError("connection reset")
+    sc = _stealth_with_fake_session(fake)
+    with pytest.raises(httpx.RequestError, match="connection reset"):
+        sc.get("http://x")
+
+
+def test_stealth_translates_follow_redirects_kwarg():
+    fake = MagicMock()
+    fake.request.return_value = _FakeCffiResponse()
+    sc = _stealth_with_fake_session(fake)
+    sc.get("http://x", follow_redirects=True)
+    # curl_cffi uses allow_redirects, not follow_redirects
+    _, kwargs = fake.request.call_args
+    assert kwargs.get("allow_redirects") is True
+    assert "follow_redirects" not in kwargs


### PR DESCRIPTION
Two feature additions, plus the version bump and the merged doc/test fixes already on this branch.

## 1. `pyscrappy extract` — scrape a URL straight to a file

A new CLI subcommand, no code required to grab a page to disk:

```bash
pyscrappy extract https://example.com out.md              # Markdown
pyscrappy extract https://example.com data.json           # JSON
pyscrappy extract https://example.com page.txt            # extracted page text
pyscrappy extract https://example.com raw.html            # raw fetched markup
pyscrappy extract https://example.com items.txt --css-selector ".product"
pyscrappy extract https://example.com page.html --render-js
```

The output format is inferred from the file extension (`.md` / `.json` / `.txt` / `.html`); `--css-selector` narrows extraction to matching elements. The `.html` path fetches raw markup directly, since the structured result doesn't retain source HTML.

## 2. TLS-fingerprint impersonation (`ScraperConfig(impersonate=...)`)

Many anti-bot systems block a plain client's TLS/JA3 fingerprint before serving anything. Setting `impersonate="chrome"` routes the **sync** `HttpClient` through a `curl_cffi` session that mimics a real browser's fingerprint, getting past that class of block without a headless browser:

```python
from pyscrappy import ScraperConfig, GenericScraper

cfg = ScraperConfig(impersonate="chrome")   # or "chrome124", "safari", "firefox"
with GenericScraper(cfg) as gs:
    result = gs.scrape("https://example.com")
```

- Implemented as an **adapter** (`core/_stealth.py`): the `curl_cffi` session is wrapped to present httpx's interface and raise httpx exception types, so the existing retry / rate-limit / cache / robots logic wraps it unchanged.
- `curl_cffi` is an optional extra: `pip install pyscrappy[stealth]`. A clear error points there if it's missing.
- The **async path raises `NotImplementedError`** when `impersonate` is set (curl_cffi's async stack is a separate fork, deferred until there's demand).

## Tests

- CLI `extract`: 6 tests (each format, the `--css-selector` path, unknown-extension error).
- Impersonation: 7 tests (httpx-vs-stealth routing, not-installed error, async guard, adapter status/exception/kwarg normalization) — all runnable without `curl_cffi` installed via mocking.

Full suite green; `ruff check` + `ruff format` clean.
