### PR TITLE
Fix derived selectors losing adaptive context

### DIFF
--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -65,6 +65,14 @@ class Selector:
 
         return urlparse(self._url).netloc or None
 
+    def _child(self, html: str | Tag) -> Selector:
+        return Selector(
+            html,
+            self._parser,
+            url=self._url,
+            adaptive_store=self._store,
+        )
+
     # -- basic access --
     @property
     def tag(self) -> str | None:
@@ -135,7 +143,7 @@ class Selector:
                     confidence = result.confidence
 
         return SelectorList(
-            [Selector(el, self._parser) for el in matches],
+            [self._child(el) for el in matches],
             pseudo=pseudo,
             attr=attr,
             adaptive_confidence=confidence,
@@ -161,9 +169,7 @@ class Selector:
             if isinstance(r, str):
                 strings.append(r)
             else:
-                selectors.append(
-                    Selector(BeautifulSoup(etree.tostring(r), self._parser), self._parser)
-                )
+                selectors.append(self._child(BeautifulSoup(etree.tostring(r), self._parser)))
         if strings:  # a text()/@attr XPath: expose the strings directly
             return SelectorList([], _strings=strings)
         return SelectorList(selectors)
@@ -176,7 +182,7 @@ class Selector:
         if class_ is not None:
             kwargs["class_"] = class_
         matches = self._node.find_all(name, **kwargs)
-        return SelectorList([Selector(el, self._parser) for el in matches])
+        return SelectorList([self._child(el) for el in matches])
 
     def find_by_text(self, text: str, tag: str | None = None, exact: bool = False) -> SelectorList:
         """Find elements whose text contains ``text`` (or equals it, if ``exact``).
@@ -190,7 +196,7 @@ class Selector:
         found = [
             el for el in self._node.find_all(tag or True) if isinstance(el, Tag) and matches(el)
         ]
-        return SelectorList([Selector(el, self._parser) for el in found])
+        return SelectorList([self._child(el) for el in found])
 
     def find_similar(self, limit: int | None = None) -> SelectorList:
         """Find sibling-level elements structurally similar to this one: same tag
@@ -207,7 +213,7 @@ class Selector:
             sib_classes = set(sib.get("class") or [])
             # Same tag, and (no classes to compare) or a shared class.
             if not my_classes or (my_classes & sib_classes):
-                similar.append(Selector(sib, self._parser))
+                similar.append(self._child(sib))
                 if limit is not None and len(similar) >= limit:
                     break
         return SelectorList(similar)
@@ -216,7 +222,7 @@ class Selector:
     @property
     def parent(self) -> Selector | None:
         p = getattr(self._node, "parent", None)
-        return Selector(p, self._parser) if isinstance(p, Tag) else None
+        return self._child(p) if isinstance(p, Tag) else None
 
     def __repr__(self) -> str:
         return f"<Selector {self.tag or 'document'}>"

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -204,6 +204,19 @@ def test_selector_css_namespaced_by_site(tmp_path):
     assert len(other) == 0  # no fingerprint saved for b.com
 
 
+def test_chained_selector_auto_save_can_heal_on_fresh_page(tmp_path):
+    store = AdaptiveStore(tmp_path / "a.json")
+    page_v1 = Selector(_V1, url="https://shop.example.com/p/1", adaptive_store=store)
+    card = page_v1.css(".product-card")[0]
+    card.css(".price", auto_save=True, adaptive_id="price")
+
+    page_v2 = Selector(_V2, url="https://shop.example.com/p/2", adaptive_store=store)
+    healed = page_v2.css(".missing-price", adaptive=True, adaptive_id="price")
+
+    assert len(healed) == 1
+    assert healed[0].attrs.get("data-testid") == "price"
+
+
 # --- comparison: our weighting beats a naive uniform average ---
 
 

--- a/tests/test_generic/test_selector.py
+++ b/tests/test_generic/test_selector.py
@@ -1,6 +1,7 @@
 """Tests for the chainable Selector parser."""
 
 from pyscrappy import Selector
+from pyscrappy.generic.adaptive_store import AdaptiveStore
 
 _HTML = """
 <html><body>
@@ -129,3 +130,23 @@ def test_selector_accepts_prebuilt_html_string():
     # The documented "use the parser directly" entry point.
     page = Selector("<div><p class='x'>hi</p></div>")
     assert page.css(".x::text").get() == "hi"
+
+
+def test_derived_selectors_preserve_url_and_adaptive_store(tmp_path):
+    store = AdaptiveStore(tmp_path / "adaptive.json")
+    page = Selector(_HTML, url="https://shop.example.com/products", adaptive_store=store)
+    product = page.css(".product")[0]
+    derived = [
+        product,
+        page.xpath("//div[@id='p1']")[0],
+        page.find_all("div", id="p1")[0],
+        page.find_by_text("Alpha", tag="h2", exact=True)[0],
+        product.find_similar()[0],
+        product.parent,
+    ]
+
+    for child in derived:
+        assert child is not None
+        assert child._url == "https://shop.example.com/products"
+        assert child._store is store
+        assert child._namespace() == "shop.example.com"


### PR DESCRIPTION
Fixes #144.

## Summary

- construct derived selectors through one helper that preserves the parent URL and adaptive store
- cover CSS, XPath, `find_all`, `find_by_text`, `find_similar`, and parent navigation
- prove a fingerprint saved from a chained selector can be healed from a fresh selector in the same site namespace

## Verification

- `pytest tests/test_generic/test_selector.py tests/test_generic/test_adaptive.py -v` (41 passed)
- `ruff check src/`
- focused lint for both changed test files
- bounded full suite: 490 passed, 1 skipped, 20 deselected

The default full-suite attempt in a no-network sandbox also ran 490 passing tests but exposed one unrelated existing HTTP retry test that performs a robots.txt lookup. It was excluded from the bounded full run; no HTTP behavior was changed here.
