### PR TITLE
chore: bump PyScrappy to 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.5.4] - 2026-08-14
+
+### Added
+- **`ScrapeResult.to_ndjson()` and `.to_yaml()` exporters**, and `save()` now infers `.ndjson`/`.jsonl` and `.yaml`/`.yml` from the file extension. YAML uses the optional `pyscrappy[yaml]` extra and is `safe_load`-round-trippable (#145).
+
+### Fixed
+- `Retry-After` is parsed for both the delay-seconds and HTTP-date forms (a date value no longer crashes the request), and it is now honored on `503` responses as well as `429`, across the sync and async clients (#143).
+- Derived/chained selectors (`page.css(...)[0]`, `find_all`, `find_similar`, `parent`, etc.) now preserve the parent's `url` and adaptive store, so per-site adaptive namespacing and healing work through a selector chain (#144).
+
 ## [1.5.3] - 2026-08-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.3"
+version = "1.5.4"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.3",
+  "version": "1.5.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 __all__ = [
     # Core


### PR DESCRIPTION
Patch release covering the Retry-After parsing/503 fix (#143), the NDJSON/YAML exporters (#145), and the derived-selector context fix (#144).