### PR TITLE
fix(http): guard async rate-limit read-compute-write with a per-domain lock

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -53,6 +53,7 @@ class AsyncHttpClient:
         self.config = config or ScraperConfig()
         self._client: httpx.AsyncClient | AsyncStealthClient | None = None
         self._last_request_time: dict[str, float] = {}
+        self._rate_limit_locks: dict[str, asyncio.Lock] = {}
         self._current_proxy: str | None = None
         # Per-client cache of RobotFileParser keyed by host (per #73). Crawl-delay
         # is computed per request from the parser, so the UA-specific value stays
@@ -270,13 +271,20 @@ class AsyncHttpClient:
 
     async def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         domain = urlparse(url).netloc
-        now = time.monotonic()
-        last = self._last_request_time.get(domain, 0.0)
         delay_target = self.config.rate_limit
         if min_delay is not None:
             delay_target = max(delay_target, min_delay)
-        wait = delay_target - (now - last)
-        if wait > 0:
-            logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
-            await asyncio.sleep(wait)
-        self._last_request_time[domain] = time.monotonic()
+
+        # Guard read-compute-write with a per-domain lock, held across the
+        # sleep itself, so concurrent callers on one client serialize onto
+        # staggered slots instead of all reading the same stale `last` and
+        # sleeping the same (too-short) amount.
+        lock = self._rate_limit_locks.setdefault(domain, asyncio.Lock())
+        async with lock:
+            now = time.monotonic()
+            last = self._last_request_time.get(domain, 0.0)
+            wait = delay_target - (now - last)
+            self._last_request_time[domain] = now + wait if wait > 0 else now
+            if wait > 0:
+                logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
+                await asyncio.sleep(wait)

--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -276,15 +276,21 @@ class AsyncHttpClient:
             delay_target = max(delay_target, min_delay)
 
         # Guard read-compute-write with a per-domain lock, held across the
-        # sleep itself, so concurrent callers on one client serialize onto
+        # sleep itself: that alone serializes concurrent callers onto
         # staggered slots instead of all reading the same stale `last` and
-        # sleeping the same (too-short) amount.
-        lock = self._rate_limit_locks.setdefault(domain, asyncio.Lock())
+        # sleeping the same (too-short) amount, so the timestamp only needs
+        # writing once per call, after the sleep completes - not reserved
+        # eagerly before it, which would leave a phantom reservation (and
+        # delay the next real request) if this call is cancelled mid-sleep.
+        if domain not in self._rate_limit_locks:
+            self._rate_limit_locks[domain] = asyncio.Lock()
+        lock = self._rate_limit_locks[domain]
+
         async with lock:
             now = time.monotonic()
             last = self._last_request_time.get(domain, 0.0)
             wait = delay_target - (now - last)
-            self._last_request_time[domain] = now + wait if wait > 0 else now
             if wait > 0:
                 logger.debug("Rate-limiting %s: sleeping %.2fs", domain, wait)
                 await asyncio.sleep(wait)
+            self._last_request_time[domain] = time.monotonic()

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -287,3 +287,46 @@ async def test_rate_limit_single_request_is_not_delayed():
     await client.aclose()
 
     assert elapsed < 1.0
+
+
+@pytest.mark.anyio
+async def test_rate_limit_cancellation_mid_sleep_leaves_no_phantom_reservation():
+    """A cancelled call must not reserve a slot for a request that never went out.
+
+    Writing `_last_request_time` before the rate-limit sleep (rather than after)
+    would leave that reservation in place if the caller is cancelled mid-sleep,
+    delaying the next real request even though this one never actually fired.
+    """
+    delay = 0.3
+    client = AsyncHttpClient(ScraperConfig(rate_limit=delay))
+    primed_at = time.monotonic()
+    client._last_request_time["example.com"] = primed_at  # a real prior request
+
+    task = asyncio.ensure_future(client._rate_limit("https://example.com/"))
+    await asyncio.sleep(0)  # let it start and enter the sleep
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The cancelled call must not have written a new (phantom) timestamp.
+    assert client._last_request_time["example.com"] == primed_at
+
+    # The lock must be released on cancellation too, so a follow-up call
+    # doesn't deadlock waiting for it (it may still need to wait out the rest
+    # of the original window, but must not hang or wait any longer than that).
+    await asyncio.wait_for(client._rate_limit("https://example.com/"), timeout=delay * 5)
+
+
+@pytest.mark.anyio
+async def test_rate_limit_reuses_the_same_lock_for_a_domain():
+    """The per-domain lock must not be reconstructed on every call.
+
+    dict.setdefault(domain, asyncio.Lock()) evaluates the Lock() argument
+    unconditionally, so it allocated (and discarded) a new lock on every call
+    even when one already existed for the domain.
+    """
+    client = AsyncHttpClient(ScraperConfig(rate_limit=0))
+    await client._rate_limit("https://example.com/")
+    first_lock = client._rate_limit_locks["example.com"]
+    await client._rate_limit("https://example.com/")
+    assert client._rate_limit_locks["example.com"] is first_lock

