### PR TITLE
fix: broken logo on PyPI (absolute raw URL) + bump to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.5.2] - 2026-08-10
+
+### Fixed
+- README logo uses an absolute raw-GitHub URL so it renders on the PyPI project page (a repo-relative path only resolves on GitHub).
+
 ## [1.5.1] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.1"
+version = "1.5.2"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 __all__ = [
     # Core


### PR DESCRIPTION
The header logo shows as a broken image on the [PyPI package page](https://pypi.org/project/PyScrappy/).

**Cause:** the README used a repo-relative image src (`public/logo.png`). GitHub resolves relative paths against the repo, but PyPI renders the README standalone with no access to repo files, so the image 404s there.

**Fix:** point the logo at the absolute raw-GitHub URL (`https://raw.githubusercontent.com/mldsveda/PyScrappy/main/public/logo.png`, verified 200), the same way the Glama badge just below it already uses an absolute URL. Renders on both GitHub and PyPI.

**Bump to 1.5.2:** PyPI freezes the README at publish time, so the fix only reaches the package page on a new release. Version bumped across `pyproject.toml`, `__init__.py`, and `server.json`, with a changelog entry.