### PR TITLE
Fix Retry-After HTTP-date parsing and honor Retry-After on 503 (#143)

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -26,6 +26,7 @@ from pyscrappy.core.http import (
     _CACHE_LOCK,
     _SHARED_CACHE,
     backoff_delay,
+    parse_retry_after,
 )
 
 logger = logging.getLogger("pyscrappy.async_http")
@@ -109,7 +110,9 @@ class AsyncHttpClient:
                 resp = await client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
                 if resp.status_code == 429:
-                    retry_after = float(resp.headers.get("Retry-After", self.config.retry_delay))
+                    retry_after = parse_retry_after(
+                        resp.headers.get("Retry-After"), self.config.retry_delay
+                    )
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
                         await asyncio.sleep(retry_after)
@@ -123,8 +126,11 @@ class AsyncHttpClient:
             except httpx.HTTPStatusError as exc:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
+                    delay = backoff_delay(self.config, attempt)
+                    if exc.response.status_code == 503 and "Retry-After" in exc.response.headers:
+                        delay = parse_retry_after(exc.response.headers.get("Retry-After"), delay)
                     await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
-                    await asyncio.sleep(backoff_delay(self.config, attempt))
+                    await asyncio.sleep(delay)
                     continue
                 raise NetworkError(f"HTTP {exc.response.status_code} from {url}") from exc
 
@@ -166,7 +172,10 @@ class AsyncHttpClient:
                 headers = self._merge_headers(extra_headers)
                 resp = await client.post(url, headers=headers, follow_redirects=True, **kwargs)
                 if resp.status_code >= 500 and attempt < self.config.max_retries:
-                    await asyncio.sleep(backoff_delay(self.config, attempt))
+                    delay = backoff_delay(self.config, attempt)
+                    if resp.status_code == 503 and "Retry-After" in resp.headers:
+                        delay = parse_retry_after(resp.headers.get("Retry-After"), delay)
+                    await asyncio.sleep(delay)
                     continue
                 resp.raise_for_status()
                 return resp.text

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -6,6 +6,8 @@ import logging
 import random
 import threading
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 from urllib.parse import urlencode
 
@@ -16,6 +18,28 @@ from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import NetworkError, RateLimitError
 
 logger = logging.getLogger("pyscrappy.http")
+
+
+def parse_retry_after(value: str | None, default: float) -> float:
+    """Parse a ``Retry-After`` header value, which RFC 7231 allows as either
+    delay-seconds (e.g. ``"120"``) or an HTTP-date (e.g. ``"Wed, 21 Oct 2025 07:28:00 GMT"``).
+
+    Returns delay in seconds (>= 0.0). If value is missing or unparseable,
+    returns ``default``.
+    """
+    if not value:
+        return default
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(value)
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+    except (TypeError, ValueError, OverflowError):
+        return default
 
 
 def backoff_delay(config: ScraperConfig, attempt: int) -> float:
@@ -121,7 +145,9 @@ class HttpClient:
                 resp = client.get(url, headers=headers, follow_redirects=True, **kwargs)
 
                 if resp.status_code == 429:
-                    retry_after = float(resp.headers.get("Retry-After", self.config.retry_delay))
+                    retry_after = parse_retry_after(
+                        resp.headers.get("Retry-After"), self.config.retry_delay
+                    )
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
                         time.sleep(retry_after)
@@ -136,6 +162,8 @@ class HttpClient:
                 last_exc = exc
                 if exc.response.status_code >= 500 and attempt < self.config.max_retries:
                     delay = self._backoff_delay(attempt)
+                    if exc.response.status_code == 503 and "Retry-After" in exc.response.headers:
+                        delay = parse_retry_after(exc.response.headers.get("Retry-After"), delay)
                     logger.warning(
                         "Server error %s on %s, retry %d in %.1fs",
                         exc.response.status_code,
@@ -188,7 +216,10 @@ class HttpClient:
                 headers = self._merge_headers(extra_headers)
                 resp = client.post(url, headers=headers, follow_redirects=True, **kwargs)
                 if resp.status_code >= 500 and attempt < self.config.max_retries:
-                    time.sleep(self._backoff_delay(attempt))
+                    delay = self._backoff_delay(attempt)
+                    if resp.status_code == 503 and "Retry-After" in resp.headers:
+                        delay = parse_retry_after(resp.headers.get("Retry-After"), delay)
+                    time.sleep(delay)
                     continue
                 resp.raise_for_status()
                 return resp.text

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -5,7 +5,7 @@ is exercised elsewhere; here we confirm the async path works and mirrors the
 sync behavior (retries, caching, header handling).
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -150,3 +150,57 @@ def test_async_cache_key_handles_url_with_existing_query_string():
     key_b = client._cache_key("http://x?a=1?b=2", None)
     assert key_a != key_b
     assert key_a == "http://x?a=1&b=2"
+@pytest.mark.anyio
+async def test_async_get_429_http_date_retry_after():
+    config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+    client = AsyncHttpClient(config)
+
+    resp_429 = _resp(status=429)
+    resp_429.headers = {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}
+
+    resp_200 = _resp(text="ok")
+
+    mock = MagicMock()
+    mock.get = AsyncMock(side_effect=[resp_429, resp_200])
+    mock.aclose = AsyncMock()
+
+    client._client = mock
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        res = await client.get("https://example.com")
+        assert res.text == "ok"
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args[0][0] > 0
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_get_503_honors_retry_after():
+    config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+    client = AsyncHttpClient(config)
+
+    resp_503 = _resp(status=503)
+    resp_503.headers = {"Retry-After": "25"}
+    resp_503.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("503", request=MagicMock(), response=resp_503)
+    )
+
+    resp_200 = _resp(text="ok")
+
+    mock_1 = MagicMock()
+    mock_1.get = AsyncMock(return_value=resp_503)
+    mock_1.aclose = AsyncMock()
+
+    mock_2 = MagicMock()
+    mock_2.get = AsyncMock(return_value=resp_200)
+    mock_2.aclose = AsyncMock()
+
+    client._client = mock_1
+    client._build_client = MagicMock(side_effect=[mock_2])
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        res = await client.get("https://example.com")
+        assert res.text == "ok"
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args[0][0] == 25.0
+    await client.aclose()

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -150,9 +150,13 @@ def test_async_cache_key_handles_url_with_existing_query_string():
     key_b = client._cache_key("http://x?a=1?b=2", None)
     assert key_a != key_b
     assert key_a == "http://x?a=1&b=2"
+
+
 @pytest.mark.anyio
 async def test_async_get_429_http_date_retry_after():
-    config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+    # retry_delay=0.0 so a positive sleep can only come from actually parsing
+    # the HTTP-date header, not from the fallback default.
+    config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=0.0)
     client = AsyncHttpClient(config)
 
     resp_429 = _resp(status=429)

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -1,13 +1,14 @@
 """Tests for pyscrappy.core.http."""
 
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import NetworkError, RateLimitError
-from pyscrappy.core.http import HttpClient, backoff_delay
+from pyscrappy.core.http import HttpClient, backoff_delay, parse_retry_after
 
 
 class TestHttpClientInit:
