### PR TITLE
fix: N+1 OMDb calls in title search with enrich opt-out

### DIFF
--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -124,9 +124,10 @@ class IMDBScraper(BaseScraper):
     ) -> ScrapeResult:
         """Async counterpart to :meth:`scrape` (same args/returns).
 
-        Like :meth:`scrape`, ``enrich=True`` (the default) issues one extra
-        OMDb call per search hit; pass ``enrich=False`` for one request per
-        page instead.
+        Like :meth:`scrape`, ``enrich=True`` (the default) issues one extra OMDb
+        call per search hit — roughly ``max_pages + max_pages * 10`` calls total
+        (OMDb returns ~10 hits/page). Pass ``enrich=False`` to skip the per-hit
+        lookups and issue only one request per page.
         """
         if genre or chart:
             unsupported = "genre" if genre else "chart"
@@ -236,7 +237,9 @@ class IMDBScraper(BaseScraper):
 
         return self._build_search_result(movies, errors)
 
-    async def _search_by_title_async(self, query: str, max_pages: int, enrich: bool) -> ScrapeResult:
+    async def _search_by_title_async(
+        self, query: str, max_pages: int, enrich: bool
+    ) -> ScrapeResult:
         movies: list[dict[str, Any]] = []
         errors: list[ScrapeError] = []
 

--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -118,6 +118,7 @@ class IMDBScraper(BaseScraper):
         query: str | None = None,
         chart: str | None = None,
         max_pages: int = 1,
+        enrich: bool = True,
     ) -> ScrapeResult:
         """Async counterpart to :meth:`scrape` (same args/returns)."""
         if genre or chart:
@@ -159,7 +160,7 @@ class IMDBScraper(BaseScraper):
 
         if _IMDB_ID_RE.match(query.strip()):
             return await self._lookup_by_id_async(query.strip())
-        return await self._search_by_title_async(query, max_pages)
+        return await self._search_by_title_async(query, max_pages, enrich)
 
     def _get(self, params: dict[str, str]) -> dict[str, Any]:
         """Call OMDb and return the parsed JSON object."""
@@ -228,7 +229,7 @@ class IMDBScraper(BaseScraper):
 
         return self._build_search_result(movies, errors)
 
-    async def _search_by_title_async(self, query: str, max_pages: int) -> ScrapeResult:
+    async def _search_by_title_async(self, query: str, max_pages: int, enrich: bool) -> ScrapeResult:
         movies: list[dict[str, Any]] = []
         errors: list[ScrapeError] = []
 
@@ -242,7 +243,7 @@ class IMDBScraper(BaseScraper):
             # Enrich each search hit with full details (genre, rating, plot…).
             for hit in results:
                 imdb_id = hit.get("imdbID")
-                if not imdb_id:
+                if not enrich or not imdb_id:
                     movies.append(self._normalise(hit))
                     continue
                 details = await self._get_async({"i": imdb_id})

--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -64,9 +64,11 @@ class IMDBScraper(BaseScraper):
             genre: Not supported — OMDb has no genre-browse endpoint.
             chart: Not supported — OMDb has no chart endpoint.
             max_pages: Pages of search results to fetch (10 results per page).
-            enrich: Whether to enrich search results with full OMDb details.
-                    Defaults to ``True``. Set to ``False`` to return lightweight
-                    search results and make only one request per page.
+            enrich: Whether to enrich each search hit with a full per-title OMDb
+                lookup (genre, rating, plot…). Defaults to ``True``, which costs
+                one extra API call per hit — roughly ``max_pages + max_pages * 10``
+                calls total (OMDb returns ~10 hits/page). Set to ``False`` to skip
+                the per-hit lookups and issue only one request per page.
 
         Returns:
             ScrapeResult with movie data.
@@ -120,7 +122,12 @@ class IMDBScraper(BaseScraper):
         max_pages: int = 1,
         enrich: bool = True,
     ) -> ScrapeResult:
