### PR TITLE
Sitemap-aware crawling (1.5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [1.5.8] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to PyScrappy are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.5.8] - 2026-08-25
+
+### Added
+- **Sitemap crawling.** `GenericScraper.sitemap_urls(url)` enumerates a site's page URLs from its `sitemap.xml` (discovered via `robots.txt` `Sitemap:` directives, else the conventional path), following a `<sitemapindex>` one level into its child sitemaps and handling gzip-compressed sitemaps. `GenericScraper.scrape_sitemap(url, max_urls=...)` fetches and extracts every listed page concurrently (via `scrape_all`) into one `ScrapeResult` (#160).
 
 ### Changed
-- **Retry backoff uses full jitter by default.** Concurrent failures now spread each exponential retry across the interval from zero to its capped delay instead of retrying in lockstep. Set `ScraperConfig(retry_jitter=False)` to preserve the deterministic schedule; explicit server `Retry-After` values remain unchanged.
+- **Retry backoff uses full jitter by default.** Concurrent failures now spread each exponential retry across the interval from zero to its capped delay instead of retrying in lockstep. Set `ScraperConfig(retry_jitter=False)` to preserve the deterministic schedule; explicit server `Retry-After` values remain unchanged (#163).
 
 ## [1.5.7] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ PyScrappy is an AI-native web scraping toolkit that turns websites into structur
 - **Chainable `Selector`** — navigate HTML directly with CSS/XPath, `find_all`, `find_by_text`, and `find_similar` (Scrapy/BeautifulSoup-style)
 - **Adaptive (self-healing) selectors** — remember an element and relocate it by similarity when a site changes its markup, so scrapers don't silently break
 - **Concurrent scraping** — `scrape_many` / `scrape_all` run scrapes in parallel
+- **Sitemap crawling** — enumerate and scrape a whole site from its `sitemap.xml` (index + gzip aware)
 - **Proxy & scraping-API support** — route through a proxy or ScraperAPI/ScrapeOps for blocked sites
 - **TLS-fingerprint impersonation** — `impersonate="chrome"` gets past anti-bot filters that block plain clients (optional `curl_cffi` backend)
 - **Command-line extract** — `pyscrappy extract <url> out.md` scrapes a URL straight to a file, no code
@@ -514,6 +515,31 @@ results = scrape_all([
     lambda: NewsScraper().scrape(feed_url="https://rss.nytimes.com/services/xml/rss/nyt/World.xml"),
 ])
 ```
+
+### Sitemap crawling
+
+Pagination follows next-page links; a **sitemap** enumerates a whole site's URLs
+directly. `GenericScraper` can read `/sitemap.xml` (discovered from `robots.txt`
+`Sitemap:` directives, or the conventional path), follow a `<sitemapindex>` into
+its child sitemaps, and scrape every listed page.
+
+```python
+from pyscrappy import GenericScraper
+
+with GenericScraper() as gs:
+    # Just enumerate the URLs:
+    urls = gs.sitemap_urls("https://example.com")            # -> list[str]
+
+    # Or fetch + extract each, concurrently, into one result:
+    result = gs.scrape_sitemap("https://example.com", max_urls=100)
+    print(len(result.data), "pages scraped")
+```
+
+Handles `<urlset>` leaves and `<sitemapindex>` files (recursing one level),
+gzip-compressed sitemaps (`.xml.gz`), and de-duplicates URLs. Fetches go through
+the usual rate-limiting, caching, proxy, and stealth machinery, and the fan-out
+reuses `scrape_all`. `max_urls` caps the crawl (a sitemap can list tens of
+thousands of URLs, so it's required for `scrape_sitemap`).
 
 ### Response caching
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.7"
+version = "1.5.8"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.7",
+  "version": "1.5.8",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/generic/scraper.py
+++ b/src/pyscrappy/generic/scraper.py
@@ -279,3 +279,130 @@ class GenericScraper(BaseScraper):
             items.append(row)
 
         return items
+
+    # -- sitemap crawling --
+
+    def sitemap_urls(self, url: str, max_urls: int | None = None) -> list[str]:
+        """Enumerate a site's page URLs from its sitemap(s).
+
+        Discovers sitemaps from the site's ``robots.txt`` ``Sitemap:`` directives,
+        falling back to the conventional ``/sitemap.xml``. Fetches each, parses
+        ``<urlset>`` leaves for page URLs and recurses one level into any
+        ``<sitemapindex>`` children. gzip-compressed sitemaps are handled. Fetches
+        go through the normal HTTP client (rate-limit, cache, proxy, stealth);
+        robots checking is skipped for the sitemap/robots files themselves.
+
+        Args:
+            url: Any URL on the target site (its host is used to locate sitemaps).
+            max_urls: Cap on the number of page URLs returned (None = no cap).
+
+        Returns:
+            A de-duplicated list of page URLs, in discovery order, capped to
+            ``max_urls``.
+        """
+        from urllib.parse import urljoin
+
+        from pyscrappy.core.robots import get_host_and_robots_url
+        from pyscrappy.generic.sitemap import parse_sitemap, sitemaps_from_robots
+
+        _, robots_url = get_host_and_robots_url(url)
+
+        # 1. Discover sitemap URLs: robots.txt Sitemap: lines, else /sitemap.xml.
+        sitemap_queue: list[str] = []
+        try:
+            robots_txt = self.http.get_raw(robots_url).text
+            sitemap_queue = sitemaps_from_robots(robots_txt)
+        except Exception:  # noqa: BLE001 - robots is optional; fall back below
+            sitemap_queue = []
+        if not sitemap_queue:
+            sitemap_queue = [urljoin(robots_url, "/sitemap.xml")]
+
+        # 2. Fetch + parse. Recurse one level for sitemap-index children.
+        page_urls: list[str] = []
+        seen_pages: set[str] = set()
+        seen_sitemaps: set[str] = set()
+        # queue holds (sitemap_url, is_child) so an index only recurses one level.
+        queue: list[tuple[str, bool]] = [(s, False) for s in sitemap_queue]
+        while queue:
+            if max_urls is not None and len(page_urls) >= max_urls:
+                break
+            sm_url, is_child = queue.pop(0)
+            if sm_url in seen_sitemaps:
+                continue
+            seen_sitemaps.add(sm_url)
+            try:
+                data = self.http.get_raw(sm_url).content
+            except Exception:  # noqa: BLE001 - a missing/broken sitemap is skipped
+                continue
+            pages, children = parse_sitemap(data)
+            for p in pages:
+                if p not in seen_pages:
+                    seen_pages.add(p)
+                    page_urls.append(p)
+                    if max_urls is not None and len(page_urls) >= max_urls:
+                        break
+            if not is_child:  # only descend one level into an index
+                queue.extend((c, True) for c in children)
+
+        return page_urls[:max_urls] if max_urls is not None else page_urls
+
+    def scrape_sitemap(
+        self,
+        url: str,
+        max_urls: int = 100,
+        selectors: dict[str, str] | None = None,
+        render_js: bool | None = None,
+        max_workers: int = 8,
+    ) -> ScrapeResult:
+        """Scrape every page listed in a site's sitemap, concurrently.
+
+        Enumerates URLs via :meth:`sitemap_urls` (capped at ``max_urls``), scrapes
+        each with the normal extraction pipeline, and merges everything into one
+        :class:`ScrapeResult` (data concatenated, per-URL errors preserved).
+
+        Args:
+            url: Any URL on the target site.
+            max_urls: Maximum number of pages to scrape (default 100). A sitemap
+                can list tens of thousands of URLs, so this is a required guard.
+            selectors: Optional CSS selectors, passed through to :meth:`scrape`.
+            render_js: JS-render override, passed through to :meth:`scrape`.
+            max_workers: Concurrency for the fan-out.
+
+        Returns:
+            A single ScrapeResult over all scraped pages.
+        """
+        from pyscrappy.concurrent import scrape_all
+
+        urls = self.sitemap_urls(url, max_urls=max_urls)
+        if not urls:
+            return ScrapeResult(
+                data=[],
+                metadata=ScrapeMetadata(source_urls=[url], scraper="generic:sitemap"),
+                errors=[ScrapeError(url=url, message="no sitemap URLs found")],
+            )
+
+        # Each page is scraped by its own scraper instance so the concurrent
+        # fetches don't share one client's mutable per-request state.
+        def _one(page_url: str):
+            def _run() -> ScrapeResult:
+                with GenericScraper(self.config) as gs:
+                    return gs.scrape(page_url, selectors=selectors, render_js=render_js)
+
+            return _run
+
+        results = scrape_all([_one(u) for u in urls], max_workers=max_workers)
+
+        data: list[dict[str, Any]] = []
+        errors: list[ScrapeError] = []
+        for r in results:
+            data.extend(r.data)
+            errors.extend(r.errors)
+        return ScrapeResult(
+            data=data,
+            metadata=ScrapeMetadata(
+                source_urls=urls,
+                total_pages=len(urls),
+                scraper="generic:sitemap",
+            ),
+            errors=errors,
+        )

--- a/src/pyscrappy/generic/scraper.py
+++ b/src/pyscrappy/generic/scraper.py
@@ -300,6 +300,7 @@ class GenericScraper(BaseScraper):
             A de-duplicated list of page URLs, in discovery order, capped to
             ``max_urls``.
         """
+        from collections import deque
         from urllib.parse import urljoin
 
         from pyscrappy.core.robots import get_host_and_robots_url
@@ -307,13 +308,21 @@ class GenericScraper(BaseScraper):
 
         _, robots_url = get_host_and_robots_url(url)
 
+        # Fetch robots.txt / sitemaps through the normal client (retry, cache,
+        # proxy, rate-limit) but skip the robots *permission* check for these
+        # files themselves. get() raises on a non-2xx / missing file; we treat any
+        # failure as "this sitemap isn't there" and move on.
+        def _fetch(u: str) -> bytes | None:
+            try:
+                return self.http.get(u, skip_robots_check=True).content
+            except Exception:  # noqa: BLE001 - a missing/broken file is skipped
+                return None
+
         # 1. Discover sitemap URLs: robots.txt Sitemap: lines, else /sitemap.xml.
-        sitemap_queue: list[str] = []
-        try:
-            robots_txt = self.http.get_raw(robots_url).text
-            sitemap_queue = sitemaps_from_robots(robots_txt)
-        except Exception:  # noqa: BLE001 - robots is optional; fall back below
-            sitemap_queue = []
+        robots_body = _fetch(robots_url)
+        sitemap_queue = (
+            sitemaps_from_robots(robots_body.decode(errors="replace")) if robots_body else []
+        )
         if not sitemap_queue:
             sitemap_queue = [urljoin(robots_url, "/sitemap.xml")]
 
@@ -322,17 +331,17 @@ class GenericScraper(BaseScraper):
         seen_pages: set[str] = set()
         seen_sitemaps: set[str] = set()
         # queue holds (sitemap_url, is_child) so an index only recurses one level.
-        queue: list[tuple[str, bool]] = [(s, False) for s in sitemap_queue]
+        # deque so dequeuing is O(1) even with many discovered sitemaps.
+        queue: deque[tuple[str, bool]] = deque((s, False) for s in sitemap_queue)
         while queue:
             if max_urls is not None and len(page_urls) >= max_urls:
                 break
-            sm_url, is_child = queue.pop(0)
+            sm_url, is_child = queue.popleft()
             if sm_url in seen_sitemaps:
                 continue
             seen_sitemaps.add(sm_url)
-            try:
-                data = self.http.get_raw(sm_url).content
-            except Exception:  # noqa: BLE001 - a missing/broken sitemap is skipped
+            data = _fetch(sm_url)
+            if data is None:
                 continue
             pages, children = parse_sitemap(data)
             for p in pages:

--- a/src/pyscrappy/generic/sitemap.py
+++ b/src/pyscrappy/generic/sitemap.py
@@ -64,16 +64,20 @@ def parse_sitemap(data: bytes) -> tuple[list[str], list[str]]:
     page_urls: list[str] = []
     child_sitemaps: list[str] = []
 
-    if root_tag == "sitemapindex":
-        for loc in root.iter():
-            if _local(loc.tag) == "loc" and loc.text:
-                child_sitemaps.append(loc.text.strip())
-    else:
-        # Treat anything else as a urlset (leaf). <urlset> is the common case;
-        # being lenient here means a non-standard root still yields its <loc>s.
-        for loc in root.iter():
-            if _local(loc.tag) == "loc" and loc.text:
-                page_urls.append(loc.text.strip())
+    # Take only the <loc> that is a *direct child* of an entry element (<url> in a
+    # urlset, <sitemap> in an index). Extension namespaces nest their own <loc>
+    # deeper (e.g. <url><image:image><image:loc>), whose local name is also "loc";
+    # collecting every descendant <loc> would wrongly return those image/video
+    # URLs as pages. Direct-child scoping excludes them.
+    entry_tag = "sitemap" if root_tag == "sitemapindex" else "url"
+    sink = child_sitemaps if root_tag == "sitemapindex" else page_urls
+    for entry in root:
+        if _local(entry.tag) != entry_tag:
+            continue
+        for child in entry:
+            if _local(child.tag) == "loc" and child.text:
+                sink.append(child.text.strip())
+                break  # one <loc> per entry
 
     return page_urls, child_sitemaps
 

--- a/src/pyscrappy/generic/sitemap.py
+++ b/src/pyscrappy/generic/sitemap.py
@@ -1,0 +1,90 @@
+"""Sitemap parsing and discovery.
+
+The other half of "crawl everything": pagination follows next-page links, while a
+sitemap enumerates a site's URLs directly and reliably. This module is pure
+parsing — no network. :class:`~pyscrappy.generic.scraper.GenericScraper` wires it
+to the HTTP client (fetching, robots, rate-limit, cache) via ``sitemap_urls`` and
+``scrape_sitemap``.
+
+Handles both sitemap flavors (https://www.sitemaps.org/protocol.html):
+
+- ``<urlset>`` — a leaf sitemap listing page ``<loc>`` URLs.
+- ``<sitemapindex>`` — points to child sitemaps, each its own ``<loc>``.
+
+Parsing is namespace-agnostic (sitemaps declare the sitemaps.org namespace, but
+we match on the local tag name so a missing/odd namespace still works) and
+forgiving: a malformed document yields empty lists rather than raising.
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+from xml.etree import ElementTree as ET
+
+_GZIP_MAGIC = b"\x1f\x8b"
+
+
+def maybe_gunzip(data: bytes) -> bytes:
+    """Decompress ``data`` if it is gzip (``.xml.gz`` sitemaps are common).
+
+    Detected by the gzip magic bytes rather than the URL suffix, since servers
+    serve gzipped sitemaps under plain ``.xml`` URLs too. Returns the input
+    unchanged if it isn't gzip or can't be decompressed."""
+    if data[:2] == _GZIP_MAGIC:
+        try:
+            return gzip.decompress(data)
+        except (OSError, EOFError):
+            return data
+    return data
+
+
+def _local(tag: str) -> str:
+    """Local tag name without its XML namespace ('{ns}loc' -> 'loc')."""
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def parse_sitemap(data: bytes) -> tuple[list[str], list[str]]:
+    """Parse sitemap XML into ``(page_urls, child_sitemap_urls)``.
+
+    - A ``<urlset>`` yields its ``<url><loc>`` values as ``page_urls``.
+    - A ``<sitemapindex>`` yields its ``<sitemap><loc>`` values as
+      ``child_sitemap_urls`` (the caller fetches those in turn).
+
+    Robust to gzip input and to a missing/odd namespace. A parse error returns
+    ``([], [])`` rather than raising, so one bad sitemap can't abort a crawl.
+    """
+    data = maybe_gunzip(data)
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError:
+        return [], []
+
+    root_tag = _local(root.tag)
+    page_urls: list[str] = []
+    child_sitemaps: list[str] = []
+
+    if root_tag == "sitemapindex":
+        for loc in root.iter():
+            if _local(loc.tag) == "loc" and loc.text:
+                child_sitemaps.append(loc.text.strip())
+    else:
+        # Treat anything else as a urlset (leaf). <urlset> is the common case;
+        # being lenient here means a non-standard root still yields its <loc>s.
+        for loc in root.iter():
+            if _local(loc.tag) == "loc" and loc.text:
+                page_urls.append(loc.text.strip())
+
+    return page_urls, child_sitemaps
+
+
+_SITEMAP_DIRECTIVE = re.compile(r"^\s*sitemap\s*:\s*(\S+)", re.IGNORECASE | re.MULTILINE)
+
+
+def sitemaps_from_robots(robots_txt: str) -> list[str]:
+    """Extract ``Sitemap:`` directive URLs from robots.txt content.
+
+    robots.txt may list one or more ``Sitemap: <absolute-url>`` lines; these are
+    the site's own declaration of where its sitemaps live and are preferred over
+    guessing ``/sitemap.xml``."""
+    return [m.group(1).strip() for m in _SITEMAP_DIRECTIVE.finditer(robots_txt or "")]

--- a/tests/test_generic/test_sitemap.py
+++ b/tests/test_generic/test_sitemap.py
@@ -58,6 +58,21 @@ def test_parse_ignores_namespace():
     assert pages == ["https://x.com/a"]
 
 
+def test_parse_excludes_extension_loc():
+    # image:/video: extension namespaces nest their own <loc> (local name "loc")
+    # inside a <url>; only the <url>'s direct-child <loc> is a page URL.
+    ns = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+    img = 'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'
+    xml = (
+        f"<urlset {ns} {img}>"
+        "<url><loc>https://x.com/page</loc>"
+        "<image:image><image:loc>https://x.com/pic.jpg</image:loc></image:image>"
+        "</url></urlset>"
+    ).encode()
+    pages, _ = parse_sitemap(xml)
+    assert pages == ["https://x.com/page"]  # image URL excluded
+
+
 def test_sitemaps_from_robots():
     txt = "User-agent: *\nSitemap: https://x.com/sitemap.xml\nSitemap: https://x.com/news.xml\n"
     assert sitemaps_from_robots(txt) == ["https://x.com/sitemap.xml", "https://x.com/news.xml"]
@@ -68,28 +83,29 @@ def test_sitemaps_from_robots():
 
 
 def _scraper_with_responses(mapping, robots_txt=None, robots_raises=False):
-    """A GenericScraper whose http.get_raw returns bodies by URL substring."""
+    """A GenericScraper whose http.get returns bodies by URL substring. A missing
+    URL raises (mirroring HttpClient.get's non-2xx behavior), which sitemap_urls
+    treats as 'not there' and skips."""
     gs = GenericScraper()
     http = MagicMock()
 
-    def get_raw(url, **kwargs):
+    def get(url, **kwargs):
         resp = MagicMock()
         if "robots" in url:
             if robots_raises:
                 raise RuntimeError("no robots")
-            resp.text = robots_txt or ""
-            resp.content = (robots_txt or "").encode()
+            body = robots_txt or ""
+            resp.text = body
+            resp.content = body.encode()
             return resp
         for frag, body in mapping.items():
             if frag in url:
                 resp.text = body.decode() if isinstance(body, bytes) else body
                 resp.content = body if isinstance(body, bytes) else body.encode()
                 return resp
-        resp.text = ""
-        resp.content = b""
-        return resp
+        raise RuntimeError(f"404 {url}")  # unknown URL -> get() would raise
 
-    http.get_raw = get_raw
+    http.get = get
     gs._http = http
     return gs
 

--- a/tests/test_generic/test_sitemap.py
+++ b/tests/test_generic/test_sitemap.py
@@ -1,0 +1,180 @@
+"""Tests for sitemap parsing (pure) and GenericScraper sitemap crawling (#160)."""
+
+import gzip
+from unittest.mock import MagicMock
+
+from pyscrappy import GenericScraper
+from pyscrappy.generic.sitemap import (
+    maybe_gunzip,
+    parse_sitemap,
+    sitemaps_from_robots,
+)
+
+_NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+
+
+def _urlset(*urls):
+    body = "".join(f"<url><loc>{u}</loc></url>" for u in urls)
+    return f"<urlset {_NS}>{body}</urlset>".encode()
+
+
+def _index(*sitemaps):
+    body = "".join(f"<sitemap><loc>{s}</loc></sitemap>" for s in sitemaps)
+    return f"<sitemapindex {_NS}>{body}</sitemapindex>".encode()
+
+
+# -- pure parsing --
+
+
+def test_parse_urlset():
+    pages, children = parse_sitemap(_urlset("https://x.com/a", "https://x.com/b"))
+    assert pages == ["https://x.com/a", "https://x.com/b"]
+    assert children == []
+
+
+def test_parse_sitemapindex():
+    pages, children = parse_sitemap(_index("https://x.com/s1.xml", "https://x.com/s2.xml"))
+    assert pages == []
+    assert children == ["https://x.com/s1.xml", "https://x.com/s2.xml"]
+
+
+def test_parse_gzip_sitemap():
+    pages, _ = parse_sitemap(gzip.compress(_urlset("https://x.com/a")))
+    assert pages == ["https://x.com/a"]
+
+
+def test_maybe_gunzip_passthrough_for_plain_bytes():
+    assert maybe_gunzip(b"<xml/>") == b"<xml/>"
+
+
+def test_parse_garbage_returns_empty():
+    assert parse_sitemap(b"<<not xml") == ([], [])
+    assert parse_sitemap(b"") == ([], [])
+
+
+def test_parse_ignores_namespace():
+    # No namespace declared at all — local-name matching still finds <loc>.
+    pages, _ = parse_sitemap(b"<urlset><url><loc>https://x.com/a</loc></url></urlset>")
+    assert pages == ["https://x.com/a"]
+
+
+def test_sitemaps_from_robots():
+    txt = "User-agent: *\nSitemap: https://x.com/sitemap.xml\nSitemap: https://x.com/news.xml\n"
+    assert sitemaps_from_robots(txt) == ["https://x.com/sitemap.xml", "https://x.com/news.xml"]
+    assert sitemaps_from_robots("") == []
+
+
+# -- GenericScraper.sitemap_urls --
+
+
+def _scraper_with_responses(mapping, robots_txt=None, robots_raises=False):
+    """A GenericScraper whose http.get_raw returns bodies by URL substring."""
+    gs = GenericScraper()
+    http = MagicMock()
+
+    def get_raw(url, **kwargs):
+        resp = MagicMock()
+        if "robots" in url:
+            if robots_raises:
+                raise RuntimeError("no robots")
+            resp.text = robots_txt or ""
+            resp.content = (robots_txt or "").encode()
+            return resp
+        for frag, body in mapping.items():
+            if frag in url:
+                resp.text = body.decode() if isinstance(body, bytes) else body
+                resp.content = body if isinstance(body, bytes) else body.encode()
+                return resp
+        resp.text = ""
+        resp.content = b""
+        return resp
+
+    http.get_raw = get_raw
+    gs._http = http
+    return gs
+
+
+def test_sitemap_urls_recurses_index_via_robots():
+    gs = _scraper_with_responses(
+        {
+            "sitemap_index": _index("https://x.com/s1.xml"),
+            "s1.xml": _urlset("https://x.com/p0", "https://x.com/p1"),
+        },
+        robots_txt="Sitemap: https://x.com/sitemap_index.xml\n",
+    )
+    assert gs.sitemap_urls("https://x.com/page") == ["https://x.com/p0", "https://x.com/p1"]
+
+
+def test_sitemap_urls_max_urls_caps():
+    gs = _scraper_with_responses(
+        {"sitemap.xml": _urlset(*[f"https://x.com/p{i}" for i in range(10)])},
+        robots_txt="Sitemap: https://x.com/sitemap.xml\n",
+    )
+    assert gs.sitemap_urls("https://x.com/p", max_urls=3) == [
+        "https://x.com/p0",
+        "https://x.com/p1",
+        "https://x.com/p2",
+    ]
+
+
+def test_sitemap_urls_falls_back_to_sitemap_xml_without_robots():
+    gs = _scraper_with_responses(
+        {"sitemap.xml": _urlset("https://x.com/a")},
+        robots_raises=True,
+    )
+    assert gs.sitemap_urls("https://x.com/p") == ["https://x.com/a"]
+
+
+def test_sitemap_urls_dedupes():
+    gs = _scraper_with_responses(
+        {"sitemap.xml": _urlset("https://x.com/a", "https://x.com/a", "https://x.com/b")},
+        robots_txt="Sitemap: https://x.com/sitemap.xml\n",
+    )
+    assert gs.sitemap_urls("https://x.com/p") == ["https://x.com/a", "https://x.com/b"]
+
+
+def test_sitemap_urls_index_only_recurses_one_level():
+    # A child sitemap that is itself an index must NOT be descended into further.
+    gs = _scraper_with_responses(
+        {
+            "top.xml": _index("https://x.com/mid.xml"),
+            "mid.xml": _index("https://x.com/leaf.xml"),  # child index — not followed
+            "leaf.xml": _urlset("https://x.com/deep"),
+        },
+        robots_txt="Sitemap: https://x.com/top.xml\n",
+    )
+    # top -> mid (an index, treated as a child; its children are not followed),
+    # so no page URLs are reached.
+    assert gs.sitemap_urls("https://x.com/p") == []
+
+
+def test_scrape_sitemap_merges_results(monkeypatch):
+    gs = _scraper_with_responses(
+        {"sitemap.xml": _urlset("https://x.com/a", "https://x.com/b")},
+        robots_txt="Sitemap: https://x.com/sitemap.xml\n",
+    )
+
+    # Stub scrape_all to avoid real page fetches; return one item per URL.
+    import pyscrappy.generic.scraper as scraper_mod
+    from pyscrappy.core.models import ScrapeMetadata, ScrapeResult
+
+    def fake_scrape_all(funcs, max_workers=8):
+        return [
+            ScrapeResult(data=[{"i": n}], metadata=ScrapeMetadata()) for n, _ in enumerate(funcs)
+        ]
+
+    monkeypatch.setattr(scraper_mod, "scrape_all", fake_scrape_all, raising=False)
+    # scrape_all is imported inside the method, so patch the source module too.
+    monkeypatch.setattr("pyscrappy.concurrent.scrape_all", fake_scrape_all)
+
+    result = gs.scrape_sitemap("https://x.com/p", max_urls=10)
+    assert len(result.data) == 2
+    assert result.metadata.total_pages == 2
+    assert result.metadata.scraper == "generic:sitemap"
+
+
+def test_scrape_sitemap_no_urls_returns_error():
+    gs = _scraper_with_responses({}, robots_raises=True)
+    result = gs.scrape_sitemap("https://x.com/p")
+    assert result.data == []
+    assert result.errors and "no sitemap URLs" in result.errors[0].message


### PR DESCRIPTION
Closes #160.

## What

The reliable counterpart to pagination: enumerate and scrape a whole site from its `sitemap.xml`.

- **`GenericScraper.sitemap_urls(url, max_urls=None)`** — discovers sitemaps from `robots.txt` `Sitemap:` directives (falling back to `/sitemap.xml`), fetches and parses them, follows a `<sitemapindex>` one level into its child sitemaps, de-duplicates, and caps at `max_urls`.
- **`GenericScraper.scrape_sitemap(url, max_urls=100, ...)`** — enumerates via `sitemap_urls`, scrapes each page concurrently (`scrape_all`), and merges into one `ScrapeResult` (per-URL errors preserved).
- **`pyscrappy/generic/sitemap.py`** — pure, namespace-agnostic parsing of `<urlset>` / `<sitemapindex>`, gzip-aware (detected by magic bytes, since gzipped sitemaps are served under plain `.xml` URLs too), and `Sitemap:` extraction from robots.txt. Malformed input returns empty lists rather than raising, so one bad sitemap can't abort a crawl.

Fetches reuse the normal HTTP client (rate-limit, cache, proxy, stealth); robots checks are skipped for the sitemap/robots files themselves.

## Notes from the issue, all covered
- ✅ `<urlset>` and `<sitemapindex>` (recurse one level)
- ✅ discover from `robots.txt` `Sitemap:`, else `/sitemap.xml`
- ✅ reuse robots/rate-limit/cache machinery
- ✅ gzip (`.xml.gz`) decompression
- ✅ `max_urls` cap; fan-out via `scrape_all`

## Testing
- 14 new tests: parser (urlset/index/gzip/robots/garbage/no-namespace), `sitemap_urls` (index recursion, cap, `/sitemap.xml` fallback, dedupe, one-level-only), `scrape_sitemap` (merge + no-urls-error).
- Full suite: 554 passed, ruff check + format clean.

Also folds the already-merged retry-jitter change (#163/#165) into the 1.5.8 changelog entry and bumps all four version sites.