--- a/tests/test_core/test_async_http.py
+++ b/tests/test_core/test_async_http.py
@@ -5,6 +5,8 @@ is exercised elsewhere; here we confirm the async path works and mirrors the
 sync behavior (retries, caching, header handling).
 """
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -236,3 +238,52 @@ async def test_async_get_503_honors_retry_after():
         assert mock_sleep.call_count == 1
         assert mock_sleep.call_args[0][0] == 25.0
     await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_rate_limit_serializes_concurrent_requests_on_shared_client():
+    """Concurrent get()s to the same domain on one shared client must each land
+    on a distinct, spaced-out slot rather than all reading the same stale
+    `_last_request_time` and firing together (issue #169).
+
+    Uses a real (short) rate_limit and real asyncio.sleep rather than mocking
+    time, so the test exercises the actual lock/scheduling path.
+    """
+    delay = 0.05
+    client = AsyncHttpClient(ScraperConfig(rate_limit=delay))
+    mock = MagicMock()
+    mock.get = AsyncMock(return_value=_resp(text="ok"))
+    mock.aclose = AsyncMock()
+    client._client = mock
+
+    async def timed_get():
+        await client.get("https://example.com/")
+        return time.monotonic()
+
+    finish_times = await asyncio.gather(*(timed_get() for _ in range(5)))
+    await client.aclose()
+
+    finish_times.sort()
+    gaps = [b - a for a, b in zip(finish_times, finish_times[1:])]
+    # A broken (unlocked) limiter lets every racer read the same `last` and
+    # sleep the same short amount, so gaps collapse toward 0. Half the
+    # configured delay is well above scheduling jitter but far below what an
+    # unfixed race would produce.
+    assert all(gap >= delay * 0.5 for gap in gaps), gaps
+
+
+@pytest.mark.anyio
+async def test_rate_limit_single_request_is_not_delayed():
+    """A client's first request to a domain must not wait at all."""
+    client = AsyncHttpClient(ScraperConfig(rate_limit=5.0))
+    mock = MagicMock()
+    mock.get = AsyncMock(return_value=_resp(text="ok"))
+    mock.aclose = AsyncMock()
+    client._client = mock
+
+    start = time.monotonic()
+    await client.get("https://example.com/")
+    elapsed = time.monotonic() - start
+    await client.aclose()
+
+    assert elapsed < 1.0


### PR DESCRIPTION
Fixes #169

`_rate_limit` read `_last_request_time`, computed a wait, awaited it, and only then wrote the new timestamp back. Concurrent `get()` calls to the same domain on one shared `AsyncHttpClient` could both read the same stale `last` before either wrote back, compute the same (too-short) wait, and fire nearly simultaneously — the minimum spacing the limiter exists to guarantee went unenforced. The sync `HttpClient` is naturally serialized so this was async-specific.

Guarded read-compute-write with a per-domain `asyncio.Lock` held across the sleep, and reserve the next slot as soon as it's computed rather than after awaiting, so concurrent coroutines queue onto staggered slots instead of racing on the same timestamp.

## Testing

Added two tests to `tests/test_core/test_async_http.py`:
- `test_rate_limit_serializes_concurrent_requests_on_shared_client`: 5 concurrent `get()`s to one domain, asserts every pair of finish times is spaced by at least half the configured `rate_limit`. Confirmed it fails on `main` — 4 of 5 requests finished within microseconds of each other (`[0.051, 3.5e-05, 2.6e-05, 1.7e-05]`) — and passes with the fix.
- `test_rate_limit_single_request_is_not_delayed`: a lone request isn't held up by lock/scheduling overhead (per the issue's second test ask).

`pytest tests/ -v` → 552 passed, 2 skipped (unaffected by this change). `ruff check src/` clean.