### PR TITLE
fix: make AdaptiveStore.save() atomic via tempfile + os.replace (#138)

### DIFF
--- a/src/pyscrappy/generic/adaptive_store.py
+++ b/src/pyscrappy/generic/adaptive_store.py
@@ -74,7 +74,5 @@ class AdaptiveStore:
                 pass
             raise
 
-    def retrieve(
-        self, identifier: str, namespace: str | None = None
-    ) -> dict[str, Any] | None:
+    def retrieve(self, identifier: str, namespace: str | None = None) -> dict[str, Any] | None:
         return self._load().get(self._key(identifier, namespace))

--- a/src/pyscrappy/generic/adaptive_store.py
+++ b/src/pyscrappy/generic/adaptive_store.py
@@ -47,18 +47,31 @@ class AdaptiveStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
         # Write atomically: serialize to a temp file in the same directory,
-        # then os.replace() it over the target.  os.replace() is an atomic
+        # then os.replace() it over the target. os.replace() is an atomic
         # rename on both POSIX and Windows, so a reader always sees either
         # the old complete file or the new complete file — never a partial one.
-        fd, tmp = tempfile.mkstemp(
-            dir=self.path.parent, suffix=".tmp"
-        )
+        fd, tmp = tempfile.mkstemp(dir=self.path.parent, suffix=".tmp")
+        f = None
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
+            f = os.fdopen(fd, "w", encoding="utf-8")
+            json.dump(data, f, indent=2)
+            f.close()
             os.replace(tmp, self.path)
         except BaseException:
-            os.unlink(tmp)
+            if f is not None:
+                try:
+                    f.close()
+                except OSError:
+                    pass
+            else:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
             raise
 
     def retrieve(

--- a/src/pyscrappy/generic/adaptive_store.py
+++ b/src/pyscrappy/generic/adaptive_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +45,23 @@ class AdaptiveStore:
         data = self._load()
         data[self._key(identifier, namespace)] = fingerprint
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-    def retrieve(self, identifier: str, namespace: str | None = None) -> dict[str, Any] | None:
+        # Write atomically: serialize to a temp file in the same directory,
+        # then os.replace() it over the target.  os.replace() is an atomic
+        # rename on both POSIX and Windows, so a reader always sees either
+        # the old complete file or the new complete file — never a partial one.
+        fd, tmp = tempfile.mkstemp(
+            dir=self.path.parent, suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp, self.path)
+        except BaseException:
+            os.unlink(tmp)
+            raise
+
+    def retrieve(
+        self, identifier: str, namespace: str | None = None
+    ) -> dict[str, Any] | None:
         return self._load().get(self._key(identifier, namespace))

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -270,10 +270,11 @@ def test_save_atomic_no_corruption_on_write_failure(tmp_path):
     # Verify the initial save worked
     assert store.retrieve("price", namespace="example.com") == fp
 
-    # Patch os.replace to simulate a crash after the temp file is written
+    # Patch os.replace on the specific module to avoid side-effects on concurrent code
     import unittest.mock as mock
 
-    with mock.patch("os.replace", side_effect=OSError("disk full")):
+    target = "pyscrappy.generic.adaptive_store.os.replace"
+    with mock.patch(target, side_effect=OSError("disk full")):
         try:
             store.save("new_key", {"fake": True}, namespace="example.com")
         except OSError:

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -19,7 +19,9 @@ def _el(html, selector):
 
 
 def test_fingerprint_captures_core_features():
-    el = _el('<div class="list"><span id="price" class="amount">$10</span></div>', "#price")
+    el = _el(
+        '<div class="list"><span id="price" class="amount">$10</span></div>', "#price"
+    )
     fp = fingerprint(el)
     assert fp["tag"] == "span"
     assert fp["id"] == "price"
@@ -102,7 +104,9 @@ def test_relocate_finds_title_by_text_when_class_changes():
 
 def test_relocate_returns_none_below_threshold():
     fp = fingerprint(_el(_V1, ".price"))
-    root = BeautifulSoup("<html><body><p>totally unrelated page</p></body></html>", "lxml")
+    root = BeautifulSoup(
+        "<html><body><p>totally unrelated page</p></body></html>", "lxml"
+    )
     result = relocate(fp, root)
     assert result.element is None
     assert result.confidence < 55
@@ -186,7 +190,9 @@ def test_selector_css_auto_save_then_heal(tmp_path):
 
 def test_selector_css_no_heal_without_adaptive_flag(tmp_path):
     store = AdaptiveStore(tmp_path / "a.json")
-    Selector(_V1, adaptive_store=store).css(".price", auto_save=True, adaptive_id="price")
+    Selector(_V1, adaptive_store=store).css(
+        ".price", auto_save=True, adaptive_id="price"
+    )
     # Without adaptive=True, a broken selector just returns empty (unchanged behavior).
     healed = Selector(_V2, adaptive_store=store).css(".price", adaptive_id="price")
     assert len(healed) == 0
@@ -218,7 +224,9 @@ def _uniform_score(fp, cand):
         SequenceMatcher(None, fp["text"] or "", cfp["text"] or "").ratio(),
         _jaccard_local(fp["classes"], cfp["classes"]),
         SequenceMatcher(None, "/".join(fp["path"]), "/".join(cfp["path"])).ratio(),
-        SequenceMatcher(None, "/".join(fp["siblings"]), "/".join(cfp["siblings"])).ratio(),
+        SequenceMatcher(
+            None, "/".join(fp["siblings"]), "/".join(cfp["siblings"])
+        ).ratio(),
     ]
     return sum(parts) / len(parts) * 100
 

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -259,3 +259,30 @@ def test_weighted_scorer_beats_uniform_on_volatile_decoy():
 
     # And end-to-end relocation picks the true element.
     assert relocate(fp, root).element is true_el
+
+
+def test_save_atomic_no_corruption_on_write_failure(tmp_path):
+    """A failed write must not corrupt the existing store."""
+    store = AdaptiveStore(tmp_path / "adaptive.json")
+    fp = fingerprint(_el(_V1, ".price"))
+    store.save("price", fp, namespace="example.com")
+
+    # Verify the initial save worked
+    assert store.retrieve("price", namespace="example.com") == fp
+
+    # Patch os.replace to simulate a crash after the temp file is written
+    import unittest.mock as mock
+
+    with mock.patch("os.replace", side_effect=OSError("disk full")):
+        try:
+            store.save("new_key", {"fake": True}, namespace="example.com")
+        except OSError:
+            pass
+
+    # The original data must survive — not be corrupted or lost
+    assert store.retrieve("price", namespace="example.com") == fp
+    # The failed key must not appear
+    assert store.retrieve("new_key", namespace="example.com") is None
+    # No leftover .tmp files
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert len(tmp_files) == 0, f"Leftover temp files: {tmp_files}"

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -19,9 +19,7 @@ def _el(html, selector):
 
 
 def test_fingerprint_captures_core_features():
-    el = _el(
-        '<div class="list"><span id="price" class="amount">$10</span></div>', "#price"
-    )
+    el = _el('<div class="list"><span id="price" class="amount">$10</span></div>', "#price")
     fp = fingerprint(el)
     assert fp["tag"] == "span"
     assert fp["id"] == "price"
@@ -104,9 +102,7 @@ def test_relocate_finds_title_by_text_when_class_changes():
 
 def test_relocate_returns_none_below_threshold():
     fp = fingerprint(_el(_V1, ".price"))
-    root = BeautifulSoup(
-        "<html><body><p>totally unrelated page</p></body></html>", "lxml"
-    )
+    root = BeautifulSoup("<html><body><p>totally unrelated page</p></body></html>", "lxml")
     result = relocate(fp, root)
     assert result.element is None
     assert result.confidence < 55
@@ -190,9 +186,7 @@ def test_selector_css_auto_save_then_heal(tmp_path):
 
 def test_selector_css_no_heal_without_adaptive_flag(tmp_path):
     store = AdaptiveStore(tmp_path / "a.json")
-    Selector(_V1, adaptive_store=store).css(
-        ".price", auto_save=True, adaptive_id="price"
-    )
+    Selector(_V1, adaptive_store=store).css(".price", auto_save=True, adaptive_id="price")
     # Without adaptive=True, a broken selector just returns empty (unchanged behavior).
     healed = Selector(_V2, adaptive_store=store).css(".price", adaptive_id="price")
     assert len(healed) == 0
@@ -224,9 +218,7 @@ def _uniform_score(fp, cand):
         SequenceMatcher(None, fp["text"] or "", cfp["text"] or "").ratio(),
         _jaccard_local(fp["classes"], cfp["classes"]),
         SequenceMatcher(None, "/".join(fp["path"]), "/".join(cfp["path"])).ratio(),
-        SequenceMatcher(
-            None, "/".join(fp["siblings"]), "/".join(cfp["siblings"])
-        ).ratio(),
+        SequenceMatcher(None, "/".join(fp["siblings"]), "/".join(cfp["siblings"])).ratio(),
     ]
     return sum(parts) / len(parts) * 100
 


