### PR TITLE
Fix offset-based pagination advancement and add tests

### DIFF
--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -1,85 +1,61 @@
-"""Automatic pagination detection."""
-
-from __future__ import annotations
-
-import re
-from urllib.parse import urljoin
-
-from bs4 import BeautifulSoup, Tag
-
-_NEXT_PATTERNS = re.compile(
-    r"(^next$|^>$|^>>$|^›$|^»$|next\s*page|next\s*›|load\s*more)",
-    re.IGNORECASE,
-)
-
-# Single source of truth for numbered-pagination URLs: the capture groups yield
-# the page number, and the same pattern is used both to *detect* a paginated URL
-# and to *extract* its number — so the two can't drift apart (which was the bug
-# behind #77, where detection matched offset=/start=//p/ but extraction didn't).
-_PAGE_NUMBER = re.compile(
-    r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)",
-    re.IGNORECASE,
-)
-
-
-def find_next_page_url(soup: BeautifulSoup, current_url: str) -> str | None:
-    """Detect the next-page URL from the current page's HTML.
-
-    Looks for:
-    1. ``<link rel="next">`` in ``<head>``
-    2. ``<a>`` tags whose text matches "next", ">", ">>", etc.
-    3. ``<a>`` tags whose class/aria-label suggest pagination
-
-    Returns the absolute URL of the next page, or ``None`` if not found.
-    """
-    # 1. <link rel="next">
-    link_next = soup.find("link", rel="next")
-    if link_next and isinstance(link_next, Tag):
-        href = link_next.get("href")
-        if href:
-            return urljoin(current_url, str(href))
-
-    # 2. <a> with "next" text or aria-label
-    for a in soup.find_all("a", href=True):
-        text = a.get_text(strip=True)
-        aria = str(a.get("aria-label", ""))
-        classes = " ".join(a.get("class", []))
-
-        if _NEXT_PATTERNS.search(text) or _NEXT_PATTERNS.search(aria):
-            return urljoin(current_url, str(a["href"]))
-
-        if "next" in classes.lower() and _PAGE_NUMBER.search(str(a["href"])):
-            return urljoin(current_url, str(a["href"]))
-
-    # 3. Look for numbered pagination links and pick the next number
-    page_links = _find_page_number_links(soup, current_url)
-    if page_links:
-        current_num = _extract_page_number(current_url)
-        if current_num is not None:
-            target = current_num + 1
-            for num, url in page_links:
-                if num == target:
-                    return url
-
+def _extract_page_number(self, url):
+    match = self._PAGE_NUMBER.search(url)
+    if match:
+        # Check if the matched group is for offset or start
+        if match.group(1) and ('offset=' in url or 'start=' in url):
+            # Return the current offset value
+            return int(match.group(1))
+        elif match.group(2):
+            # Return the current page number
+            return int(match.group(2))
     return None
 
 
-def _find_page_number_links(soup: BeautifulSoup, base_url: str) -> list[tuple[int, str]]:
-    """Find pagination links that contain page numbers."""
-    results: list[tuple[int, str]] = []
-    for a in soup.find_all("a", href=True):
-        href = str(a["href"])
-        if not _PAGE_NUMBER.search(href):
-            continue
-        num = _extract_page_number(href)
-        if num is not None:
-            results.append((num, urljoin(base_url, href)))
-    return results
+def find_next_page_url(self, url, page_size):
+    match = self._PAGE_NUMBER.search(url)
+    if match:
+        if match.group(1) and ('offset=' in url or 'start=' in url):
+            # Calculate the next offset value
+            current_offset = int(match.group(1))
+            next_offset = current_offset + page_size
+            return url.replace(match.group(1), str(next_offset))
+        elif match.group(2):
+            # Calculate the next page number
+            current_page = int(match.group(2))
+            next_page = current_page + 1
+            return url.replace(match.group(2), str(next_page))
+    return None
 
+# Add tests to verify the changes
+import unittest
 
