### PR TITLE
Observability hooks: on_request / on_retry / on_cache_hit (1.5.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to PyScrappy are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.5.9] - 2026-08-25
+
+### Added
+- **Observability hooks.** `ScraperConfig` accepts optional `on_request(url)`, `on_retry(url, attempt, delay, error)`, and `on_cache_hit(url)` callbacks, invoked at the corresponding points in both the sync and async HTTP clients — for progress bars/metrics on long crawls without enabling logging. Best-effort: a callback that raises is logged at debug and never breaks the request (#162).
+
 ## [1.5.8] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -584,6 +584,26 @@ config = ScraperConfig(cache_ttl=3600, cache_dir="~/.cache/pyscrappy")
 `clear_cache()` empties the in-memory cache; the on-disk cache persists by
 design — delete its `cache_dir` to clear it.
 
+### Observability hooks
+
+For long crawls, pass lightweight callbacks to watch requests live (progress
+bars, metrics) without turning on logging:
+
+```python
+config = ScraperConfig(
+    on_request=lambda url: print("GET", url),               # before a network fetch
+    on_retry=lambda url, attempt, delay, err: print("retry", attempt, url),
+    on_cache_hit=lambda url: print("cached", url),          # served from cache
+)
+```
+
+- `on_request(url)` fires once before a URL is fetched (not on a cache hit).
+- `on_retry(url, attempt, delay, error)` fires before each backoff sleep.
+- `on_cache_hit(url)` fires when a request is served from cache.
+
+All three are best-effort: a callback that raises is logged at debug and never
+breaks the scrape. They fire on both the sync and async paths.
+
 ## Dependencies
 
 **Required:** `httpx`, `beautifulsoup4`, `lxml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.8"
+version = "1.5.9"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.8",
+  "version": "1.5.9",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.8"
+__version__ = "1.5.9"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -76,11 +76,15 @@ class AsyncHttpClient:
 
     async def get(self, url: str, skip_robots_check: bool = False, **kwargs: Any) -> httpx.Response:
         """GET with retries, rate-limiting, and optional caching (see HttpClient.get)."""
+        # The logical target URL the caller asked for; hooks report this even
+        # when scraper_api routing rewrites `url` to the provider endpoint below.
+        target_url = url
+
         cache_key = self._cache_key(url, kwargs.get("params"))
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("Cache hit for %s", url)
-            _fire(self.config.on_cache_hit, url)
+            _fire(self.config.on_cache_hit, target_url)
             return cached
 
         if scraper_api.is_configured(self.config.scraper_api):
@@ -102,7 +106,7 @@ class AsyncHttpClient:
             crawl_delay = await check_robots_async(self, url, user_agent=user_agent)
 
         await self._rate_limit(url, min_delay=crawl_delay)
-        _fire(self.config.on_request, url)  # a network fetch is about to happen
+        _fire(self.config.on_request, target_url)  # a network fetch is about to happen
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
@@ -118,7 +122,11 @@ class AsyncHttpClient:
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
                         _fire(
-                            self.config.on_retry, url, attempt, retry_after, "429 Too Many Requests"
+                            self.config.on_retry,
+                            target_url,
+                            attempt,
+                            retry_after,
+                            "429 Too Many Requests",
                         )
                         await asyncio.sleep(retry_after)
                         continue
@@ -134,7 +142,7 @@ class AsyncHttpClient:
                     delay = backoff_delay(self.config, attempt)
                     if exc.response.status_code == 503 and "Retry-After" in exc.response.headers:
                         delay = parse_retry_after(exc.response.headers.get("Retry-After"), delay)
-                    _fire(self.config.on_retry, url, attempt, delay, exc)
+                    _fire(self.config.on_retry, target_url, attempt, delay, exc)
                     await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
                     await asyncio.sleep(delay)
                     continue
@@ -144,7 +152,7 @@ class AsyncHttpClient:
                 last_exc = exc
                 if attempt < self.config.max_retries:
                     delay = backoff_delay(self.config, attempt)
-                    _fire(self.config.on_retry, url, attempt, delay, exc)
+                    _fire(self.config.on_retry, target_url, attempt, delay, exc)
                     await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
                     await asyncio.sleep(delay)
                     continue

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -25,6 +25,7 @@ from pyscrappy.core.exceptions import NetworkError, RateLimitError
 from pyscrappy.core.http import (
     _SHARED_CACHE,
     _disk_cache_for,
+    _fire,
     backoff_delay,
     parse_retry_after,
 )
@@ -79,6 +80,7 @@ class AsyncHttpClient:
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("Cache hit for %s", url)
+            _fire(self.config.on_cache_hit, url)
             return cached
 
         if scraper_api.is_configured(self.config.scraper_api):
@@ -100,6 +102,7 @@ class AsyncHttpClient:
             crawl_delay = await check_robots_async(self, url, user_agent=user_agent)
 
         await self._rate_limit(url, min_delay=crawl_delay)
+        _fire(self.config.on_request, url)  # a network fetch is about to happen
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
@@ -114,6 +117,9 @@ class AsyncHttpClient:
                     )
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
+                        _fire(
+                            self.config.on_retry, url, attempt, retry_after, "429 Too Many Requests"
+                        )
                         await asyncio.sleep(retry_after)
                         continue
                     raise RateLimitError(f"Rate-limited by {url} after {attempt} attempts")
@@ -128,6 +134,7 @@ class AsyncHttpClient:
                     delay = backoff_delay(self.config, attempt)
                     if exc.response.status_code == 503 and "Retry-After" in exc.response.headers:
                         delay = parse_retry_after(exc.response.headers.get("Retry-After"), delay)
+                    _fire(self.config.on_retry, url, attempt, delay, exc)
                     await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
                     await asyncio.sleep(delay)
                     continue
@@ -136,8 +143,10 @@ class AsyncHttpClient:
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.config.max_retries:
+                    delay = backoff_delay(self.config, attempt)
+                    _fire(self.config.on_retry, url, attempt, delay, exc)
                     await self.aclose()  # close the pool; retry rebuilds + re-picks proxy
-                    await asyncio.sleep(backoff_delay(self.config, attempt))
+                    await asyncio.sleep(delay)
                     continue
 
         raise NetworkError(

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Callable, Literal
 
 _DEFAULT_USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
@@ -78,6 +78,17 @@ class ScraperConfig:
             Requires the optional ``curl_cffi`` dependency (``pip install
             pyscrappy[stealth]``). ``None`` (the default) uses the normal httpx
             client.
+        on_request: Optional callback ``(url) -> None`` invoked once before a URL
+            is fetched over the network (not on a cache hit). For progress bars /
+            metrics on long crawls.
+        on_retry: Optional callback ``(url, attempt, delay, error) -> None``
+            invoked before each backoff sleep, where ``attempt`` is the attempt
+            that just failed, ``delay`` the seconds about to be slept, and
+            ``error`` the exception (or a short string for a 429).
+        on_cache_hit: Optional callback ``(url) -> None`` invoked when a request
+            is served from the response cache instead of the network.
+            All three hooks are best-effort: a callback that raises is logged at
+            debug and never breaks the request.
     """
 
     timeout: float = 30.0
@@ -100,6 +111,10 @@ class ScraperConfig:
     cache_dir: str | None = None
     impersonate: str | None = None
     retry_jitter: bool = True
+    # Observability hooks (best-effort; a raising callback never breaks a scrape).
+    on_request: Callable[[str], None] | None = None
+    on_retry: Callable[[str, int, float, object], None] | None = None
+    on_cache_hit: Callable[[str], None] | None = None
 
     def pick_proxy(self, exclude: str | None = None) -> str | None:
         """Return a single proxy URL (rotating if a list was configured)."""

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -113,7 +113,7 @@ class ScraperConfig:
     retry_jitter: bool = True
     # Observability hooks (best-effort; a raising callback never breaks a scrape).
     on_request: Callable[[str], None] | None = None
-    on_retry: Callable[[str, int, float, object], None] | None = None
+    on_retry: Callable[[str, int, float, Exception | str], None] | None = None
     on_cache_hit: Callable[[str], None] | None = None
 
     def pick_proxy(self, exclude: str | None = None) -> str | None:

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -30,6 +30,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger("pyscrappy.http")
 
 
+def _fire(callback: Any, *args: Any) -> None:
+    """Invoke an optional observability hook, swallowing any error.
+
+    Hooks (on_request / on_retry / on_cache_hit) are best-effort: a callback that
+    raises must never break a scrape, so it's caught and logged at debug."""
+    if callback is None:
+        return
+    try:
+        callback(*args)
+    except Exception:  # noqa: BLE001 - a user hook must never break the request
+        logger.debug("observability hook raised", exc_info=True)
+
+
 def parse_retry_after(value: str | None, default: float) -> float:
     """Parse a ``Retry-After`` header value, which RFC 7231 allows as either
     delay-seconds (e.g. ``"120"``) or an HTTP-date (e.g. ``"Wed, 21 Oct 2025 07:28:00 GMT"``).
@@ -291,6 +304,7 @@ class HttpClient:
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("Cache hit for %s", url)
+            _fire(self.config.on_cache_hit, url)
             return cached
 
         # Route through a scraping-API service if configured, so blocked sites
@@ -315,6 +329,7 @@ class HttpClient:
             crawl_delay = check_robots_sync(self, url, user_agent=user_agent)
 
         self._rate_limit(url, min_delay=crawl_delay)
+        _fire(self.config.on_request, url)  # a network fetch is about to happen
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
@@ -329,6 +344,9 @@ class HttpClient:
                     )
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
+                        _fire(
+                            self.config.on_retry, url, attempt, retry_after, "429 Too Many Requests"
+                        )
                         time.sleep(retry_after)
                         continue
                     raise RateLimitError(f"Rate-limited by {url} after {attempt} attempts")
@@ -350,6 +368,7 @@ class HttpClient:
                         attempt,
                         delay,
                     )
+                    _fire(self.config.on_retry, url, attempt, delay, exc)
                     self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue
@@ -360,6 +379,7 @@ class HttpClient:
                 if attempt < self.config.max_retries:
                     delay = self._backoff_delay(attempt)
                     logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
+                    _fire(self.config.on_retry, url, attempt, delay, exc)
                     self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -300,11 +300,16 @@ class HttpClient:
         and returned for repeat requests within the TTL, skipping both the
         network and the rate limiter.
         """
+        # The logical target URL the caller asked for. Observability hooks always
+        # report this, even when scraper_api routing later rewrites `url` to the
+        # provider endpoint — a hook wants to see the site, not the service.
+        target_url = url
+
         cache_key = self._cache_key(url, kwargs.get("params"))
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("Cache hit for %s", url)
-            _fire(self.config.on_cache_hit, url)
+            _fire(self.config.on_cache_hit, target_url)
             return cached
 
         # Route through a scraping-API service if configured, so blocked sites
@@ -329,7 +334,7 @@ class HttpClient:
             crawl_delay = check_robots_sync(self, url, user_agent=user_agent)
 
         self._rate_limit(url, min_delay=crawl_delay)
-        _fire(self.config.on_request, url)  # a network fetch is about to happen
+        _fire(self.config.on_request, target_url)  # a network fetch is about to happen
 
         last_exc: Exception | None = None
         for attempt in range(1, self.config.max_retries + 1):
@@ -368,7 +373,7 @@ class HttpClient:
                         attempt,
                         delay,
                     )
-                    _fire(self.config.on_retry, url, attempt, delay, exc)
+                    _fire(self.config.on_retry, target_url, attempt, delay, exc)
                     self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue
@@ -379,7 +384,7 @@ class HttpClient:
                 if attempt < self.config.max_retries:
                     delay = self._backoff_delay(attempt)
                     logger.warning("Request error on %s, retry %d in %.1fs", url, attempt, delay)
-                    _fire(self.config.on_retry, url, attempt, delay, exc)
+                    _fire(self.config.on_retry, target_url, attempt, delay, exc)
                     self.close()  # close the pool; retry rebuilds + re-picks proxy
                     time.sleep(delay)
                     continue

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -236,3 +236,25 @@ async def test_async_get_503_honors_retry_after():
         assert mock_sleep.call_count == 1
         assert mock_sleep.call_args[0][0] == 25.0
     await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_on_request_hook_fires():
+    seen = []
+    client, _ = _mock_async_client(
+        ScraperConfig(rate_limit=0, on_request=seen.append), [_resp(text="hi")]
+    )
+    await client.get("https://example.com")
+    assert seen == ["https://example.com"]
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_raising_hook_does_not_break_request():
+    def boom(url):
+        raise RuntimeError("hook exploded")
+
+    client, _ = _mock_async_client(ScraperConfig(rate_limit=0, on_request=boom), [_resp(text="hi")])
+    resp = await client.get("https://example.com")  # must not raise
+    assert resp.status_code == 200
+    await client.aclose()

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -727,3 +727,95 @@ class TestHttpClientCaching:
         assert hit is not None
         assert hit.headers.get_list("Set-Cookie") == ["a=1", "b=2"]
         assert hit.headers.get("Content-Type") == "text/html"
+
+
+class TestObservabilityHooks:
+    @pytest.fixture(autouse=True)
+    def _clear_shared_cache(self):
+        HttpClient.clear_cache()
+        yield
+        HttpClient.clear_cache()
+
+    def _client(self, config):
+        client = HttpClient(config)
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.text = "<html>OK</html>"
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        mock = MagicMock()
+        mock.get.return_value = resp
+        client._client = mock
+        return client, mock
+
+    def test_on_request_fires_once_per_fetch(self):
+        seen = []
+        client, _ = self._client(ScraperConfig(rate_limit=0, on_request=seen.append))
+        client.get("https://example.com")
+        assert seen == ["https://example.com"]
+        client.close()
+
+    def test_on_request_not_fired_on_cache_hit(self):
+        seen = []
+        client, mock = self._client(
+            ScraperConfig(rate_limit=0, cache_ttl=60, on_request=seen.append)
+        )
+        client.get("https://example.com")  # network
+        client.get("https://example.com")  # cache hit
+        assert seen == ["https://example.com"]  # fired once, not on the hit
+        assert mock.get.call_count == 1
+        client.close()
+
+    def test_on_cache_hit_fires_on_hit(self):
+        hits = []
+        client, _ = self._client(
+            ScraperConfig(rate_limit=0, cache_ttl=60, on_cache_hit=hits.append)
+        )
+        client.get("https://example.com")  # network, no hit
+        client.get("https://example.com")  # cache hit
+        assert hits == ["https://example.com"]
+        client.close()
+
+    def test_on_retry_fires_per_retry(self):
+        retries = []
+        config = ScraperConfig(
+            max_retries=3,
+            rate_limit=0,
+            retry_delay=0,
+            retry_jitter=False,
+            on_retry=lambda url, attempt, delay, error: retries.append((attempt, url)),
+        )
+        client = HttpClient(config)
+
+        err = MagicMock(spec=httpx.Response)
+        err.status_code = 500
+
+        def raise_500():
+            raise httpx.HTTPStatusError("500", request=MagicMock(), response=err)
+
+        err.raise_for_status = raise_500
+        ok = MagicMock(spec=httpx.Response)
+        ok.status_code = 200
+        ok.raise_for_status = MagicMock()
+
+        # First two attempts 500, third succeeds.
+        m1 = MagicMock()
+        m1.get.return_value = err
+        m2 = MagicMock()
+        m2.get.return_value = err
+        m3 = MagicMock()
+        m3.get.return_value = ok
+        client._client = m1
+        client._build_client = MagicMock(side_effect=[m2, m3])
+        client.get("https://example.com")
+        assert [a for a, _ in retries] == [1, 2]  # one on_retry per failed attempt
+        client.close()
+
+    def test_raising_hook_does_not_break_request(self):
+        def boom(url):
+            raise RuntimeError("hook exploded")
+
+        client, _ = self._client(ScraperConfig(rate_limit=0, on_request=boom))
+        resp = client.get("https://example.com")  # must not raise
+        assert resp.status_code == 200
+        client.close()

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -819,3 +819,17 @@ class TestObservabilityHooks:
         resp = client.get("https://example.com")  # must not raise
         assert resp.status_code == 200
         client.close()
+
+    def test_on_request_reports_target_url_not_scraper_api_endpoint(self):
+        # With scraper_api routing, url is rewritten to the provider endpoint
+        # before the fetch; hooks must still report the logical target URL (#171).
+        seen = []
+        config = ScraperConfig(
+            rate_limit=0,
+            scraper_api={"provider": "scraperapi", "api_key": "KEY"},
+            on_request=seen.append,
+        )
+        client, _ = self._client(config)
+        client.get("https://target.example.com/page")
+        assert seen == ["https://target.example.com/page"]  # not api.scraperapi.com
+        client.close()


### PR DESCRIPTION
Closes #162.

## What

Optional `ScraperConfig` callbacks to watch a crawl live (progress bars, metrics) without enabling stdlib logging:

- **`on_request(url)`** — once before a URL is fetched over the network (not on a cache hit).
- **`on_retry(url, attempt, delay, error)`** — before each backoff sleep (429, 5xx, request-error paths).
- **`on_cache_hit(url)`** — when a request is served from the response cache.

```python
config = ScraperConfig(on_request=lambda url: print("GET", url))
```

Wired at the matching points in **both** `HttpClient` and `AsyncHttpClient` via a shared `_fire()` helper. All three are **best-effort**: a callback that raises is caught and logged at debug, never breaking the request.

## Notes from the issue, all covered
- ✅ `on_request` fires once per network fetch, not on a cache hit
- ✅ `on_retry` per retry with the attempt number
- ✅ a raising callback doesn't break the request
- ✅ mirrored across sync and async

## Testing
- 7 new tests: fires-once, not-on-cache-hit, per-retry attempt numbers, raising-hook-safe, plus async on_request + async raising-hook.
- Full suite: 562 passed, ruff check + format clean.

Docs (README Observability hooks section + CHANGELOG) and a patch bump to 1.5.9 across all four version sites.