-        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        """Async counterpart to :meth:`scrape` (same args/returns).
+
+        Like :meth:`scrape`, ``enrich=True`` (the default) issues one extra
+        OMDb call per search hit; pass ``enrich=False`` for one request per
+        page instead.
+        """
         if genre or chart:
             unsupported = "genre" if genre else "chart"
             return ScrapeResult(

--- a/src/pyscrappy/scrapers/imdb.py
+++ b/src/pyscrappy/scrapers/imdb.py
@@ -54,6 +54,7 @@ class IMDBScraper(BaseScraper):
         query: str | None = None,
         chart: str | None = None,
         max_pages: int = 1,
+        enrich: bool = True,
     ) -> ScrapeResult:
         """Fetch movie data from IMDB (via OMDb).
 
@@ -63,6 +64,9 @@ class IMDBScraper(BaseScraper):
             genre: Not supported — OMDb has no genre-browse endpoint.
             chart: Not supported — OMDb has no chart endpoint.
             max_pages: Pages of search results to fetch (10 results per page).
+            enrich: Whether to enrich search results with full OMDb details.
+                    Defaults to ``True``. Set to ``False`` to return lightweight
+                    search results and make only one request per page.
 
         Returns:
             ScrapeResult with movie data.
@@ -106,7 +110,7 @@ class IMDBScraper(BaseScraper):
 
         if _IMDB_ID_RE.match(query.strip()):
             return self._lookup_by_id(query.strip())
-        return self._search_by_title(query, max_pages)
+        return self._search_by_title(query, max_pages, enrich)
 
     async def scrape_async(  # type: ignore[override]
         self,
@@ -200,7 +204,7 @@ class IMDBScraper(BaseScraper):
             errors=errors,
         )
 
-    def _search_by_title(self, query: str, max_pages: int) -> ScrapeResult:
+    def _search_by_title(self, query: str, max_pages: int, enrich: bool) -> ScrapeResult:
         movies: list[dict[str, Any]] = []
         errors: list[ScrapeError] = []
 
@@ -214,7 +218,7 @@ class IMDBScraper(BaseScraper):
             # Enrich each search hit with full details (genre, rating, plot…).
             for hit in results:
                 imdb_id = hit.get("imdbID")
-                if not imdb_id:
+                if not enrich or not imdb_id:
                     movies.append(self._normalise(hit))
                     continue
                 details = self._get({"i": imdb_id})

--- a/tests/test_scrapers/test_imdb.py
+++ b/tests/test_scrapers/test_imdb.py
@@ -1,7 +1,10 @@
 """Tests for pyscrappy.scrapers.imdb (OMDb-backed)."""
 
 import json
-from unittest.mock import MagicMock
+import asyncio
+
+from unittest.mock import MagicMock, AsyncMock
+
 
 import pytest
 
@@ -54,6 +57,14 @@ def _scraper_with(responses):
     mock_http = MagicMock()
     mock_http.get_html.side_effect = responses
     scraper._http = mock_http  # bypass real network
+    return scraper
+
+def _scraper_with_async(responses):
+    """Build an IMDBScraper whose async HTTP layer returns queued JSON strings."""
+    scraper = IMDBScraper(api_key="testkey")
+    mock_async_http = MagicMock()
+    mock_async_http.get_html = AsyncMock(side_effect=responses)
+    scraper._async_http = mock_async_http
     return scraper
 
 
@@ -135,6 +146,36 @@ class TestIMDBSearchByTitle:
         assert scraper._http.get_html.call_count == 1
         assert len(result.data) == 1
         assert result.errors == []
+
+class TestIMDBSearchByTitleAsync:
+    def test_search_async_enriches_with_details(self):
+        # First call: search list. Second call: details for the one hit.
+        scraper = _scraper_with_async([SEARCH_JSON, DETAILS_JSON])
+        result = asyncio.run(
+            scraper.scrape_async(query="inception", max_pages=1)
+        )
+        assert len(result.data) == 1
+        assert result.data[0]["genre"] == "Action, Adventure, Sci-Fi"
+        assert result.data[0]["director"] == "Christopher Nolan"
+
+    def test_search_async_no_results(self):
+        scraper = _scraper_with_async([NOT_FOUND_JSON])
+        result = asyncio.run(
+            scraper.scrape_async(query="zzzznotarealmovie")
+        )
+        assert result.data == []
+        assert result.errors
+
+    def test_search_async_without_enrich_skips_details(self):
+        scraper = _scraper_with_async([SEARCH_JSON])
+        result = asyncio.run(
+            scraper.scrape_async(query="inception", max_pages=1, enrich=False)
+        )
+
+        assert scraper._async_http.get_html.call_count == 1
+        assert len(result.data) == 1
+        assert result.errors == []
+
 
 class TestNormalise:
     def test_na_becomes_absent(self):

--- a/tests/test_scrapers/test_imdb.py
+++ b/tests/test_scrapers/test_imdb.py
@@ -1,10 +1,8 @@
 """Tests for pyscrappy.scrapers.imdb (OMDb-backed)."""
 
-import json
 import asyncio
-
-from unittest.mock import MagicMock, AsyncMock
-
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -58,6 +56,7 @@ def _scraper_with(responses):
     mock_http.get_html.side_effect = responses
     scraper._http = mock_http  # bypass real network
     return scraper
+
 
 def _scraper_with_async(responses):
     """Build an IMDBScraper whose async HTTP layer returns queued JSON strings."""
@@ -146,35 +145,46 @@ class TestIMDBSearchByTitle:
         assert scraper._http.get_html.call_count == 1
         assert len(result.data) == 1
         assert result.errors == []
+        # The row is the lightweight search result: search fields are populated,
+        # but detail-only fields (from the skipped per-hit lookup) are absent.
+        movie = result.data[0]
+        assert movie["title"] == "Inception"
+        assert movie["imdb_id"] == "tt1375666"
+        assert movie["type"] == "movie"
+        # detail-only fields (from the skipped per-hit lookup) are absent
+        assert "genre" not in movie
+        assert "director" not in movie
+
 
 class TestIMDBSearchByTitleAsync:
     def test_search_async_enriches_with_details(self):
         # First call: search list. Second call: details for the one hit.
         scraper = _scraper_with_async([SEARCH_JSON, DETAILS_JSON])
-        result = asyncio.run(
-            scraper.scrape_async(query="inception", max_pages=1)
-        )
+        result = asyncio.run(scraper.scrape_async(query="inception", max_pages=1))
         assert len(result.data) == 1
         assert result.data[0]["genre"] == "Action, Adventure, Sci-Fi"
         assert result.data[0]["director"] == "Christopher Nolan"
 
     def test_search_async_no_results(self):
         scraper = _scraper_with_async([NOT_FOUND_JSON])
-        result = asyncio.run(
-            scraper.scrape_async(query="zzzznotarealmovie")
-        )
+        result = asyncio.run(scraper.scrape_async(query="zzzznotarealmovie"))
         assert result.data == []
         assert result.errors
 
     def test_search_async_without_enrich_skips_details(self):
         scraper = _scraper_with_async([SEARCH_JSON])
-        result = asyncio.run(
-            scraper.scrape_async(query="inception", max_pages=1, enrich=False)
-        )
+        result = asyncio.run(scraper.scrape_async(query="inception", max_pages=1, enrich=False))
 
         assert scraper._async_http.get_html.call_count == 1
         assert len(result.data) == 1
         assert result.errors == []
+        movie = result.data[0]
+        assert movie["title"] == "Inception"
+        assert movie["imdb_id"] == "tt1375666"
+        assert movie["type"] == "movie"
+        # detail-only fields (from the skipped per-hit lookup) are absent
+        assert "genre" not in movie
+        assert "director" not in movie
 
 
 class TestNormalise:

--- a/tests/test_scrapers/test_imdb.py
+++ b/tests/test_scrapers/test_imdb.py
@@ -127,6 +127,14 @@ class TestIMDBSearchByTitle:
         assert result.data == []
         assert result.errors
 
+    def test_search_without_enrich_skips_details(self):
+        # Queue only the search page — a stray detail-lookup call would error out.
+        scraper = _scraper_with([SEARCH_JSON])
+        result = scraper.scrape(query="inception", max_pages=1, enrich=False)
+
+        assert scraper._http.get_html.call_count == 1
+        assert len(result.data) == 1
+        assert result.errors == []
 
 class TestNormalise:
     def test_na_becomes_absent(self):


### PR DESCRIPTION
## Summary

Closes #132.

Adds an `enrich: bool = True` parameter to `IMDBScraper.scrape` / `scrape_async`, letting callers opt out of the per-hit OMDb detail lookup that title searches previously always performed. Default behavior is unchanged.

## Problem

Every title search hit was enriched with a second OMDb call (`_get({"i": imdb_id})`), with no way to skip it. Call volume was roughly `max_pages + max_pages * 10` (OMDb returns ~10 hits/page), which can burn through the free-tier daily quota (1,000 calls/day) quickly and without warning. The docstring mentioned "10 results per page" but never the hidden per-hit cost.

## Changes

- `scrape` / `scrape_async`: added `enrich: bool = True` param, threaded through to `_search_by_title` / `_search_by_title_async`.
- `_search_by_title` / `_search_by_title_async`: the per-hit detail call is now skipped when `enrich=False`, returning the lightweight search row instead (title, year, imdbID, type, poster).
- Docstrings on both `scrape` and `scrape_async` now document the call multiplier (`max_pages + max_pages * 10`) and the `enrich=False` opt-out.

## Tests

Added to `tests/test_scrapers/test_imdb.py`:

- `TestIMDBSearchByTitle::test_search_without_enrich_skips_details` (sync) — asserts `enrich=False` results in exactly one HTTP call (`get_html.call_count == 1`), and that the search still returns data with no errors.
- `TestIMDBSearchByTitleAsync` (new class, mirrors the sync class) — covers the async path end to end:
  - `test_search_async_enriches_with_details` — default (`enrich=True`) behavior unchanged.
  - `test_search_async_no_results` — not-found case still works async.
  - `test_search_async_without_enrich_skips_details` — same one-call assertion as the sync test, via a new `_scraper_with_async` fixture.

The `enrich=False` tests queue only one mock response on purpose — if the per-hit lookup ever fired when it shouldn't, the mock would run out of queued responses and error, in addition to the explicit `call_count == 1` assertion failing.

`_scraper_with_async` mocks `_async_http` with `AsyncMock` on `.get_html` (mirroring the existing `_scraper_with` pattern for `_http`), since CONTRIBUTING.md's testing principles reference `_http` specifically but the async path needed its own equivalent.

- `pytest tests/ -v` — all passing
- `ruff check src/` — passing

## Acceptance criteria (from #132)

- [x] `scrape(query=..., details=False)` issues one request per page (no per-hit lookups) 
  - Implemented as `enrich=False` per the issue's suggested naming.
- [x] Default behavior unchanged (still enriched).
- [x] Docstring notes the per-hit lookup cost and the opt-out.
- [x] Applied to both sync and async loops.