-def _extract_page_number(url: str) -> int | None:
-    """Extract a page number from a URL, or None if it isn't paginated."""
-    match = _PAGE_NUMBER.search(url)
-    if not match:
-        return None
-    return int(match.group(1) or match.group(2))
+class TestPagination(unittest.TestCase):
+    def setUp(self):
+        self.pagination = Pagination()
+
+    def test_extract_page_number_offset(self):
+        url = 'https://example.com/api?offset=10'
+        self.assertEqual(self.pagination._extract_page_number(url), 10)
+
+    def test_extract_page_number_start(self):
+        url = 'https://example.com/api?start=20'
+        self.assertEqual(self.pagination._extract_page_number(url), 20)
+
+    def test_extract_page_number_page(self):
+        url = 'https://example.com/api?page=3'
+        self.assertEqual(self.pagination._extract_page_number(url), 3)
+
+    def test_find_next_page_url_offset(self):
+        url = 'https://example.com/api?offset=10'
+        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?offset=15')
+
+    def test_find_next_page_url_start(self):
+        url = 'https://example.com/api?start=20'
+        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?start=25')
+
+    def test_find_next_page_url_page(self):
+        url = 'https://example.com/api?page=3'
+        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?page=4')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -1,61 +1,114 @@
-def _extract_page_number(self, url):
-    match = self._PAGE_NUMBER.search(url)
-    if match:
-        # Check if the matched group is for offset or start
-        if match.group(1) and ('offset=' in url or 'start=' in url):
-            # Return the current offset value
-            return int(match.group(1))
-        elif match.group(2):
-            # Return the current page number
-            return int(match.group(2))
+"""Automatic pagination detection."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup, Tag
+
+_NEXT_PATTERNS = re.compile(
+    r"(^next$|^>$|^>>$|^›$|^»$|next\s*page|next\s*›|load\s*more)",
+    re.IGNORECASE,
+)
+
+# Single source of truth for numbered-pagination URLs: the capture groups yield
+# the page number, and the same pattern is used both to *detect* a paginated URL
+# and to *extract* its number — so the two can't drift apart (which was the bug
+# behind #77, where detection matched offset=/start=//p/ but extraction didn't).
+_PAGE_NUMBER = re.compile(
+    r"[?&](?:page|p|pg|offset|start)=(\d+)|/(?:page|p)/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def find_next_page_url(soup: BeautifulSoup, current_url: str) -> str | None:
+    """Detect the next-page URL from the current page's HTML.
+
+    Looks for:
+    1. ``<link rel="next">`` in ``<head>``
+    2. ``<a>`` tags whose text matches "next", ">", ">>", etc.
+    3. ``<a>`` tags whose class/aria-label suggest pagination
+
+    Returns the absolute URL of the next page, or ``None`` if not found.
+    """
+    # 1. <link rel="next">
+    link_next = soup.find("link", rel="next")
+    if link_next and isinstance(link_next, Tag):
+        href = link_next.get("href")
+        if href:
+            return urljoin(current_url, str(href))
+
+    # 2. <a> with "next" text or aria-label
+    for a in soup.find_all("a", href=True):
+        text = a.get_text(strip=True)
+        aria = str(a.get("aria-label", ""))
+        classes = " ".join(a.get("class", []))
+
+        if _NEXT_PATTERNS.search(text) or _NEXT_PATTERNS.search(aria):
+            return urljoin(current_url, str(a["href"]))
+
+        if "next" in classes.lower() and _PAGE_NUMBER.search(str(a["href"])):
+            return urljoin(current_url, str(a["href"]))
+
+    # 3. Look for numbered pagination links and pick the next number
+    page_links = _find_page_number_links(soup, current_url)
+    if page_links:
+        current_num = _extract_page_number(current_url)
+        if current_num is not None:
+            step = _page_step(current_url, page_links)
+            if step is None:
+                return None
+            target = current_num + step
+            for num, url in page_links:
+                if num == target:
+                    return url
+
     return None
 
 
-def find_next_page_url(self, url, page_size):
-    match = self._PAGE_NUMBER.search(url)
-    if match:
-        if match.group(1) and ('offset=' in url or 'start=' in url):
-            # Calculate the next offset value
-            current_offset = int(match.group(1))
-            next_offset = current_offset + page_size
-            return url.replace(match.group(1), str(next_offset))
-        elif match.group(2):
-            # Calculate the next page number
-            current_page = int(match.group(2))
-            next_page = current_page + 1
-            return url.replace(match.group(2), str(next_page))
-    return None
+def _page_step(current_url: str,
+               page_links: list[tuple[int, str]]) -> int | None:
+    """Increment between numbered pages.
 
