### PR TITLE
fix(core): create parent directories in ScrapeResult.save()

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -256,4 +256,6 @@ class ScrapeResult:
                 f"Unsupported extension {suffix!r} for save(); "
                 "use .json, .csv, .md, .ndjson, .jsonl, .yaml, or .yml"
             )
-        _Path(path).write_text(content, encoding="utf-8")
+        path_obj = _Path(path)
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
+        path_obj.write_text(content, encoding="utf-8")

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -214,6 +214,13 @@ class TestScrapeResult:
         assert "title,n" in csv_path.read_text().replace(" ", "")
         assert "**title:** x" in md_path.read_text()
 
+    def test_save_creates_parent_directories(self, tmp_path):
+        """save() must create missing parent directories instead of raising."""
+        result = ScrapeResult(data=[{"title": "x", "n": 1}])
+        json_path = tmp_path / "nested" / "deep" / "dir" / "out.json"
+        result.save(str(json_path))
+        assert json.loads(json_path.read_text())["data"] == [{"title": "x", "n": 1}]
+
     def test_save_unsupported_extension(self, tmp_path):
         result = ScrapeResult(data=[{"a": 1}])
         with pytest.raises(ValueError, match="Unsupported extension"):


### PR DESCRIPTION
## Fix: `ScrapeResult.save()` fails when parent directories don't exist

Closes #150

### Problem
`ScrapeResult.save(path)` writes directly with `Path.write_text()` and never creates parent directories. Saving to any path with a non-existent directory component (e.g. `out/nested/data.json`) raises `FileNotFoundError` instead of writing the file.

### Fix
Create the parent directory tree before writing:

```python
path_obj = _Path(path)
path_obj.parent.mkdir(parents=True, exist_ok=True)
path_obj.write_text(content, encoding="utf-8")
```

An existing flat path (no parent directories) is unaffected — `mkdir(..., exist_ok=True)` is a no-op when the parent already exists.

### Tests
Added `test_save_creates_parent_directories` in `tests/test_core/test_models.py`, verifying a nested-path save writes the expected content.

### Verification
- `pytest tests/` → **483 passed, 9 skipped, 19 deselected**
- `ruff check src/` → **All checks passed**