@@ -226,6 +227,90 @@ class TestHttpClientGet:
         assert mock_httpx_1.get.call_count == 1
         assert mock_httpx_2.get.call_count == 1
         client.close()
+
+    def test_get_429_http_date_retry_after(self):
+        config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+        client = HttpClient(config)
+
+        # HTTP-date in the future (e.g. +10s)
+        resp_429 = MagicMock(spec=httpx.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}
+
+        resp_200 = MagicMock(spec=httpx.Response)
+        resp_200.status_code = 200
+        resp_200.raise_for_status = MagicMock()
+
+        mock_httpx = MagicMock()
+        mock_httpx.get.side_effect = [resp_429, resp_200]
+        client._client = mock_httpx
+
+        with patch("time.sleep") as mock_sleep:
+            res = client.get("https://example.com")
+            assert res.status_code == 200
+            assert mock_sleep.call_count == 1
+            assert mock_sleep.call_args[0][0] > 0
+        client.close()
+
+    def test_get_503_honors_retry_after(self):
+        config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+        client = HttpClient(config)
+
+        resp_503 = MagicMock(spec=httpx.Response)
+        resp_503.status_code = 503
+        resp_503.headers = {"Retry-After": "15"}
+
+        def raise_503():
+            raise httpx.HTTPStatusError(
+                "503 Service Unavailable",
+                request=MagicMock(),
+                response=resp_503,
+            )
+
+        resp_503.raise_for_status = raise_503
+
+        resp_200 = MagicMock(spec=httpx.Response)
+        resp_200.status_code = 200
+        resp_200.raise_for_status = MagicMock()
+
+        mock_httpx_1 = MagicMock()
+        mock_httpx_1.get.return_value = resp_503
+        mock_httpx_2 = MagicMock()
+        mock_httpx_2.get.return_value = resp_200
+
+        client._client = mock_httpx_1
+        client._build_client = MagicMock(side_effect=[mock_httpx_2])
+
+        with patch("time.sleep") as mock_sleep:
+            res = client.get("https://example.com")
+            assert res.status_code == 200
+            assert mock_sleep.call_count == 1
+            assert mock_sleep.call_args[0][0] == 15.0
+        client.close()
+
+
+class TestParseRetryAfter:
+    def test_numeric_delay_seconds(self):
+        assert parse_retry_after("120", 5.0) == 120.0
+        assert parse_retry_after("0", 5.0) == 0.0
+
+    def test_negative_delay_clamped_to_zero(self):
+        assert parse_retry_after("-10", 5.0) == 0.0
+
+    def test_none_or_empty_returns_default(self):
+        assert parse_retry_after(None, 5.0) == 5.0
+        assert parse_retry_after("", 5.0) == 5.0
+
+    def test_invalid_string_returns_default(self):
+        assert parse_retry_after("garbage-header-value", 5.0) == 5.0
+
+    def test_http_date_future(self):
+        # 100 seconds in the future
+        future_ts = datetime.now(timezone.utc).timestamp() + 100
+        future_dt = datetime.fromtimestamp(future_ts, tz=timezone.utc)
+        date_str = future_dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        parsed = parse_retry_after(date_str, 5.0)
+        assert 90.0 <= parsed <= 110.0
 
 
 class TestHttpClientRateLimit:

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -229,7 +229,9 @@ class TestHttpClientGet:
         client.close()
 
     def test_get_429_http_date_retry_after(self):
-        config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=1.0)
+        # retry_delay=0.0 so a positive sleep can only come from actually parsing
+        # the HTTP-date header, not from the fallback default.
+        config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=0.0)
         client = HttpClient(config)
 
         # HTTP-date in the future (e.g. +10s)


### PR DESCRIPTION
fixes #143

added a shared parse_retry_after helper in http.py to handle both delay-seconds and HTTP-date formats for Retry-After headers

updated sync and async HTTP clients to use this helper for 429 rate limit retries and 503 service unavailable responses

added unit tests for parse_retry_after, HTTP-date 429 handling, and 503 Retry-After support across sync and async clients