### PR TITLE
fix(core): create parent directories in ScrapeResult.save()

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -240,7 +240,8 @@ class ScrapeResult:
         """
         from pathlib import Path as _Path
 
-        suffix = _Path(path).suffix.lower()
+        p = _Path(path)
+        suffix = p.suffix.lower()
         if suffix == ".json":
             content = self.to_json()
         elif suffix == ".csv":
@@ -256,4 +257,5 @@ class ScrapeResult:
                 f"Unsupported extension {suffix!r} for save(); "
                 "use .json, .csv, .md, .ndjson, .jsonl, .yaml, or .yml"
             )
-        _Path(path).write_text(content, encoding="utf-8")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -344,4 +344,3 @@ class TestScrapeResult:
         saved = tmp_path / "bare_out.json"
         assert saved.exists()
         assert json.loads(saved.read_text())["data"] == [{"b": 2}]
-

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -329,3 +329,19 @@ class TestScrapeResult:
         path = tmp_path / "empty.ndjson"
         result.save(str(path))
         assert path.read_text() == ""
+
+    def test_save_creates_parent_directories(self, tmp_path):
+        result = ScrapeResult(data=[{"a": 1}])
+        nested_path = tmp_path / "nested" / "deeply" / "out.json"
+        result.save(str(nested_path))
+        assert nested_path.exists()
+        assert json.loads(nested_path.read_text())["data"] == [{"a": 1}]
+
+    def test_save_bare_filename(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = ScrapeResult(data=[{"b": 2}])
+        result.save("bare_out.json")
+        saved = tmp_path / "bare_out.json"
+        assert saved.exists()
+        assert json.loads(saved.read_text())["data"] == [{"b": 2}]
+


### PR DESCRIPTION
Fixes #150

## Changes
- Ensure parent directory structure is created via `p.parent.mkdir(parents=True, exist_ok=True)` before `write_text` in `ScrapeResult.save()`
- Add unit tests for saving into nested path and bare filename