-# Add tests to verify the changes
-import unittest
+    For offset=/start= URLs the step is the page size, inferred from the gaps
+    between the page-link values (issue #151: +1 is almost always wrong there).
+    For page/p URLs the step is always 1.
+    """
+    if _is_offset_style(current_url):
+        values = sorted({num for num, _ in page_links})
+        steps = {b - a for a, b in zip(values, values[1:]) if b > a}
+        if steps:
+            return min(steps)
+        return None
+    return 1
 
-class TestPagination(unittest.TestCase):
-    def setUp(self):
-        self.pagination = Pagination()
 
-    def test_extract_page_number_offset(self):
-        url = 'https://example.com/api?offset=10'
-        self.assertEqual(self.pagination._extract_page_number(url), 10)
+def _is_offset_style(url: str) -> bool:
+    """True if the URL's numbered parameter is offset=/start=."""
+    match = _PAGE_NUMBER.search(url)
+    if not match or match.group(1) is None:
+        return False
+    key = url[match.start():match.start(1)].lstrip("?&").rstrip("=").lower()
+    return key in ("offset", "start")
 
-    def test_extract_page_number_start(self):
-        url = 'https://example.com/api?start=20'
-        self.assertEqual(self.pagination._extract_page_number(url), 20)
 
-    def test_extract_page_number_page(self):
-        url = 'https://example.com/api?page=3'
-        self.assertEqual(self.pagination._extract_page_number(url), 3)
+def _find_page_number_links(soup: BeautifulSoup, base_url: str) -> list[tuple[int, str]]:
+    """Find pagination links that contain page numbers."""
+    results: list[tuple[int, str]] = []
+    for a in soup.find_all("a", href=True):
+        href = str(a["href"])
+        if not _PAGE_NUMBER.search(href):
+            continue
+        num = _extract_page_number(href)
+        if num is not None:
+            results.append((num, urljoin(base_url, href)))
+    return results
 
-    def test_find_next_page_url_offset(self):
-        url = 'https://example.com/api?offset=10'
-        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?offset=15')
 
-    def test_find_next_page_url_start(self):
-        url = 'https://example.com/api?start=20'
-        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?start=25')
-
-    def test_find_next_page_url_page(self):
-        url = 'https://example.com/api?page=3'
-        self.assertEqual(self.pagination.find_next_page_url(url, 5), 'https://example.com/api?page=4')
-
-if __name__ == '__main__':
-    unittest.main()
+def _extract_page_number(url: str) -> int | None:
+    """Extract a page number from a URL, or None if it isn't paginated."""
+    match = _PAGE_NUMBER.search(url)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))

--- a/src/pyscrappy/generic/pagination.py
+++ b/src/pyscrappy/generic/pagination.py
@@ -67,8 +67,7 @@ def find_next_page_url(soup: BeautifulSoup, current_url: str) -> str | None:
     return None
 
 
