### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`GoogleSearchScraper`.** Google web search organic results as clean JSON via the SerpBase Search API (`SERPBASE_API_KEY`, 100 free searches). No browser, CAPTCHA handling, or selector maintenance; supports optional `language`/`country` (hl/gl) parameters and graceful degradation when no API key is configured.
+
 ## [1.5.5] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ latest headlines from bbc.co.uk and the AAPL stock quote."*
 
 ## Built-in scrapers
 
-PyScrappy ships **24 built-in scrapers**, and every one that works without a
+PyScrappy ships **25 built-in scrapers**, and every one that works without a
 proxy is also exposed as an [MCP tool](#mcp-server-use-pyscrappy-from-an-ai-agent).
 
 A few of them:
 
 - **`GenericScraper`** — scrape any URL with auto-extraction (text, links, images, tables, metadata)
-- **Data / research** — **`WikipediaScraper`**, **`StockScraper`** (Yahoo Finance), **`NewsScraper`** (RSS/Atom), **`GitHubScraper`**, **`HackerNewsScraper`**, plus weather, crypto, currency, dictionary, image, LinkedIn-jobs, and book search
+- **Data / research** — **`WikipediaScraper`**, **`StockScraper`** (Yahoo Finance), **`NewsScraper`** (RSS/Atom), **`GitHubScraper`**, **`HackerNewsScraper`**, **`GoogleSearchScraper`** (Google organic results as JSON via the SerpBase API), plus weather, crypto, currency, dictionary, image, LinkedIn-jobs, and book search
 - **E-commerce** — **`AmazonScraper`**, `NeweggScraper`, `IKEAScraper`
 - **Social / media / food** — **`YouTubeScraper`**, SoundCloud, Zomato, Uber Eats (Instagram / Twitter / Spotify also ship, but are blocked and need a proxy)
 

--- a/README.md
+++ b/README.md
@@ -202,9 +202,11 @@ A few of them:
 python -c "from pyscrappy import list_scrapers; print(', '.join(sorted(list_scrapers())))"
 ```
 
-**`IMDBScraper`** (`lookup_movie`) is the one exception that needs a key — a free
-[OMDb](https://www.omdbapi.com/apikey.aspx) `OMDB_API_KEY` (see the
-[MCP config](#available-tools) above for how to pass it).
+Two scrapers need a key. **`IMDBScraper`** (`lookup_movie`) uses a free
+[OMDb](https://www.omdbapi.com/apikey.aspx) `OMDB_API_KEY`, and
+**`GoogleSearchScraper`** uses a SerpBase `SERPBASE_API_KEY` (free trial at
+[serpbase.dev](https://serpbase.dev), see the
+[MCP config](#available-tools) above for how to pass keys).
 
 ## Plugins
 

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -52,6 +52,7 @@ from pyscrappy.scrapers.crypto import CryptoScraper
 from pyscrappy.scrapers.currency import CurrencyScraper
 from pyscrappy.scrapers.dictionary import DictionaryScraper
 from pyscrappy.scrapers.github import GitHubScraper
+from pyscrappy.scrapers.google_search import GoogleSearchScraper
 from pyscrappy.scrapers.hackernews import HackerNewsScraper
 from pyscrappy.scrapers.ikea import IKEAScraper
 from pyscrappy.scrapers.image_search import ImageSearchScraper
@@ -81,6 +82,7 @@ for _cls in (
     CurrencyScraper,
     DictionaryScraper,
     GitHubScraper,
+    GoogleSearchScraper,
     HackerNewsScraper,
     IKEAScraper,
     ImageSearchScraper,
@@ -126,6 +128,7 @@ __all__ = [
     "CurrencyScraper",
     "DictionaryScraper",
     "GitHubScraper",
+    "GoogleSearchScraper",
     "HackerNewsScraper",
     "OpenLibraryScraper",
     "WeatherScraper",

--- a/src/pyscrappy/scrapers/__init__.py
+++ b/src/pyscrappy/scrapers/__init__.py
@@ -3,6 +3,7 @@ from pyscrappy.scrapers.crypto import CryptoScraper
 from pyscrappy.scrapers.currency import CurrencyScraper
 from pyscrappy.scrapers.dictionary import DictionaryScraper
 from pyscrappy.scrapers.github import GitHubScraper
+from pyscrappy.scrapers.google_search import GoogleSearchScraper
 from pyscrappy.scrapers.hackernews import HackerNewsScraper
 from pyscrappy.scrapers.ikea import IKEAScraper
 from pyscrappy.scrapers.image_search import ImageSearchScraper
@@ -28,6 +29,7 @@ __all__ = [
     "CurrencyScraper",
     "DictionaryScraper",
     "GitHubScraper",
+    "GoogleSearchScraper",
     "HackerNewsScraper",
     "OpenLibraryScraper",
     "WeatherScraper",

--- a/src/pyscrappy/scrapers/google_search.py
+++ b/src/pyscrappy/scrapers/google_search.py
@@ -8,9 +8,8 @@ organic results as clean JSON, so this scraper needs no browser, no CAPTCHA
 handling, and no selector upkeep.
 
 Set a SerpBase API key in the ``SERPBASE_API_KEY`` environment variable, or
-pass ``api_key`` to the constructor. New accounts start with 100 free searches
-(no credit card required); afterwards it is pay-as-you-go ($0.30 per 1k
-queries).
+pass ``api_key`` to the constructor. See https://serpbase.dev for current
+pricing and a free trial.
 """
 
 from __future__ import annotations
@@ -90,8 +89,8 @@ class GoogleSearchScraper(BaseScraper):
                         message=(
                             "No SerpBase API key. Set the SERPBASE_API_KEY "
                             "environment variable or pass api_key=... to "
-                            "GoogleSearchScraper. Get a free key (100 free "
-                            "searches, no credit card) at https://serpbase.dev"
+                            "GoogleSearchScraper. Get a key at "
+                            "https://serpbase.dev"
                         ),
                     )
                 ],
@@ -131,8 +130,8 @@ class GoogleSearchScraper(BaseScraper):
                         message=(
                             "No SerpBase API key. Set the SERPBASE_API_KEY "
                             "environment variable or pass api_key=... to "
-                            "GoogleSearchScraper. Get a free key (100 free "
-                            "searches, no credit card) at https://serpbase.dev"
+                            "GoogleSearchScraper. Get a key at "
+                            "https://serpbase.dev"
                         ),
                     )
                 ],
@@ -151,9 +150,7 @@ class GoogleSearchScraper(BaseScraper):
         )
         return self._build_result(json.loads(raw), max_results=max_results)
 
-    def _build_result(
-        self, payload: dict[str, Any], max_results: int
-    ) -> ScrapeResult:
+    def _build_result(self, payload: dict[str, Any], max_results: int) -> ScrapeResult:
         """Map the SerpBase envelope to a ScrapeResult.
 
         The API always answers 200 and reports failures through the business
@@ -165,7 +162,7 @@ class GoogleSearchScraper(BaseScraper):
             detail = payload.get("error") or payload.get("message") or "request failed"
             return ScrapeResult(
                 data=[],
-                metadata=ScrapeMetadata(scraper=self.name),
+                metadata=ScrapeMetadata(source_urls=[_SERP_BASE_URL], scraper=self.name),
                 errors=[
                     ScrapeError(
                         url=_SERP_BASE_URL,

--- a/src/pyscrappy/scrapers/google_search.py
+++ b/src/pyscrappy/scrapers/google_search.py
@@ -1,0 +1,194 @@
+"""Google web search via the SerpBase Search API.
+
+Google's own search pages are served to interactive browsers only: plain HTTP
+clients get a consent interstitial or a CAPTCHA before parsing ever sees a
+result, and the markup changes often enough that selector maintenance is a
+constant cost. The SerpBase Search API (https://serpbase.dev) returns the same
+organic results as clean JSON, so this scraper needs no browser, no CAPTCHA
+handling, and no selector upkeep.
+
+Set a SerpBase API key in the ``SERPBASE_API_KEY`` environment variable, or
+pass ``api_key`` to the constructor. New accounts start with 100 free searches
+(no credit card required); afterwards it is pay-as-you-go ($0.30 per 1k
+queries).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from pyscrappy.core.base import BaseScraper
+from pyscrappy.core.config import ScraperConfig
+from pyscrappy.core.models import ScrapeError, ScrapeMetadata, ScrapeResult
+
+_SERP_BASE_URL = "https://api.serpbase.dev/google/search"
+_DEFAULT_MAX_RESULTS = 10
+
+
+class GoogleSearchScraper(BaseScraper):
+    """Fetch Google web search results as JSON via the SerpBase API.
+
+    Usage::
+
+        # Needs an API key: export SERPBASE_API_KEY=... (free trial at serpbase.dev)
+        with GoogleSearchScraper() as scraper:
+            result = scraper.scrape(query="pyscrappy web scraping")
+
+            # Locale-aware searches mirror Google's hl/gl parameters
+            result = scraper.scrape(
+                query="best pizza",
+                language="it",   # hl=it
+                country="it",    # gl=it
+            )
+
+    Each record in ``result.data`` has ``title``, ``link``, ``snippet`` and
+    ``position`` keys, in Google's ranking order.
+    """
+
+    name = "google_search"
+
+    def __init__(
+        self,
+        config: ScraperConfig | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        super().__init__(config)
+        self.api_key = api_key or os.environ.get("SERPBASE_API_KEY")
+
+    def scrape(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+        language: str | None = None,
+        country: str | None = None,
+    ) -> ScrapeResult:
+        """Search Google and return organic results via the SerpBase API.
+
+        Args:
+            query: The search terms, exactly as you would type them into Google.
+            max_results: Maximum number of organic results to return (the API
+                response is truncated to this many records).
+            language: Optional Google interface language, e.g. ``"de"``.
+            country: Optional Google results region, e.g. ``"de"``.
+
+        Returns:
+            ScrapeResult with one record per organic result (``title``,
+            ``link``, ``snippet``, ``position``).
+        """
+        if not query:
+            raise ValueError("Provide query=<search terms>.")
+
+        if not self.api_key:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(scraper=self.name),
+                errors=[
+                    ScrapeError(
+                        url=_SERP_BASE_URL,
+                        message=(
+                            "No SerpBase API key. Set the SERPBASE_API_KEY "
+                            "environment variable or pass api_key=... to "
+                            "GoogleSearchScraper. Get a free key (100 free "
+                            "searches, no credit card) at https://serpbase.dev"
+                        ),
+                    )
+                ],
+            )
+
+        payload: dict[str, Any] = {"q": query}
+        if language:
+            payload["hl"] = language
+        if country:
+            payload["gl"] = country
+
+        raw = self.http.post_json(
+            _SERP_BASE_URL,
+            json=payload,
+            headers={"X-API-Key": self.api_key},
+        )
+        return self._build_result(json.loads(raw), max_results=max_results)
+
+    async def scrape_async(  # type: ignore[override]
+        self,
+        query: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+        language: str | None = None,
+        country: str | None = None,
+    ) -> ScrapeResult:
+        """Async counterpart to :meth:`scrape` (same args/returns)."""
+        if not query:
+            raise ValueError("Provide query=<search terms>.")
+
+        if not self.api_key:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(scraper=self.name),
+                errors=[
+                    ScrapeError(
+                        url=_SERP_BASE_URL,
+                        message=(
+                            "No SerpBase API key. Set the SERPBASE_API_KEY "
+                            "environment variable or pass api_key=... to "
+                            "GoogleSearchScraper. Get a free key (100 free "
+                            "searches, no credit card) at https://serpbase.dev"
+                        ),
+                    )
+                ],
+            )
+
+        payload: dict[str, Any] = {"q": query}
+        if language:
+            payload["hl"] = language
+        if country:
+            payload["gl"] = country
+
+        raw = await self.async_http.post_json(
+            _SERP_BASE_URL,
+            json=payload,
+            headers={"X-API-Key": self.api_key},
+        )
+        return self._build_result(json.loads(raw), max_results=max_results)
+
+    def _build_result(
+        self, payload: dict[str, Any], max_results: int
+    ) -> ScrapeResult:
+        """Map the SerpBase envelope to a ScrapeResult.
+
+        The API always answers 200 and reports failures through the business
+        envelope instead: ``status`` is 0 on success and non-zero on failure,
+        so a failed request surfaces as a clear per-call error rather than as
+        an empty result set that looks like "no results found".
+        """
+        if payload.get("status") != 0:
+            detail = payload.get("error") or payload.get("message") or "request failed"
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(scraper=self.name),
+                errors=[
+                    ScrapeError(
+                        url=_SERP_BASE_URL,
+                        message=f"SerpBase: {detail} (status={payload.get('status')})",
+                    )
+                ],
+            )
+
+        data: list[dict[str, Any]] = []
+        for item in payload.get("organic") or []:
+            data.append(
+                {
+                    "title": item.get("title", ""),
+                    "link": item.get("link") or item.get("url", ""),
+                    "snippet": item.get("snippet", ""),
+                    "position": item.get("position", len(data) + 1),
+                }
+            )
+        if max_results > 0:
+            data = data[:max_results]
+
+        return ScrapeResult(
+            data=data,
+            metadata=ScrapeMetadata(source_urls=[_SERP_BASE_URL], scraper=self.name),
+            errors=[],
+        )

--- a/tests/test_scrapers/test_google_search.py
+++ b/tests/test_scrapers/test_google_search.py
@@ -1,0 +1,120 @@
+"""Tests for the SerpBase-backed GoogleSearchScraper."""
+
+import json
+from unittest.mock import MagicMock
+
+from pyscrappy.scrapers.google_search import GoogleSearchScraper
+
+
+def _with(scraper, *responses):
+    scraper._http = MagicMock()
+    scraper._http.post_json.side_effect = responses
+    return scraper
+
+
+class TestGoogleSearch:
+    def test_parse(self):
+        payload = json.dumps(
+            {
+                "status": 0,
+                "request_id": "req_1",
+                "organic": [
+                    {
+                        "title": "PyScrappy",
+                        "link": "https://github.com/mldsveda/PyScrappy",
+                        "snippet": "A robust Python web scraping toolkit.",
+                        "position": 1,
+                    },
+                    {
+                        "title": "Scraping API",
+                        "link": "https://example.com",
+                        "snippet": "JSON search results.",
+                        "position": 2,
+                    },
+                ],
+            }
+        )
+        s = _with(GoogleSearchScraper(api_key="k"), payload)
+        r = s.scrape(query="pyscrappy")
+        assert len(r.data) == 2
+        first = r.data[0]
+        assert first["title"] == "PyScrappy"
+        assert first["link"] == "https://github.com/mldsveda/PyScrappy"
+        assert first["snippet"] == "A robust Python web scraping toolkit."
+        assert first["position"] == 1
+        assert r.errors == []
+
+    def test_missing_key_returns_helpful_error(self):
+        s = GoogleSearchScraper()
+        r = s.scrape(query="anything")
+        assert r.data == []
+        assert "SERPBASE_API_KEY" in r.errors[0].message
+        assert "serpbase.dev" in r.errors[0].message
+
+    def test_error_envelope_is_not_silent_empty(self):
+        # The API answers 200 and signals failures through the envelope:
+        # a non-zero status must surface as an error, not as "no results".
+        payload = json.dumps({"status": 7, "error": "invalid api key"})
+        s = _with(GoogleSearchScraper(api_key="bad"), payload)
+        r = s.scrape(query="x")
+        assert r.data == []
+        assert "invalid api key" in r.errors[0].message
+
+    def test_max_results_truncates(self):
+        organic = [
+            {
+                "title": f"Result {i}",
+                "link": f"https://example.com/{i}",
+                "snippet": "",
+                "position": i,
+            }
+            for i in range(1, 21)
+        ]
+        payload = json.dumps({"status": 0, "organic": organic})
+        s = _with(GoogleSearchScraper(api_key="k"), payload)
+        r = s.scrape(query="x", max_results=5)
+        assert len(r.data) == 5
+        assert r.data[-1]["position"] == 5
+
+    def test_request_shape_and_headers(self):
+        s = _with(GoogleSearchScraper(api_key="secret"), json.dumps({"status": 0, "organic": []}))
+        s.scrape(query="hello world", language="en", country="us")
+        args, kwargs = s._http.post_json.call_args
+        assert args[0] == "https://api.serpbase.dev/google/search"
+        assert kwargs["headers"] == {"X-API-Key": "secret"}
+        assert kwargs["json"]["q"] == "hello world"
+        assert kwargs["json"]["hl"] == "en"
+        assert kwargs["json"]["gl"] == "us"
+        # Locale params must be omitted when not requested (no empty defaults).
+        s2 = _with(GoogleSearchScraper(api_key="k"), json.dumps({"status": 0, "organic": []}))
+        s2.scrape(query="no locale")
+        _, kwargs2 = s2._http.post_json.call_args
+        assert "hl" not in kwargs2["json"]
+        assert "gl" not in kwargs2["json"]
+
+    def test_async_parse(self):
+        import asyncio
+
+        payload = json.dumps(
+            {
+                "status": 0,
+                "organic": [
+                    {
+                        "title": "PyScrappy",
+                        "link": "https://github.com/mldsveda/PyScrappy",
+                        "snippet": "A robust Python web scraping toolkit.",
+                        "position": 1,
+                    }
+                ],
+            }
+        )
+
+        async def _fake_post_json(*args, **kwargs):
+            return payload
+
+        s = GoogleSearchScraper(api_key="k")
+        s._async_http = MagicMock()
+        s._async_http.post_json.side_effect = _fake_post_json
+        r = asyncio.run(s.scrape_async(query="pyscrappy"))
+        assert len(r.data) == 1
+        assert r.data[0]["title"] == "PyScrappy"

--- a/tests/test_scrapers/test_google_search.py
+++ b/tests/test_scrapers/test_google_search.py
@@ -44,7 +44,10 @@ class TestGoogleSearch:
         assert first["position"] == 1
         assert r.errors == []
 
-    def test_missing_key_returns_helpful_error(self):
+    def test_missing_key_returns_helpful_error(self, monkeypatch):
+        # Deterministic regardless of the runner's environment: an externally
+        # set SERPBASE_API_KEY would otherwise trigger a real HTTP request.
+        monkeypatch.delenv("SERPBASE_API_KEY", raising=False)
         s = GoogleSearchScraper()
         r = s.scrape(query="anything")
         assert r.data == []


### PR DESCRIPTION
## Summary

Adds a new built-in scraper to PyScrappy: `GoogleSearchScraper` returns Google organic search results as clean JSON via the SerpBase Search API — no browser, no CAPTCHA handling, no selector maintenance.

## Background

PyScrappy's 25 scrapers cover Wikipedia, news, GitHub, image search, and more, but there was no Google **web** search scraper. That's not an oversight: Google's search pages are effectively unreachable for scripted clients (consent interstitial, CAPTCHA walls, frequently changing markup — the same class of problem the IMDB scraper already solved by switching from blocked HTML to a JSON API). The IMDB scraper sets the precedent in this codebase: blocked page → structured API with an env-var key.

SerpBase (https://serpbase.dev) is a Google Search Results API that returns organic results (title, link, snippet, position) as JSON from a single POST. It follows the exact pattern the IMDB scraper uses, right down to the key-missing behavior.

## Changes

- **New**: `src/pyscrappy/scrapers/google_search.py` — `GoogleSearchScraper` (`name = "google_search"`):
  - POST `https://api.serpbase.dev/google/search` with a JSON body (`q`, optional `hl`/`gl`) and the key in the `X-API-Key` header
  - Maps the `organic[]` array to `{title, link, snippet, position}` records in Google's ranking order
  - Truncates to `max_results` (default 10) client-side
  - Sync (`scrape`) and native async (`scrape_async`) paths, mirroring the IMDBScraper structure
- **Updated**: `src/pyscrappy/scrapers/__init__.py` — import + `__all__` entry (alphabetical)
- **Updated**: `src/pyscrappy/__init__.py` — import, built-in registration tuple, and `__all__` entry, so the MCP server, CLI, and `list_scrapers()` expose it automatically (no core or MCP changes needed)
- **New**: `tests/test_scrapers/test_google_search.py` — 6 unit tests (see Testing)
- **Updated**: `README.md` (scraper count 24 → 25 + listing) and `CHANGELOG.md` (Unreleased entry)

## Design decisions

| Decision | Rationale |
|----------|-----------|
| API key via `SERPBASE_API_KEY` env var / `api_key=` | Mirrors the existing `OMDB_API_KEY` pattern in `IMDBScraper` |
| POST + JSON body + `X-API-Key` header | SerpBase's current documented contract (POST-only; GET + query-param keys are deprecated) |
| Key missing → `ScrapeResult` with a helpful `ScrapeError` (not an exception, not a silent empty list) | Exactly how `IMDBScraper` degrades; no behavior change for users without a key |
| Business error envelope (`HTTP 200` + `status != 0`) surfaced as `ScrapeError` | The API reports failures in the envelope, so a failed request must not look like "no results found" |
| No new dependencies | Reuses the existing `HttpClient.post_json` / `AsyncHttpClient.post_json` (httpx is already a core dependency) |
| Client-side truncation to `max_results` | Avoids depending on an unverified server-side page-size parameter; documented in the docstring |
| Optional `language`/`country` → `hl`/`gl` | Maps 1:1 to Google's own locale controls; omitted entirely when not requested |

## Testing

- 6 new unit tests (mock `post_json`, no network): parse, missing key, error-envelope, max_results truncation, request shape/headers, async path
- Full suite: **490 passed, 9 skipped** (unchanged from main baseline behavior)
- `ruff check` clean on all changed/new files; `compileall` clean; `git diff --check` clean

No API key is ever committed; tests mock upstream HTTP per the contributing guide.