### PR TITLE
Release 1.5.6: robots.txt fail-closed, offset pagination, save() mkdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.5.6] - 2026-08-19
+
+### Fixed
+- **robots.txt server errors now fail closed.** A `5xx` (or a connection error / timeout) while fetching `robots.txt` is treated as disallow-all and is *not* cached, so a later request re-fetches — instead of the previous behavior of parsing an empty body as allow-all and caching that for the session. `4xx` (e.g. a missing `robots.txt`) still means allow-all, and `2xx` rules are unchanged. Sync and async paths are kept in lockstep (#152).
+- **Offset-based pagination advances by the page size, not by 1.** For `offset=`/`start=` URLs, `find_next_page_url` now infers the step from the gaps between the page links (e.g. `0/20/40/60` → `+20`) instead of `+1`, which silently under-collected on offset-paginated sites. `page`/`p` URLs still advance by 1 (#151).
+- **`ScrapeResult.save()` creates parent directories.** Saving to a path whose directory does not exist (e.g. `out/nested/data.json`) now creates the directory tree instead of raising `FileNotFoundError` (#150).
+
 ## [1.5.5] - 2026-08-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.5"
+version = "1.5.6"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.5",
+  "version": "1.5.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/core/robots.py
+++ b/src/pyscrappy/core/robots.py
@@ -32,6 +32,30 @@ def _parse_robots(text: str) -> RobotFileParser:
     return parser
 
 
+def _disallow_all() -> RobotFileParser:
+    """A parser that forbids everything, for transient robots.txt failures."""
+    return _parse_robots("User-agent: *\nDisallow: /")
+
+
+def _parser_for_response(status_code: int, text: str) -> tuple[RobotFileParser, bool]:
+    """Decide the parser for a robots.txt HTTP response, and whether it may be
+    cached, following RFC 9309 / Googlebot conventions:
+
+    - 2xx: use the returned rules (cacheable).
+    - 4xx (e.g. 404/410 "no robots.txt"): allow-all (cacheable).
+    - 5xx: disallow-all, and *not* cacheable, because a server error is transient
+      and a later request should re-fetch rather than reuse a temporary block.
+
+    Returns ``(parser, cacheable)``.
+    """
+    if 200 <= status_code < 300:
+        return _parse_robots(text), True
+    if 400 <= status_code < 500:
+        return _parse_robots(""), True
+    # 5xx (and any other unexpected status): fail closed, don't cache.
+    return _disallow_all(), False
+
+
 def _crawl_delay_for(parser: RobotFileParser, user_agent: str) -> float | None:
     """Crawl-delay this parser advertises for ``user_agent`` (None if absent).
 
@@ -72,15 +96,23 @@ def _fetch_and_cache_sync(
     client: HttpClient, host: str, robots_url: str, user_agent: str
 ) -> RobotFileParser:
     """Fetch robots.txt via the sync client (skipping the robots check recursively,
-    and sending the same User-Agent being enforced) and cache the parser per-client."""
+    and sending the same User-Agent being enforced) and cache the parser per-client.
+
+    Transient failures (5xx or a network error) fail closed with a disallow-all
+    parser that is *not* cached, so the next request re-fetches instead of reusing
+    a temporary block."""
+    # get_raw (not get) so a non-200 returns its status code instead of raising,
+    # letting us tell 4xx (allow-all) apart from 5xx (fail closed). It performs a
+    # bare fetch with no robots check, so there is no recursion.
     try:
-        resp = client.get(robots_url, skip_robots_check=True, headers={"User-Agent": user_agent})
-        parser = _parse_robots(resp.text) if resp.status_code == 200 else _parse_robots("")
+        resp = client.get_raw(robots_url, headers={"User-Agent": user_agent})
+        parser, cacheable = _parser_for_response(resp.status_code, resp.text)
     except Exception as exc:
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
-        parser = _parse_robots("")
+        parser, cacheable = _disallow_all(), False
 
-    client._robots_cache[host] = parser
+    if cacheable:
+        client._robots_cache[host] = parser
     return parser
 
 
@@ -110,15 +142,21 @@ async def _fetch_and_cache_async(
     client: AsyncHttpClient, host: str, robots_url: str, user_agent: str
 ) -> RobotFileParser:
     """Fetch robots.txt via the async client (skipping the robots check recursively,
-    and sending the same User-Agent being enforced) and cache the parser per-client."""
+    and sending the same User-Agent being enforced) and cache the parser per-client.
+
+    Transient failures (5xx or a network error) fail closed with a disallow-all
+    parser that is *not* cached, so the next request re-fetches instead of reusing
+    a temporary block."""
+    # get_raw (not get) so a non-200 returns its status code instead of raising,
+    # letting us tell 4xx (allow-all) apart from 5xx (fail closed). It performs a
+    # bare fetch with no robots check, so there is no recursion.
     try:
-        resp = await client.get(
-            robots_url, skip_robots_check=True, headers={"User-Agent": user_agent}
-        )
-        parser = _parse_robots(resp.text) if resp.status_code == 200 else _parse_robots("")
+        resp = await client.get_raw(robots_url, headers={"User-Agent": user_agent})
+        parser, cacheable = _parser_for_response(resp.status_code, resp.text)
     except Exception as exc:
         logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
-        parser = _parse_robots("")
+        parser, cacheable = _disallow_all(), False
 
-    client._robots_cache[host] = parser
+    if cacheable:
+        client._robots_cache[host] = parser
     return parser

--- a/tests/test_core/test_robots.py
+++ b/tests/test_core/test_robots.py
@@ -171,3 +171,98 @@ async def test_async_obey_robots_disallowed():
         async with AsyncHttpClient(config) as async_client:
             with pytest.raises(RobotsDisallowedError):
                 await async_client.get("https://example.com/private/data")
+
+
+# --- transient robots.txt failures fail closed and are not cached (#152) ---
+
+
+def _resp(status_code: int, text: str = "") -> MagicMock:
+    """A fake httpx.Response. The robots fetch uses get_raw(), which does not call
+    raise_for_status(), so a non-2xx simply comes back with its status code."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = {}
+    resp.text = text
+    return resp
+
+
+def test_robots_5xx_disallows_and_is_not_cached_then_200_is_honored():
+    # First robots.txt fetch 500s -> fail closed (disallow-all), and crucially do
+    # not cache that block; the next fetch returns real rules and is honored.
+    config = ScraperConfig(obey_robots=True, rate_limit=0, max_retries=1)
+    robots_calls = 0
+
+    def fake_httpx_get(url, *args, **kwargs):
+        nonlocal robots_calls
+        if "robots.txt" in str(url):
+            robots_calls += 1
+            if robots_calls == 1:
+                return _resp(500)
+            return _resp(200, "User-agent: *\nDisallow: /admin/\n")
+        return _resp(200, "OK")
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            # While robots.txt is 500ing, everything is blocked.
+            with pytest.raises(RobotsDisallowedError):
+                client.get("https://example.com/anything")
+            # The transient failure must not have been cached.
+            assert "example.com" not in client._robots_cache
+            # Next request re-fetches; now robots.txt is healthy and allows /public/.
+            resp = client.get("https://example.com/public/page")
+            assert resp.text == "OK"
+            assert "example.com" in client._robots_cache
+
+    assert robots_calls == 2  # the block was re-fetched, not served from cache
+
+
+def test_robots_network_error_disallows_and_is_not_cached():
+    config = ScraperConfig(obey_robots=True, rate_limit=0, max_retries=1)
+
+    def fake_httpx_get(url, *args, **kwargs):
+        if "robots.txt" in str(url):
+            raise httpx.ConnectError("boom")
+        return _resp(200, "OK")
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            with pytest.raises(RobotsDisallowedError):
+                client.get("https://example.com/anything")
+            assert "example.com" not in client._robots_cache
+
+
+def test_robots_404_still_allows_all_and_is_cached():
+    # No regression: a missing robots.txt (404) means allow-all, and that is cached.
+    config = ScraperConfig(obey_robots=True, rate_limit=0, max_retries=1)
+    robots_calls = 0
+
+    def fake_httpx_get(url, *args, **kwargs):
+        nonlocal robots_calls
+        if "robots.txt" in str(url):
+            robots_calls += 1
+            return _resp(404)
+        return _resp(200, "OK")
+
+    with patch("httpx.Client.get", side_effect=fake_httpx_get):
+        with HttpClient(config) as client:
+            assert client.get("https://example.com/a").text == "OK"
+            assert client.get("https://example.com/b").text == "OK"
+            assert "example.com" in client._robots_cache
+
+    assert robots_calls == 1  # allow-all was cached, not re-fetched
+
+
+@pytest.mark.anyio
+async def test_async_robots_5xx_disallows_and_is_not_cached():
+    config = ScraperConfig(obey_robots=True, rate_limit=0, max_retries=1)
+
+    async def fake_async_get(url, *args, **kwargs):
+        if "robots.txt" in str(url):
+            return _resp(500)
+        return _resp(200, "OK")
+
+    with patch("httpx.AsyncClient.get", side_effect=fake_async_get):
+        async with AsyncHttpClient(config) as async_client:
+            with pytest.raises(RobotsDisallowedError):
+                await async_client.get("https://example.com/anything")
+            assert "example.com" not in async_client._robots_cache


### PR DESCRIPTION
## Summary

Release 1.5.6. Bundles the robots.txt server-error fix (#152) with two
contributor fixes already merged to main (#151, #150), and bumps the version
across all sites.

## Changes

### Fixed
- **robots.txt server errors now fail closed (#152).** A `5xx` (or a connection
  error / timeout) while fetching `robots.txt` was parsed as an empty allow-all
  body and cached for the session, so a site whose `robots.txt` was temporarily
  500ing got crawled as if unrestricted. The fetch now uses `get_raw` so the real
  status code is visible, and handling is split by class per RFC 9309 / Googlebot:
  `2xx` uses the rules, `4xx` is allow-all (both cacheable), and `5xx` / network
  errors fail closed with a disallow-all parser that is **not** cached, so the
  next request re-fetches. Sync and async share one decision helper.
- **Offset-based pagination advances by the page size, not by 1 (#151).** For
  `offset=`/`start=` URLs, `find_next_page_url` infers the step from the gaps
  between the page links (e.g. `0/20/40/60` → `+20`) instead of `+1`, which
  silently under-collected on offset-paginated sites. `page`/`p` URLs still
  advance by 1.
- **`ScrapeResult.save()` creates parent directories (#150).** Saving to a path
  whose directory does not exist (e.g. `out/nested/data.json`) now creates the
  tree instead of raising `FileNotFoundError`.

### Chore
- Bump to 1.5.6 across `pyproject.toml`, `__init__.py`, and `server.json`; update
  CHANGELOG.

## Testing
- Full suite: 523 passed, 19 deselected.
- `ruff check` and `ruff format --check`: clean.
- The robots #152 regression tests (5xx and network-error) fail on the pre-fix
  code and pass after, confirming the fix is exercised.

Closes #152.