### PR TITLE
docs: document new features + bump to 1.5.0 (and fix extract on Python 3.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ PyScrappy is an AI-native web scraping toolkit that turns websites into structur
 - **MCP server** — expose the scrapers as tools for AI agents (Claude, Cursor, local LLMs, …)
 - **JS rendering** — optional Playwright backend for JavaScript-heavy sites
 - **Custom selectors** — pass CSS selectors to extract exactly what you need
+- **Chainable `Selector`** — navigate HTML directly with CSS/XPath, `find_all`, `find_by_text`, and `find_similar` (Scrapy/BeautifulSoup-style)
 - **Concurrent scraping** — `scrape_many` / `scrape_all` run scrapes in parallel
 - **Proxy & scraping-API support** — route through a proxy or ScraperAPI/ScrapeOps for blocked sites
+- **TLS-fingerprint impersonation** — `impersonate="chrome"` gets past anti-bot filters that block plain clients (optional `curl_cffi` backend)
+- **Command-line extract** — `pyscrappy extract <url> out.md` scrapes a URL straight to a file, no code
 - **Retry & rate-limiting** — built-in exponential backoff and per-domain rate limiting
 - **Type-safe** — full type hints, `py.typed` marker
 - **20+ built-in scrapers** — Wikipedia, IMDB, stocks, news, GitHub, Amazon/IKEA, YouTube, and [more](#built-in-scrapers)
@@ -45,6 +48,9 @@ pip install 'pyscrappy[dataframe]'
 
 # MCP server (use PyScrappy's scrapers as AI-agent tools)
 pip install 'pyscrappy[mcp]'
+
+# Stealth (TLS-fingerprint impersonation to bypass anti-bot filters)
+pip install 'pyscrappy[stealth]'
 
 # Everything
 pip install 'pyscrappy[all]'
@@ -309,6 +315,29 @@ with GenericScraper() as gs:
         print(item["title"], item.get("score", ""))
 ```
 
+### Navigate HTML with `Selector`
+
+When you want to traverse markup directly (Scrapy/BeautifulSoup-style) rather than
+get back structured dicts, use `Selector`:
+
+```python
+from pyscrappy import Selector
+
+page = Selector(html)                             # or navigate any HTML string
+page.css(".title::text").getall()                 # CSS with ::text / ::attr(name)
+page.xpath("//a/@href").getall()                   # XPath (elements, text(), @attr)
+page.find_all("h2", class_="title")                # BeautifulSoup-style search
+page.find_by_text("Add to cart", tag="button")     # search by text content
+
+first = page.css(".product")[0]
+first.css(".price::text").get()                    # chainable
+first.find_similar()                               # sibling elements shaped like this one
+```
+
+`css()` / `xpath()` return a `SelectorList` with `.get()` / `.getall()` / `.text()`.
+`find_similar()` locates elements with the same tag and overlapping classes, handy
+for pulling every card/row once you've found one.
+
 ### Site-specific scrapers
 
 Every built-in scraper follows the same pattern — instantiate, `scrape(...)`,
@@ -327,6 +356,22 @@ Amazon/Newegg/IKEA, Uber Eats, and more — see the [full list](#built-in-scrape
 For per-scraper arguments and examples, see the
 [documentation](https://pyscrappy.vercel.app/docs/scrapers/).
 
+### From the command line
+
+Scrape a URL straight to a file without writing any code — the output format is
+inferred from the file extension:
+
+```sh
+pyscrappy extract https://example.com out.md      # clean Markdown
+pyscrappy extract https://example.com out.json    # structured JSON
+pyscrappy extract https://example.com out.txt     # extracted page text
+pyscrappy extract https://example.com out.html    # raw fetched HTML
+
+# Narrow to elements matching a CSS selector, or render JS first:
+pyscrappy extract https://example.com items.txt --css-selector ".product"
+pyscrappy extract https://example.com page.md --render-js
+```
+
 ## Configuration
 
 ```python
@@ -341,6 +386,7 @@ config = ScraperConfig(
     headless=True,           # browser runs headless
     render_js="auto",        # auto-detect if JS rendering is needed
     cache_ttl=0,             # response cache TTL in seconds (0 = disabled)
+    impersonate=None,        # e.g. "chrome" to spoof a browser's TLS fingerprint (see below)
 )
 
 with GenericScraper(config) as gs:
@@ -380,6 +426,25 @@ with AmazonScraper(config) as scraper:
 ```
 
 This is the reliable way to use the scrapers marked "needs proxy" above.
+
+**TLS-fingerprint impersonation** — many anti-bot systems block a plain HTTP
+client by its TLS/JA3 fingerprint before serving any content. Set `impersonate`
+to mimic a real browser's fingerprint and get past that class of block without a
+headless browser:
+
+```python
+from pyscrappy import ScraperConfig, GenericScraper
+
+# needs the optional extra:  pip install 'pyscrappy[stealth]'
+config = ScraperConfig(impersonate="chrome")   # or "chrome124", "safari", "firefox"
+
+with GenericScraper(config) as gs:
+    result = gs.scrape("https://example.com")
+```
+
+Impersonation currently applies to the **synchronous** path only; setting it on
+an async client raises a clear error. All the usual retry, rate-limiting,
+caching, and robots handling still apply.
 
 ### Concurrent scraping
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## PyScrappy: Python web scraping toolkit + MCP server for AI agents
+## PyScrappy: Python web scraping toolkit (stealth, CSS/XPath, CLI) + MCP server for AI agents
 
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI Latest Release](https://img.shields.io/pypi/v/PyScrappy.svg)](https://pypi.org/project/PyScrappy/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.4.7"
+version = "1.5.0"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"
@@ -64,7 +64,7 @@ all = [
 ]
 
 [project.scripts]
-pyscrappy = "pyscrappy.mcp.agent:main"
+pyscrappy = "pyscrappy.cli:main"
 pyscrappy-mcp = "pyscrappy.mcp.server:main"
 
 [project.urls]

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.4.7",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.4.7",
+      "version": "1.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.4.7"
+__version__ = "1.5.0"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/cli.py
+++ b/src/pyscrappy/cli.py
@@ -1,0 +1,128 @@
+"""The ``pyscrappy`` command-line interface.
+
+Kept free of any MCP imports so the plain scraping commands (``extract``) work on
+every supported Python version. The ``chat`` command needs the MCP/agent stack
+(Python >=3.10), so it's imported lazily only when that command is invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def run_extract(
+    url: str,
+    out_path: str,
+    css_selector: str | None = None,
+    render_js: bool = False,
+) -> str:
+    """Scrape ``url`` and write the result to ``out_path``. The output format is
+    chosen from the file extension:
+
+    - ``.md``   -> Markdown (``ScrapeResult.to_markdown``)
+    - ``.json`` -> JSON (``ScrapeResult.to_json``)
+    - ``.txt``  -> extracted page text
+    - ``.html`` -> raw page HTML
+
+    With ``--css-selector`` the matched elements' text is extracted instead of the
+    whole page. Returns a short status line for the CLI to print.
+    """
+    from pyscrappy import GenericScraper, scrape
+
+    ext = out_path.rsplit(".", 1)[-1].lower() if "." in out_path else ""
+    if ext not in {"json", "md", "txt", "html"}:
+        raise ValueError(f"unsupported output extension {ext!r}; use .md, .json, .txt, or .html")
+
+    if ext == "html":
+        # Raw HTML: the structured scrape result doesn't retain the source markup,
+        # so fetch the page's HTML directly.
+        with GenericScraper() as gs:
+            content = gs.http.get_html(url)
+    else:
+        selectors = {"match": css_selector} if css_selector else None
+        result = scrape(url, selectors=selectors, render_js=render_js)
+        if ext == "json":
+            content = result.to_json()
+        elif ext == "md":
+            content = result.to_markdown()
+        else:  # txt
+            if css_selector:
+                content = "\n".join(row.get("match", "") for row in result.data)
+            else:
+                content = "\n\n".join(item.get("text", {}).get("text", "") for item in result.data)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return f"wrote {len(content)} chars to {out_path}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="pyscrappy",
+        description="PyScrappy CLI: extract a URL to a file, or chat with a local LLM.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    extract = sub.add_parser(
+        "extract", help="Scrape a URL straight to a file (.md/.json/.txt/.html)."
+    )
+    extract.add_argument("url", help="The URL to scrape.")
+    extract.add_argument("output", help="Output file; format inferred from its extension.")
+    extract.add_argument(
+        "--css-selector", default=None, help="Extract only elements matching this CSS selector."
+    )
+    extract.add_argument(
+        "--render-js", action="store_true", help="Render JavaScript with a browser first."
+    )
+
+    chat = sub.add_parser(
+        "chat",
+        help="Ask a local model a question it can answer with scrapers (needs pyscrappy[mcp]).",
+    )
+    chat.add_argument("prompt", help="What to ask, in plain language.")
+    chat.add_argument("--model", default=None, help="Ollama model (default: qwen2.5).")
+    chat.add_argument("--host", default=None, help="Ollama host (default: http://localhost:11434).")
+    chat.add_argument("--max-steps", type=int, default=None, help="Max tool-calling rounds.")
+    chat.add_argument("-v", "--verbose", action="store_true", help="Print each tool call.")
+    chat.add_argument("--json", action="store_true", help="Print the raw scraper result as JSON.")
+
+    args = parser.parse_args()
+
+    if args.command == "extract":
+        status = run_extract(
+            args.url,
+            args.output,
+            css_selector=args.css_selector,
+            render_js=args.render_js,
+        )
+        print(status)
+        return
+
+    if args.command == "chat":
+        # The agent/MCP stack requires Python >=3.10 and the [mcp] extra; import it
+        # only now so `pyscrappy extract` stays usable without either.
+        try:
+            import anyio
+
+            from pyscrappy.mcp.agent import DEFAULT_HOST, DEFAULT_MODEL, MAX_STEPS, run_agent
+        except ImportError as exc:
+            raise SystemExit(
+                "The 'chat' command needs the MCP/agent extra (Python >=3.10): "
+                "pip install 'pyscrappy[mcp]'"
+            ) from exc
+
+        answer = anyio.run(
+            lambda: run_agent(
+                args.prompt,
+                model=args.model or DEFAULT_MODEL,
+                host=args.host or DEFAULT_HOST,
+                max_steps=args.max_steps or MAX_STEPS,
+                verbose=args.verbose,
+                json_output=args.json,
+            )
+        )
+        print(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyscrappy/mcp/agent.py
+++ b/src/pyscrappy/mcp/agent.py
@@ -118,70 +118,12 @@ async def run_agent(
     return stopped
 
 
-def run_extract(
-    url: str,
-    out_path: str,
-    css_selector: str | None = None,
-    render_js: bool = False,
-) -> str:
-    """Scrape ``url`` and write the result to ``out_path``. The output format is
-    chosen from the file extension:
-
-    - ``.md``   -> Markdown (``ScrapeResult.to_markdown``)
-    - ``.json`` -> JSON (``ScrapeResult.to_json``)
-    - ``.txt``  -> extracted page text
-    - ``.html`` -> raw page HTML
-
-    With ``--css-selector`` the matched elements' text is extracted instead of the
-    whole page. Returns a short status line for the CLI to print.
-    """
-    from pyscrappy import GenericScraper, scrape
-
-    ext = out_path.rsplit(".", 1)[-1].lower() if "." in out_path else ""
-    if ext not in {"json", "md", "txt", "html"}:
-        raise ValueError(f"unsupported output extension {ext!r}; use .md, .json, .txt, or .html")
-
-    if ext == "html":
-        # Raw HTML: the structured scrape result doesn't retain the source markup,
-        # so fetch the page's HTML directly.
-        with GenericScraper() as gs:
-            content = gs.http.get_html(url)
-    else:
-        selectors = {"match": css_selector} if css_selector else None
-        result = scrape(url, selectors=selectors, render_js=render_js)
-        if ext == "json":
-            content = result.to_json()
-        elif ext == "md":
-            content = result.to_markdown()
-        else:  # txt
-            if css_selector:
-                content = "\n".join(row.get("match", "") for row in result.data)
-            else:
-                content = "\n\n".join(item.get("text", {}).get("text", "") for item in result.data)
-
-    with open(out_path, "w", encoding="utf-8") as f:
-        f.write(content)
-    return f"wrote {len(content)} chars to {out_path}"
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="pyscrappy",
         description="Let a local LLM use PyScrappy's scrapers as tools (via Ollama).",
     )
     sub = parser.add_subparsers(dest="command", required=True)
-
-    extract = sub.add_parser(
-        "extract", help="Scrape a URL straight to a file (.md/.json/.txt/.html)."
-    )
-    extract.add_argument("url", help="The URL to scrape.")
-    extract.add_argument("output", help="Output file; format inferred from its extension.")
-    extract.add_argument(
-        "--css-selector", default=None, help="Extract only elements matching this CSS selector."
-    )
-    extract.add_argument(
-        "--render-js", action="store_true", help="Render JavaScript with a browser first."
-    )
 
     chat = sub.add_parser("chat", help="Ask a local model a question it can answer with scrapers.")
     chat.add_argument("prompt", help="What to ask, in plain language.")
@@ -196,16 +138,6 @@ def main() -> None:
     chat.add_argument("--json", action="store_true", help="Print the raw scraper result as JSON.")
 
     args = parser.parse_args()
-
-    if args.command == "extract":
-        status = run_extract(
-            args.url,
-            args.output,
-            css_selector=args.css_selector,
-            render_js=args.render_js,
-        )
-        print(status)
-        return
 
     if args.command == "chat":
         import anyio

--- a/tests/test_cli/test_extract.py
+++ b/tests/test_cli/test_extract.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pyscrappy.cli import run_extract
 from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
-from pyscrappy.mcp.agent import run_extract
 
 
 def _result(data):


### PR DESCRIPTION
Documents the public features now on `main` and bumps the version to **1.5.0** (minor). Also fixes CI on Python 3.9 for the `extract` command.

## README

Adds documentation for the three recent features:

- **`Selector` parser** (#123): CSS/XPath selection, `find_all`, `find_by_text`, `find_similar`, chaining — a new quick-start section plus a key-feature bullet.
- **`pyscrappy extract` CLI** (#124): scrape a URL straight to `.md` / `.json` / `.txt` / `.html`, with `--css-selector` / `--render-js` — a command-line section.
- **TLS-fingerprint impersonation** (#124): `ScraperConfig(impersonate="chrome")` — the `impersonate` config option, a stealth subsection under *Proxies and blocked sites*, and the `pyscrappy[stealth]` extra in Installation.

## Version

Bumped to **1.5.0** across `pyproject.toml`, `src/pyscrappy/__init__.py`, and `server.json` (both entries). Minor, since these are new backward-compatible public features.

## Fix: `extract` on Python 3.9

`extract` was defined in `mcp/agent.py`, which imports the MCP stack (`fastmcp`, gated to Python >=3.10) at module load. `extract` has no MCP dependency, but importing it there pulled in MCP, so test collection and the command failed on 3.9 (CI red on the last PR).

Moved `run_extract` + the CLI entry point to a new MCP-free `pyscrappy/cli.py` (entry point is now `pyscrappy.cli:main`). The `chat` command still uses the MCP agent, now imported lazily only when `chat` runs, with a clear hint to install `pyscrappy[mcp]` if absent. `mcp/agent.py` keeps the full agent unchanged.

## Verification

Full suite: 457 passed, 19 deselected. `ruff check` + `ruff format` clean. `run_extract` confirmed importable without loading MCP (the exact 3.9 breakage).