### PR TITLE
docs(readme): use absolute raw-GitHub URL for the logo so it renders on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/logo.png" alt="PyScrappy" width="480">
+  <img src="https://raw.githubusercontent.com/mldsveda/PyScrappy/main/public/logo.png" alt="PyScrappy" width="480">
 </p>
 
 <h2 align="center">Adaptive Python web scraping toolkit (self-healing, stealth)<br>+ MCP server for AI agents</h2>


### PR DESCRIPTION
The header logo used a repo-relative src (public/logo.png), which GitHub resolves but PyPI cannot — PyPI renders the README standalone with no access to repo files, so the logo showed as a broken image on the package page. Point it at the raw.githubusercontent.com URL on main (verified 200), matching how the Glama badge below it already uses an absolute URL.