-def _page_step(current_url: str,
-               page_links: list[tuple[int, str]]) -> int | None:
+def _page_step(current_url: str, page_links: list[tuple[int, str]]) -> int | None:
     """Increment between numbered pages.
 
     For offset=/start= URLs the step is the page size, inferred from the gaps
@@ -89,7 +88,7 @@ def _is_offset_style(url: str) -> bool:
     match = _PAGE_NUMBER.search(url)
     if not match or match.group(1) is None:
         return False
-    key = url[match.start():match.start(1)].lstrip("?&").rstrip("=").lower()
+    key = url[match.start() : match.start(1)].lstrip("?&").rstrip("=").lower()
     return key in ("offset", "start")
 
 

--- a/tests/test_generic/test_pagination_offsets.py
+++ b/tests/test_generic/test_pagination_offsets.py
@@ -13,28 +13,27 @@ def _soup(html: str) -> BeautifulSoup:
     return BeautifulSoup(html, "lxml")
 
 
-def _links(offsets):
-    return _soup("".join(
-        '<a href="/list?offset=%d">p%d</a>' % (o, i)
-        for i, o in enumerate(offsets)))
+def _links(values, param="offset"):
+    return _soup(
+        "".join('<a href="/list?%s=%d">p%d</a>' % (param, v, i) for i, v in enumerate(values))
+    )
 
 
 def test_offset_pagination_advances_by_inferred_page_size():
-    # ссылки 0/20/40/60 -> шаг 20; текущая offset=20 -> следующая 40
+    # links at 0/20/40/60 -> step 20; current offset=20 -> next is 40
     soup = _links([0, 20, 40, 60])
     result = find_next_page_url(soup, "https://x.com/list?offset=20")
     assert result == "https://x.com/list?offset=40"
 
 
 def test_start_pagination_advances_by_inferred_page_size():
-    soup = _links([0, 50, 100])
+    soup = _links([0, 50, 100], param="start")
     result = find_next_page_url(soup, "https://x.com/list?start=0")
     assert result == "https://x.com/list?start=50"
 
 
 def test_offset_step_is_inferred_not_hardcoded():
-    assert _page_step("https://x.com/list?offset=20",
-                      [(20, ""), (45, ""), (70, "")]) == 25
+    assert _page_step("https://x.com/list?offset=20", [(20, ""), (45, ""), (70, "")]) == 25
 
 
 def test_page_param_still_advances_by_one():

--- a/tests/test_generic/test_pagination_offsets.py
+++ b/tests/test_generic/test_pagination_offsets.py
@@ -1,0 +1,52 @@
+"""Regression tests for offset/start pagination (issue #151)."""
+
+from bs4 import BeautifulSoup
+
+from pyscrappy.generic.pagination import (
+    _extract_page_number,
+    _page_step,
+    find_next_page_url,
+)
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "lxml")
+
+
+def _links(offsets):
+    return _soup("".join(
+        '<a href="/list?offset=%d">p%d</a>' % (o, i)
+        for i, o in enumerate(offsets)))
+
+
+def test_offset_pagination_advances_by_inferred_page_size():
+    # ссылки 0/20/40/60 -> шаг 20; текущая offset=20 -> следующая 40
+    soup = _links([0, 20, 40, 60])
+    result = find_next_page_url(soup, "https://x.com/list?offset=20")
+    assert result == "https://x.com/list?offset=40"
+
+
+def test_start_pagination_advances_by_inferred_page_size():
+    soup = _links([0, 50, 100])
+    result = find_next_page_url(soup, "https://x.com/list?start=0")
+    assert result == "https://x.com/list?start=50"
+
+
+def test_offset_step_is_inferred_not_hardcoded():
+    assert _page_step("https://x.com/list?offset=20",
+                      [(20, ""), (45, ""), (70, "")]) == 25
+
+
+def test_page_param_still_advances_by_one():
+    soup = _soup('<a href="?page=2">2</a><a href="?page=3">3</a>')
+    result = find_next_page_url(soup, "https://x.com/list?page=1")
+    assert result == "https://x.com/list?page=2"
+
+
+def test_offset_without_link_steps_returns_none():
+    soup = _links([20])
+    assert find_next_page_url(soup, "https://x.com/list?offset=20") is None
+
+
+def test_extract_offset_value():
+    assert _extract_page_number("https://x.com/list?offset=20") == 20


### PR DESCRIPTION
Closes #151. The offset-based pagination was incorrectly advancing by 1, which is now fixed to advance by the page size. Added tests to verify the changes. Verified by running the tests locally and checking the pagination behavior.