### PR TITLE
Fix missing CSS attr defaults

### DIFF
--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -246,7 +246,7 @@ class SelectorList(list):
         if self._pseudo == "text":
             return [s.text() for s in self]
         if self._pseudo == "attr":
-            return [str(s.attrs.get(self._attr, "")) for s in self]
+            return [str(s.attrs[self._attr]) for s in self if self._attr in s.attrs]
         return [s.html() for s in self]
 
     def get(self, default: str | None = None) -> str | None:

--- a/tests/test_generic/test_selector.py
+++ b/tests/test_generic/test_selector.py
@@ -40,6 +40,13 @@ class TestCss:
     def test_css_attr_pseudo(self):
         assert _page().css("a::attr(href)").getall() == ["/a", "/b"]
 
+    def test_css_attr_missing_attribute_uses_default(self):
+        assert Selector("<a>x</a>").css("a::attr(href)").get("MISSING") == "MISSING"
+
+    def test_css_attr_getall_skips_missing_attributes(self):
+        html = "<a href='/present'>yes</a><a>missing</a>"
+        assert Selector(html).css("a::attr(href)").getall() == ["/present"]
+
     def test_css_chaining(self):
         first = _page().css(".product")[0]
         assert first.css(".price::text").get() == "$10"


### PR DESCRIPTION
## Summary
- Make CSS `::attr(...)` values skip elements where the requested attribute is absent.
- Let `.get(default)` return the provided default for matched elements that lack the attribute.
- Add selector regression tests for present attributes, missing attributes, and `getall()`.

Fixes #131.

## Tests
- RED: `python -m pytest tests/test_generic/test_selector.py::TestCss::test_css_attr_missing_attribute_uses_default tests/test_generic/test_selector.py::TestCss::test_css_attr_getall_skips_missing_attributes -q` failed with `'' == 'MISSING'` and `['/present', ''] == ['/present']`
- GREEN: `python -m pytest tests/test_generic/test_selector.py -q` → `21 passed`
- GREEN: `python -m pytest tests/ -q` → `471 passed, 1 skipped, 19 deselected`
- GREEN: `ruff check src/` → `All checks passed!`