### PR DESCRIPTION
## Summary

Makes `AdaptiveStore.save()` atomic by writing to a temporary file (`tempfile.mkstemp`) and then renaming it over the target with `os.replace()`.

Fixes #138

## Problem

The current `save()` method uses `Path.write_text()`, which is a non-atomic write:
- A crash mid-write leaves `adaptive.json` truncated/corrupt
- Two concurrent scrapers can interleave and clobber each other
- `_load()` silently returns `{}` on corrupt JSON, wiping all saved fingerprints

## Changes

### `src/pyscrappy/generic/adaptive_store.py`
- Added `import tempfile` (stdlib, no new dependencies)
- Replaced `self.path.write_text(json.dumps(...))` with:
  1. `tempfile.mkstemp(dir=self.path.parent)` — temp file in same directory
  2. `json.dump(data, f)` — write to temp file
  3. `os.replace(tmp, self.path)` — atomic rename (POSIX + Windows)
  4. `except BaseException: os.unlink(tmp); raise` — cleanup on failure

### `tests/test_generic/test_adaptive.py`
- Added `test_save_atomic_no_corruption_on_write_failure`:
  - Saves initial data, then simulates a failed write via `mock.patch("os.replace")`
  - Asserts original data survives intact
  - Asserts failed key does not appear
  - Asserts no leftover `.tmp` files

## Checklist
- [x] `ruff check src/` passes
- [x] All lines ≤ 100 characters
- [x] No new dependencies (uses stdlib `tempfile` + `os`)
- [x] Existing tests unmodified and expected to pass
- [x] New test covers the failure scenario
