### PR TITLE
Fix empty metadata keyword entries

### DIFF
--- a/src/pyscrappy/generic/extractors.py
+++ b/src/pyscrappy/generic/extractors.py
@@ -34,7 +34,7 @@ class MetadataExtractor:
             elif name == "author":
                 meta["author"] = content
             elif name in ("keywords",):
-                meta["keywords"] = [k.strip() for k in content.split(",")]
+                meta["keywords"] = [k.strip() for k in content.split(",") if k.strip()]
             elif name.startswith("og:"):
                 meta.setdefault("og", {})[name[3:]] = content
             elif name.startswith("twitter:"):

--- a/tests/test_generic/test_extractors.py
+++ b/tests/test_generic/test_extractors.py
@@ -41,6 +41,11 @@ class TestMetadataExtractor:
         result = self.extractor.extract(soup)
         assert result["keywords"] == ["python", "scraping", "web"]
 
+    def test_extract_keywords_ignores_empty_entries(self):
+        soup = _soup('<html><head><meta name="keywords" content="python, , web,,"></head></html>')
+        result = self.extractor.extract(soup)
+        assert result["keywords"] == ["python", "web"]
+
     def test_extract_og_tags(self):
         soup = _soup(
             "<html><head>"


### PR DESCRIPTION
## Summary
- Drop blank metadata keyword entries produced by trailing or repeated commas.
- Preserve trimming and normal comma-separated keyword behavior.
- Add a focused regression test for the blank-segment case.

Fixes #137.

## Tests
- RED: `python -m pytest tests/test_generic/test_extractors.py::TestMetadataExtractor::test_extract_keywords_ignores_empty_entries -q` returned the old empty entries.
- GREEN: extractor tests — 38 passed.
- GREEN: full suite — 477 passed, 1 skipped, 19 deselected.
- GREEN: `ruff check src/ tests/` and `ruff format --check src/ tests/`.
- GREEN: `python -m build`.
- GREEN on Python 3.9: extractor tests — 38 passed.