### PR TITLE
Document SoundCloud async JS limitation

### DIFF
--- a/src/pyscrappy/scrapers/soundcloud.py
+++ b/src/pyscrappy/scrapers/soundcloud.py
@@ -62,7 +62,12 @@ class SoundCloudScraper(BaseScraper):
         query: str,
         max_results: int = 20,
     ) -> ScrapeResult:
-        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        """Search for tracks using the async HTTP-only client.
+
+        The async path does not support the sync-only browser rendering
+        options (``render_js`` and ``scroll_pages``). Use :meth:`scrape`
+        with ``render_js=True`` when JavaScript rendering is required.
+        """
         url = f"https://soundcloud.com/search/sounds?q={quote_plus(query)}"
         html = await self.async_http.get_html(url)
         return self._build_result(html, url, max_results)

--- a/tests/test_scrapers/test_music.py
+++ b/tests/test_scrapers/test_music.py
@@ -128,6 +128,15 @@ class TestSoundCloudScraper:
         assert "q=lo+fi+beats" in url
         scraper.close()
 
+    def test_async_docstring_documents_http_only_limitation(self):
+        doc = SoundCloudScraper.scrape_async.__doc__
+
+        assert doc is not None
+        assert "HTTP-only" in doc
+        assert "render_js" in doc
+        assert "scroll_pages" in doc
+        assert "same args/returns" not in doc
+
 
 # --- Spotify ---
 


### PR DESCRIPTION
## Summary
- Remove the incorrect "same args/returns" wording from `SoundCloudScraper.scrape_async`.
- Document that the async SoundCloud path is HTTP-only and does not support `render_js`/`scroll_pages`.
- Add a regression guard for the async docstring so the limitation stays explicit.

## Verification
- RED: `python -m pytest tests/test_scrapers/test_music.py::TestSoundCloudScraper::test_async_docstring_documents_http_only_limitation -q` failed because the docstring still claimed parity.
- GREEN: `python -m pytest tests/test_scrapers/test_music.py::TestSoundCloudScraper -q`
- `python -m pytest tests/ -q`
- `ruff check src/ tests/`

Fixes #130.
