### PR TITLE
feat(adaptive): audit log for heals and an expect contract for reloca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.5.5] - 2026-08-17
+
+### Added
+- **Semantic contract on adaptive heals.** `Selector.css(..., expect=<callable>)` requires a relocated element to satisfy a caller-supplied invariant (e.g. text looks like a price); a heal that clears the structural threshold but fails the contract is rejected, so structural similarity alone can't redefine what a field means.
+- **Heal audit log.** Every accepted heal is appended to an append-only NDJSON log beside the fingerprint store (`adaptive.heal.ndjson`), recording confidence, runner-up gap, and the before/after fingerprint. Read it via `AdaptiveStore.heal_log(identifier=None, namespace=None)` so selector drift stays observable.
+- **`cache_max_size` config field** (default `512`). The in-memory response cache is now LRU-bounded, so a long-running process (e.g. the MCP server) that fetches many distinct URLs no longer grows without limit.
+
 ## [1.5.4] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -331,9 +331,16 @@ from pyscrappy import Selector
 page = Selector(html_v1, url="https://shop.example.com")
 price = page.css(".price", auto_save=True, adaptive_id="price").get()
 
-# Later, after a redesign renamed ".price" — heal instead of breaking:
+# Later, after a redesign renamed ".price" — heal instead of breaking.
+# `expect` is an optional contract: the relocated element must satisfy it,
+# so a good structural score can't smuggle in the wrong field.
 page = Selector(html_v2, url="https://shop.example.com")
