### PR TITLE
fix(cache): bound the shared response cache with an LRU eviction policy

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -23,7 +23,6 @@ from pyscrappy.core import scraper_api
 from pyscrappy.core.config import ScraperConfig
 from pyscrappy.core.exceptions import NetworkError, RateLimitError
 from pyscrappy.core.http import (
-    _CACHE_LOCK,
     _SHARED_CACHE,
     backoff_delay,
     parse_retry_after,
@@ -240,20 +239,11 @@ class AsyncHttpClient:
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:
             return None
-        with _CACHE_LOCK:
-            entry = _SHARED_CACHE.get(key)
-            if entry is None:
-                return None
-            ts, resp = entry
-            if time.monotonic() - ts > self.config.cache_ttl:
-                del _SHARED_CACHE[key]
-                return None
-            return resp
+        return _SHARED_CACHE.get(key, self.config.cache_ttl)
 
     def _cache_put(self, key: str, resp: httpx.Response) -> None:
         if self.config.cache_ttl > 0:
-            with _CACHE_LOCK:
-                _SHARED_CACHE[key] = (time.monotonic(), resp)
+            _SHARED_CACHE.put(key, resp, self.config.cache_max_size)
 
     async def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         domain = urlparse(url).netloc

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -58,6 +58,10 @@ class ScraperConfig:
         cache_ttl: Seconds to cache successful GET responses in memory. ``0``
             (the default) disables caching. When set, repeated requests for the
             same URL within the TTL skip the network and the rate limiter.
+        cache_max_size: Maximum number of live entries in the shared response
+            cache. The cache is LRU-bounded, so a long-running process (e.g. an
+            MCP server) that fetches many distinct URLs stays within this cap
+            rather than growing until restart. Defaults to ``512``.
         impersonate: Impersonate a real browser's TLS/JA3 fingerprint on the
             sync HTTP path, to get past anti-bot filters that block plain clients
             (e.g. ``"chrome"``, ``"chrome124"``, ``"safari"``, ``"firefox"``).
@@ -82,6 +86,7 @@ class ScraperConfig:
     headless: bool = True
     verify_ssl: bool = True
     cache_ttl: float = 0.0
+    cache_max_size: int = 512
     impersonate: str | None = None
 
     def pick_proxy(self, exclude: str | None = None) -> str | None:

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -6,6 +6,7 @@ import logging
 import random
 import threading
 import time
+from collections import OrderedDict
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
@@ -56,12 +57,64 @@ def backoff_delay(config: ScraperConfig, attempt: int) -> float:
     return delay
 
 
-# Process-wide response cache, shared across all HttpClient instances. This lets
-# caching survive the short-lived scraper instances that callers (e.g. the MCP
-# server) create per request. Entries are (monotonic timestamp, response). Only
-# populated when a client's config.cache_ttl > 0; guarded by a lock because
-# scrapers may run in worker threads.
-_SHARED_CACHE: dict[str, tuple[float, httpx.Response]] = {}
+# Default cap on the number of live response-cache entries. Bounds memory for
+# long-running processes (e.g. an MCP server) that fetch many distinct URLs; a
+# client may override it via config.cache_max_size.
+_DEFAULT_CACHE_MAX_SIZE = 512
+
+
+class _ResponseCache:
+    """Process-wide response cache shared across all HttpClient/AsyncHttpClient
+    instances. This lets caching survive the short-lived scraper instances that
+    callers (e.g. the MCP server) create per request.
+
+    Bounded by an LRU policy: at most ``max_size`` live entries, oldest evicted
+    first on insert. TTL is still per-entry (each client passes its own on read),
+    and expired entries are dropped on access — but the size cap guarantees the
+    cache stays bounded even for keys that are never re-requested, which a plain
+    dict could not. Guarded by a lock because scrapers may run in worker threads.
+    """
+
+    def __init__(self, max_size: int = _DEFAULT_CACHE_MAX_SIZE) -> None:
+        self._store: OrderedDict[str, tuple[float, httpx.Response]] = OrderedDict()
+        self._max_size = max_size
+        self._lock = threading.Lock()
+
+    def get(self, key: str, ttl: float) -> httpx.Response | None:
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            ts, resp = entry
+            if time.monotonic() - ts > ttl:
+                del self._store[key]  # expired
+                return None
+            self._store.move_to_end(key)  # mark as most-recently used
+            return resp
+
+    def put(self, key: str, resp: httpx.Response, max_size: int | None = None) -> None:
+        cap = self._max_size if max_size is None else max_size
+        with self._lock:
+            self._store[key] = (time.monotonic(), resp)
+            self._store.move_to_end(key)
+            while len(self._store) > cap:
+                self._store.popitem(last=False)  # evict least-recently used
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+# The single shared cache instance. Kept module-level (not per-client) so it is
+# shared across every scraper/client in the process.
+_SHARED_CACHE = _ResponseCache()
+
+# Retained for backward compatibility: the async client imports this lock. The
+# cache now owns its own lock, so this is unused internally but kept exported.
 _CACHE_LOCK = threading.Lock()
 
 
@@ -309,26 +362,16 @@ class HttpClient:
     def _cache_get(self, key: str) -> httpx.Response | None:
         if self.config.cache_ttl <= 0:
             return None
-        with _CACHE_LOCK:
-            entry = _SHARED_CACHE.get(key)
-            if entry is None:
-                return None
-            ts, resp = entry
-            if time.monotonic() - ts > self.config.cache_ttl:
-                del _SHARED_CACHE[key]  # expired
-                return None
-            return resp
+        return _SHARED_CACHE.get(key, self.config.cache_ttl)
 
     def _cache_put(self, key: str, resp: httpx.Response) -> None:
         if self.config.cache_ttl > 0:
-            with _CACHE_LOCK:
-                _SHARED_CACHE[key] = (time.monotonic(), resp)
+            _SHARED_CACHE.put(key, resp, self.config.cache_max_size)
 
     @staticmethod
     def clear_cache() -> None:
         """Empty the process-wide response cache."""
-        with _CACHE_LOCK:
-            _SHARED_CACHE.clear()
+        _SHARED_CACHE.clear()
 
     def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         from urllib.parse import urlparse

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -500,3 +500,31 @@ class TestHttpClientCaching:
         client.get_raw("https://example.com")
         assert mock_httpx.get.call_count == 2
         client.close()
+
+    def test_cache_is_bounded_by_max_size(self):
+        # A long-running process that fetches many distinct URLs must not grow the
+        # cache without limit: only the last `cache_max_size` entries stay live.
+        import pyscrappy.core.http as http_mod
+
+        client, _ = self._mock_client(ScraperConfig(rate_limit=0, cache_ttl=60, cache_max_size=3))
+        for i in range(10):
+            client.get(f"https://example.com/{i}")
+        assert len(http_mod._SHARED_CACHE) == 3
+        client.close()
+
+    def test_lru_evicts_least_recently_used(self):
+        # Re-reading an entry marks it most-recently-used, so it survives eviction
+        # while an untouched neighbour is dropped.
+        client, mock_httpx = self._mock_client(
+            ScraperConfig(rate_limit=0, cache_ttl=60, cache_max_size=2)
+        )
+        client.get("https://example.com/a")  # network
+        client.get("https://example.com/b")  # network; cache = [a, b]
+        client.get("https://example.com/a")  # cache hit; a now MRU, b now LRU
+        client.get("https://example.com/c")  # network; evicts b, cache = [a, c]
+        assert mock_httpx.get.call_count == 3
+        client.get("https://example.com/a")  # still cached -> no network
+        assert mock_httpx.get.call_count == 3
+        client.get("https://example.com/b")  # evicted -> re-fetch
+        assert mock_httpx.get.call_count == 4
+        client.close()


### PR DESCRIPTION
The process-wide response cache was a plain dict with no size limit. TTL was enforced lazily only on re-request of the same key, so a URL fetched once and never again lived until process restart. A long-running process (e.g. the MCP server) fetching many distinct URLs with cache_ttl set would grow unbounded.

Replace it with an OrderedDict-backed LRU (_ResponseCache): capped at cache_max_size live entries (new config field, default 512), oldest evicted on insert, hits promoted to most-recently-used, expired entries still dropped on access. Both HttpClient and AsyncHttpClient now delegate to the single shared instance instead of each carrying its own get/put logic.