### PR TITLE
feat(http): add jitter to retry backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **Retry backoff uses full jitter by default.** Concurrent failures now spread each exponential retry across the interval from zero to its capped delay instead of retrying in lockstep. Set `ScraperConfig(retry_jitter=False)` to preserve the deterministic schedule; explicit server `Retry-After` values remain unchanged.
+
 ## [1.5.7] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ from pyscrappy import ScraperConfig, GenericScraper
 config = ScraperConfig(
     timeout=20.0,            # request timeout in seconds
     max_retries=3,           # retry failed requests
+    retry_jitter=True,       # spread exponential retries to avoid lockstep traffic
     rate_limit=2.0,          # seconds between requests per domain
     proxy="http://...",      # proxy URL, or a list to rotate through
     scraper_api=None,        # route via a scraping-API service (see below)

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -31,6 +31,10 @@ class ScraperConfig:
             (the default) doubles each time; ``1.0`` keeps a constant delay.
         backoff_max: Upper bound (seconds) on a single retry delay, so backoff
             can't grow without limit. ``None`` (the default) means no cap.
+        retry_jitter: Whether to randomize each exponential retry delay between
+            zero and its computed, capped value. Enabled by default to prevent
+            concurrent requests from retrying in lockstep; set to ``False`` to
+            preserve the deterministic schedule.
         rate_limit: Minimum seconds between requests to the same domain.
         obey_robots: Whether to respect host robots.txt rules and Crawl-delay.
             ``False`` (the default) does not fetch robots.txt at all.
@@ -95,6 +99,7 @@ class ScraperConfig:
     cache_max_size: int = 512
     cache_dir: str | None = None
     impersonate: str | None = None
+    retry_jitter: bool = True
 
     def pick_proxy(self, exclude: str | None = None) -> str | None:
         """Return a single proxy URL (rotating if a list was configured)."""

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -56,6 +56,8 @@ def backoff_delay(config: ScraperConfig, attempt: int) -> float:
     """Retry delay (seconds) before the given attempt (1-indexed), using the
     config's base delay, backoff factor, and optional cap:
     ``retry_delay * backoff_factor ** (attempt - 1)``, clamped to ``backoff_max``.
+    With ``retry_jitter`` enabled, full jitter then selects a value uniformly
+    between zero and that capped delay so concurrent retries spread out.
 
     Module-level so scrapers with their own retry loops (e.g. the stock scraper's
     Yahoo 429 handling) honor the same configurable backoff as HttpClient.
@@ -63,7 +65,7 @@ def backoff_delay(config: ScraperConfig, attempt: int) -> float:
     delay = config.retry_delay * (config.backoff_factor ** (attempt - 1))
     if config.backoff_max is not None:
         delay = min(delay, config.backoff_max)
-    return delay
+    return random.uniform(0.0, delay) if config.retry_jitter else delay
 
 
 # Default cap on the number of live response-cache entries. Bounds memory for

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -83,6 +83,34 @@ async def test_async_retries_on_server_error():
 
 
 @pytest.mark.anyio
+async def test_async_get_sleeps_for_the_jittered_backoff():
+    err = _resp(status=500)
+    err.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=err)
+    )
+    ok = _resp(text="ok")
+    client = AsyncHttpClient(ScraperConfig(rate_limit=0, retry_delay=4.0, max_retries=2))
+
+    first_client = MagicMock()
+    first_client.get = AsyncMock(return_value=err)
+    first_client.aclose = AsyncMock()
+    second_client = MagicMock()
+    second_client.get = AsyncMock(return_value=ok)
+    second_client.aclose = AsyncMock()
+    client._client = first_client
+    client._build_client = MagicMock(side_effect=[second_client])
+
+    with patch("pyscrappy.core.http.random.uniform", return_value=1.25) as mock_uniform:
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            response = await client.get("https://example.com")
+
+    assert response.text == "ok"
+    mock_uniform.assert_called_once_with(0.0, 4.0)
+    mock_sleep.assert_awaited_once_with(1.25)
+    await client.aclose()
+
+
+@pytest.mark.anyio
 async def test_async_shares_cache_with_sync_client():
     # A value cached by the async client is visible to the sync client (shared store).
     HttpClient.clear_cache()

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -9,6 +9,7 @@ class TestScraperConfig:
         assert config.timeout == 30.0
         assert config.max_retries == 3
         assert config.retry_delay == 1.0
+        assert config.retry_jitter is True
         assert config.rate_limit == 1.0
         assert config.proxy is None
         assert config.render_js is False
@@ -31,6 +32,7 @@ class TestScraperConfig:
             timeout=10.0,
             max_retries=5,
             retry_delay=2.0,
+            retry_jitter=False,
             rate_limit=0.5,
             proxy="http://proxy:8080",
             render_js="auto",
@@ -40,6 +42,7 @@ class TestScraperConfig:
         assert config.timeout == 10.0
         assert config.max_retries == 5
         assert config.retry_delay == 2.0
+        assert config.retry_jitter is False
         assert config.rate_limit == 0.5
         assert config.proxy == "http://proxy:8080"
         assert config.render_js == "auto"

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -1,6 +1,7 @@
 """Tests for pyscrappy.core.http."""
 
 import os
+import random
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -129,32 +130,72 @@ class TestHttpClientGet:
     def test_module_backoff_delay_shared_by_scrapers(self):
         # The module-level helper (used by scrapers with their own retry loops,
         # e.g. the stock scraper) honors the same config as HttpClient.
-        cfg = ScraperConfig(retry_delay=1.0, backoff_factor=2.0, backoff_max=5.0)
+        cfg = ScraperConfig(
+            retry_delay=1.0,
+            backoff_factor=2.0,
+            backoff_max=5.0,
+            retry_jitter=False,
+        )
         assert backoff_delay(cfg, 1) == 1.0
         assert backoff_delay(cfg, 4) == 5.0  # 8.0 capped to 5.0
 
+    def test_backoff_delay_defaults_to_full_jitter_within_capped_bound(self):
+        cfg = ScraperConfig(retry_delay=1.0, backoff_factor=2.0, backoff_max=5.0)
+        seeded_random = random.Random(7)
+
+        with patch(
+            "pyscrappy.core.http.random.uniform", side_effect=seeded_random.uniform
+        ) as mock_uniform:
+            delays = [backoff_delay(cfg, 4) for _ in range(50)]
+
+        assert len(set(delays)) > 1
+        assert all(0.0 <= delay <= 5.0 for delay in delays)
+        assert {mock_call.args for mock_call in mock_uniform.call_args_list} == {(0.0, 5.0)}
+
+    def test_backoff_delay_can_disable_jitter(self):
+        cfg = ScraperConfig(
+            retry_delay=2.0,
+            backoff_factor=3.0,
+            backoff_max=10.0,
+            retry_jitter=False,
+        )
+
+        with patch("pyscrappy.core.http.random.uniform") as mock_uniform:
+            assert backoff_delay(cfg, 3) == 10.0
+
+        mock_uniform.assert_not_called()
+
     def test_backoff_delay_defaults_to_exponential_doubling(self):
-        client = HttpClient(ScraperConfig(retry_delay=1.0))  # factor 2.0 by default
+        client = HttpClient(
+            ScraperConfig(retry_delay=1.0, retry_jitter=False)
+        )  # factor 2.0 by default
         assert client._backoff_delay(1) == 1.0
         assert client._backoff_delay(2) == 2.0
         assert client._backoff_delay(3) == 4.0
         client.close()
 
     def test_backoff_factor_is_configurable(self):
-        client = HttpClient(ScraperConfig(retry_delay=2.0, backoff_factor=3.0))
+        client = HttpClient(ScraperConfig(retry_delay=2.0, backoff_factor=3.0, retry_jitter=False))
         assert client._backoff_delay(1) == 2.0
         assert client._backoff_delay(2) == 6.0
         assert client._backoff_delay(3) == 18.0
         client.close()
 
     def test_backoff_factor_one_keeps_delay_constant(self):
-        client = HttpClient(ScraperConfig(retry_delay=1.5, backoff_factor=1.0))
+        client = HttpClient(ScraperConfig(retry_delay=1.5, backoff_factor=1.0, retry_jitter=False))
         assert client._backoff_delay(1) == 1.5
         assert client._backoff_delay(5) == 1.5
         client.close()
 
     def test_backoff_max_caps_the_delay(self):
-        client = HttpClient(ScraperConfig(retry_delay=1.0, backoff_factor=2.0, backoff_max=5.0))
+        client = HttpClient(
+            ScraperConfig(
+                retry_delay=1.0,
+                backoff_factor=2.0,
+                backoff_max=5.0,
+                retry_jitter=False,
+            )
+        )
         assert client._backoff_delay(3) == 4.0  # under the cap
         assert client._backoff_delay(4) == 5.0  # 8.0 clamped to 5.0
         assert client._backoff_delay(10) == 5.0  # stays capped
@@ -191,6 +232,41 @@ class TestHttpClientGet:
         assert resp.status_code == 200
         assert mock_httpx_1.get.call_count == 1
         assert mock_httpx_2.get.call_count == 1
+        client.close()
+
+    def test_get_sleeps_for_the_jittered_backoff(self):
+        config = ScraperConfig(max_retries=2, rate_limit=0, retry_delay=4.0)
+        client = HttpClient(config)
+
+        error_response = MagicMock(spec=httpx.Response)
+        error_response.status_code = 500
+
+        def raise_500():
+            raise httpx.HTTPStatusError(
+                "500 Server Error",
+                request=MagicMock(),
+                response=error_response,
+            )
+
+        error_response.raise_for_status = raise_500
+        ok_response = MagicMock(spec=httpx.Response)
+        ok_response.status_code = 200
+        ok_response.raise_for_status = MagicMock()
+
+        first_client = MagicMock()
+        first_client.get.return_value = error_response
+        second_client = MagicMock()
+        second_client.get.return_value = ok_response
+        client._client = first_client
+        client._build_client = MagicMock(side_effect=[second_client])
+
+        with patch("pyscrappy.core.http.random.uniform", return_value=1.25) as mock_uniform:
+            with patch("time.sleep") as mock_sleep:
+                response = client.get("https://example.com")
+
+        assert response.status_code == 200
+        mock_uniform.assert_called_once_with(0.0, 4.0)
+        mock_sleep.assert_called_once_with(1.25)
         client.close()
 
     def test_get_retries_on_request_error(self):


### PR DESCRIPTION
## Summary

- apply full jitter after the exponential retry delay is capped, spreading concurrent retries across `0..delay`
- expose `ScraperConfig.retry_jitter=True` with an opt-out that preserves the previous deterministic schedule and positional config compatibility
- cover jitter spread and bounds, cap ordering, opt-out behavior, and the shared sync/async retry paths
- document the new setting and keep explicit server `Retry-After` values unchanged

Closes #163

## Validation

- `pytest tests/ -q` on Python 3.9: 514 passed, 6 skipped, 19 deselected
- full test suite on Python 3.13: 535 passed, 2 skipped, 19 deselected
- focused config/sync/async tests: 75 passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- Python 3.9 `compileall` for `src` and `tests`
- `python -m build` (sdist and wheel)

`mypy src/pyscrappy/` is not currently green on the unchanged project baseline: current mypy no longer accepts the repository's Python 3.9 target, and the suite also reports existing errors in unrelated code. The changed config file introduces no reported error; the reports in `http.py` are on pre-existing stealth-response branches.

## AI assistance

OpenAI Codex assisted with issue screening, implementation, tests, and PR preparation. I reviewed the final diff and validation results.