-result = page.css(".price", adaptive=True, adaptive_id="price")
+result = page.css(
+    ".price",
+    adaptive=True,
+    adaptive_id="price",
+    expect=lambda s: s.text().startswith("$"),
+)
 print(result.get(), "→ confidence:", result.adaptive_confidence)
 ```
 
@@ -347,6 +354,16 @@ How the relocation decides — and where it's stronger than a naive similarity m
   healing stays reliable on exactly the fields that change most between scrapes.
 - **Confidence-scored.** `SelectorList.adaptive_confidence` (0-100) tells you how
   sure the relocation was; `threshold=` sets the minimum to accept.
+- **Contract-enforced (opt-in).** Pass `expect=<callable>` to require the healed
+  element to satisfy an invariant (e.g. "text looks like a price"). A heal that
+  clears the threshold but fails the contract is rejected, so structural
+  similarity alone never redefines what a field means.
+
+A heal is a change to what a selector resolves to, so **every accepted heal is
+recorded**. The store keeps an append-only audit log (`adaptive.heal.ndjson`
+beside the fingerprint store) with the confidence, the runner-up gap, and the
+before/after fingerprint, readable via `store.heal_log()` — so drift stays
+observable instead of being silently absorbed.
 
 Fingerprints persist in a small JSON store (`~/.pyscrappy/adaptive.json` by
 default, or `$PYSCRAPPY_HOME`), namespaced by site so the same `adaptive_id` on
@@ -501,6 +518,15 @@ with WikipediaScraper(config) as ws:
 The cache is in memory and shared across scraper instances in the same process
 (so it also speeds up repeated calls through the MCP server), and is cleared
 when the process exits. Call `HttpClient.clear_cache()` to empty it manually.
+
+It is **LRU-bounded**: at most `cache_max_size` live entries (default `512`),
+with the least-recently-used entry evicted once the cap is reached. So a
+long-running process (e.g. the MCP server) that fetches many distinct URLs stays
+bounded rather than growing until restart. Raise or lower the cap as needed:
+
+```python
+config = ScraperConfig(cache_ttl=300, cache_max_size=2000)
+```
 
 ## Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.4"
+version = "1.5.5"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.4",
+  "version": "1.5.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/generic/adaptive_store.py
+++ b/src/pyscrappy/generic/adaptive_store.py
@@ -22,6 +22,14 @@ def default_store_path() -> Path:
     return root / "adaptive.json"
 
 
+def _heal_log_path(store_path: Path) -> Path:
+    """The heal-log lives beside the fingerprint store as ``<name>.heal.ndjson``.
+
+    NDJSON (one heal per line, append-only) so the audit trail accumulates every
+    relocation instead of being overwritten the way a fingerprint is."""
+    return store_path.with_suffix(".heal.ndjson")
+
+
 class AdaptiveStore:
     """Load/save element fingerprints to a JSON file, namespaced by site."""
 
@@ -76,3 +84,58 @@ class AdaptiveStore:
 
     def retrieve(self, identifier: str, namespace: str | None = None) -> dict[str, Any] | None:
         return self._load().get(self._key(identifier, namespace))
+
+    def record_heal(
+        self,
+        identifier: str,
+        *,
+        namespace: str | None,
+        confidence: float,
+        runner_up_gap: float,
+        before: dict[str, Any] | None,
+        after: dict[str, Any],
+    ) -> None:
+        """Append one relocation to the append-only heal log.
+
+        A heal is a change to what a selector resolves to, so it is recorded with
+        the fingerprint *before* and *after*, plus the confidence and the gap to
+        the runner-up. This keeps drift observable: the log is the audit trail that
+        an in-place fingerprint overwrite would otherwise erase.
+        """
+        from datetime import datetime, timezone
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "identifier": identifier,
+            "namespace": namespace,
+            "confidence": confidence,
+            "runner_up_gap": runner_up_gap,
+            "before": before,
+            "after": after,
+        }
+        log_path = _heal_log_path(self.path)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def heal_log(self, identifier: str | None = None, namespace: str | None = None) -> list[dict]:
+        """Return recorded heals, newest last. Optionally filter by identifier
+        and/or namespace. Empty list if nothing has healed yet."""
+        log_path = _heal_log_path(self.path)
+        if not log_path.exists():
+            return []
+        entries: list[dict] = []
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if identifier is not None and entry.get("identifier") != identifier:
+                continue
+            if namespace is not None and entry.get("namespace") != namespace:
+                continue
+            entries.append(entry)
+        return entries

--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -101,6 +101,7 @@ class Selector:
         auto_save: bool = False,
         adaptive_id: str | None = None,
         threshold: float = 55.0,
+        expect: Any = None,
     ) -> SelectorList:
         """Select descendants by CSS. Supports a trailing ``::text`` or
         ``::attr(name)`` pseudo-element (the values are read via ``.get()`` /
@@ -113,9 +114,16 @@ class Selector:
         - ``adaptive=True`` — if the selector matches nothing, relocate the saved
           element by structural/textual similarity instead of returning empty.
         - ``threshold`` is the minimum confidence (0-100) to accept a relocation.
+        - ``expect`` is an optional semantic contract: a callable
+          ``(Selector) -> bool`` that the relocated element must satisfy for the
+          heal to be accepted. A heal that clears ``threshold`` but fails
+          ``expect`` is rejected (returns empty), so a high structural score can't
+          smuggle in the wrong field. Use it to assert field identity, e.g.
+          ``expect=lambda s: s.text().startswith("$")``.
 
         The relocation confidence is available on the returned list's
-        ``adaptive_confidence`` attribute when healing occurred.
+        ``adaptive_confidence`` attribute when healing occurred. Every accepted
+        heal is appended to the store's audit log (see ``AdaptiveStore.heal_log``).
         """
         m = _PSEUDO.match(selector)
         base, pseudo, attr = selector, None, None
@@ -133,14 +141,30 @@ class Selector:
 
         confidence = None
         if not matches and adaptive:
-            from pyscrappy.generic.adaptive import relocate
+            from pyscrappy.generic.adaptive import fingerprint, relocate
 
-            fp = self._adaptive_store().retrieve(key, namespace=self._namespace())
+            store = self._adaptive_store()
+            ns = self._namespace()
+            fp = store.retrieve(key, namespace=ns)
             if fp is not None:
                 result = relocate(fp, self._node, threshold=threshold)
                 if result.element is not None:
-                    matches = [result.element]
-                    confidence = result.confidence
+                    healed = self._child(result.element)
+                    # Semantic contract: a strong structural score is not enough —
+                    # if the caller supplied an invariant, the relocated element
+                    # must satisfy it, or the heal is rejected as a likely misread.
+                    if expect is None or expect(healed):
+                        matches = [result.element]
+                        confidence = result.confidence
+                        # Record the heal so drift stays observable (audit trail).
+                        store.record_heal(
+                            key,
+                            namespace=ns,
+                            confidence=result.confidence,
+                            runner_up_gap=result.runner_up_gap,
+                            before=fp,
+                            after=fingerprint(result.element),
+                        )
 
         return SelectorList(
             [self._child(el) for el in matches],

--- a/tests/test_generic/test_adaptive.py
+++ b/tests/test_generic/test_adaptive.py
@@ -217,6 +217,90 @@ def test_chained_selector_auto_save_can_heal_on_fresh_page(tmp_path):
     assert healed[0].attrs.get("data-testid") == "price"
 
 
+# --- audit trail: every heal is recorded so drift stays observable ---
+
+
+def test_heal_is_recorded_in_audit_log(tmp_path):
+    store = AdaptiveStore(tmp_path / "a.json")
+    Selector(_V1, url="https://shop.example.com", adaptive_store=store).css(
+        ".price", auto_save=True, adaptive_id="price"
+    )
+    # No heal yet: only a normal save happened.
+    assert store.heal_log() == []
+
+    healed = Selector(_V2, url="https://shop.example.com", adaptive_store=store).css(
+        ".price", adaptive=True, adaptive_id="price"
+    )
+    assert len(healed) == 1
+
+    log = store.heal_log()
+    assert len(log) == 1
+    entry = log[0]
+    assert entry["identifier"] == "price"
+    assert entry["namespace"] == "shop.example.com"
+    assert entry["confidence"] >= 55
+    assert "runner_up_gap" in entry
+    # before/after fingerprints make the change auditable: the price value moved
+    # from the v1 markup to the v2 markup.
+    assert entry["before"]["text"] == "$29.99"
+    assert entry["after"]["text"] == "$24.99"
+    assert "timestamp" in entry
+
+
+def test_heal_log_filters_by_identifier_and_namespace(tmp_path):
+    store = AdaptiveStore(tmp_path / "a.json")
+    for site in ("https://a.com", "https://b.com"):
+        Selector(_V1, url=site, adaptive_store=store).css(
+            ".price", auto_save=True, adaptive_id="price"
+        )
+        Selector(_V2, url=site, adaptive_store=store).css(
+            ".price", adaptive=True, adaptive_id="price"
+        )
+
+    assert len(store.heal_log()) == 2
+    assert len(store.heal_log(namespace="a.com")) == 1
+    assert store.heal_log(namespace="a.com")[0]["namespace"] == "a.com"
+    assert len(store.heal_log(identifier="price")) == 2
+    assert store.heal_log(identifier="nope") == []
+
+
+# --- semantic contract: a heal must satisfy the caller's field invariant ---
+
+
+def test_expect_contract_accepts_a_valid_heal(tmp_path):
+    store = AdaptiveStore(tmp_path / "a.json")
+    Selector(_V1, url="https://shop.example.com", adaptive_store=store).css(
+        ".price", auto_save=True, adaptive_id="price"
+    )
+    # Contract: the healed element's text must look like a price. It does.
+    healed = Selector(_V2, url="https://shop.example.com", adaptive_store=store).css(
+        ".price",
+        adaptive=True,
+        adaptive_id="price",
+        expect=lambda s: s.text().startswith("$"),
+    )
+    assert len(healed) == 1
+    assert healed.adaptive_confidence is not None
+
+
+def test_expect_contract_rejects_a_heal_that_fails_the_invariant(tmp_path):
+    store = AdaptiveStore(tmp_path / "a.json")
+    Selector(_V1, url="https://shop.example.com", adaptive_store=store).css(
+        ".price", auto_save=True, adaptive_id="price"
+    )
+    # Contract the relocated element cannot satisfy: even a high structural score
+    # is rejected, and nothing is written to the audit log.
+    healed = Selector(_V2, url="https://shop.example.com", adaptive_store=store).css(
+        ".price",
+        adaptive=True,
+        adaptive_id="price",
+        expect=lambda s: "IMPOSSIBLE" in s.text(),
+    )
+    assert len(healed) == 0
+    assert healed.adaptive_confidence is None
+    assert store.heal_log() == []  # a rejected heal leaves no trail
+
+
 # --- comparison: our weighting beats a naive uniform average ---
 
 


### PR DESCRIPTION
…tion

Two gaps in self-healing selectors: a heal left no persistent record (an in-place fingerprint overwrite erased the drift trail), and a strong structural score was accepted without any check that the relocated element is still the field the caller wanted.

- AdaptiveStore.record_heal/heal_log: every accepted heal is appended to an append-only NDJSON log beside the store, capturing confidence, runner-up gap, and the before/after fingerprint. Drift stays observable and auditable.
- Selector.css(expect=...): an optional (Selector) -> bool contract the relocated element must satisfy. A heal that clears the structural threshold but fails the invariant is rejected and not recorded, so structural similarity cannot smuggle in the wrong field.