### PR TITLE
fix: handle scalar XPath results in Selector.xpath()

### DIFF
--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -150,11 +150,11 @@ class Selector:
         if root is None:
             return SelectorList([])
         results = root.xpath(path)
-        
+
         # Handle scalar results (float, int, bool) from functions like count(), boolean()
         if isinstance(results, (float, int, bool)):
             return SelectorList([], _strings=[str(results)])
-        
+
         selectors: list[Selector] = []
         strings: list[str] = []
         for r in results:

--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -143,11 +143,18 @@ class Selector:
 
     def xpath(self, path: str) -> SelectorList:
         """Select descendants by XPath (via lxml). Returns elements; text/attr
-        XPath expressions (``.../text()``, ``.../@href``) yield string results."""
+        XPath expressions (``.../text()``, ``.../@href``) yield string results.
+        Scalar XPath expressions (``count(...)``, ``boolean(...)``) return the
+        value as a single-item SelectorList."""
         root = etree.HTML(str(self._node))
         if root is None:
             return SelectorList([])
         results = root.xpath(path)
+        
+        # Handle scalar results (float, int, bool) from functions like count(), boolean()
+        if isinstance(results, (float, int, bool)):
+            return SelectorList([], _strings=[str(results)])
+        
         selectors: list[Selector] = []
         strings: list[str] = []
         for r in results:

--- a/tests/test_generic/test_selector.py
+++ b/tests/test_generic/test_selector.py
@@ -66,6 +66,14 @@ class TestXpath:
     def test_xpath_attr(self):
         assert _page().xpath("//a/@href").getall() == ["/a", "/b"]
 
+    def test_xpath_scalar_count(self):
+        # count(...) returns a float scalar from lxml; it must come back as a
+        # string result rather than crashing (#136).
+        assert _page().xpath("count(//div[contains(@class,'product')])").get() == "2.0"
+
+    def test_xpath_scalar_boolean(self):
+        assert _page().xpath("boolean(//div[contains(@class,'product')])").get() == "True"
+
 
 class TestFindAll:
     def test_find_all_by_tag(self):


### PR DESCRIPTION
## Summary

lxml's `xpath()` returns a scalar (float/bool) for XPath functions like `count()` and `boolean()`. The existing code tried to iterate over the scalar, causing `TypeError: 'float' object is not iterable`.

## Change

Add an `isinstance()` check before the iteration loop to return scalar results as a single-item string list.

```python
# Added before the iteration loop
if isinstance(results, (float, int, bool)):
    return SelectorList([], _strings=[str(results)])
```

## Repro

```python
from pyscrappy import Selector

Selector("<div><p>1</p><p>2</p></div>").xpath("count(//p)").getall()
# Before: TypeError: 'float' object is not iterable
# After: ['2.0']
```

Fixes #136