### PR TITLE
fix(core): preserve ragged table columns in Markdown

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -111,7 +111,13 @@ class ScrapeResult:
                 .replace("\r", "")
             )
 
-        headers = list(rows[0].keys())
+        headers: list[str] = []
+        seen: set[str] = set()
+        for row in rows:
+            for header in row:
+                if header not in seen:
+                    seen.add(header)
+                    headers.append(header)
         lines = [
             "| " + " | ".join(escape_cell(header) for header in headers) + " |",
             "| " + " | ".join("---" for _ in headers) + " |",

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -145,6 +145,25 @@ class TestScrapeResult:
         assert "| Name | Age |" in md
         assert "| Alice | 30 |" in md
 
+    def test_to_markdown_preserves_late_table_columns(self):
+        result = ScrapeResult(
+            data=[
+                {
+                    "text": {"text": "", "headings": []},
+                    "tables": [
+                        [
+                            {"A": "1", "B": "2"},
+                            {"A": "3", "B": "4", "column_3": "extra"},
+                        ]
+                    ],
+                }
+            ]
+        )
+
+        assert result.to_markdown() == (
+            "| A | B | column_3 |\n| --- | --- | --- |\n| 1 | 2 |  |\n| 3 | 4 | extra |"
+        )
+
     def test_to_markdown_escapes_table_cells(self):
         result = ScrapeResult(
             data=[


### PR DESCRIPTION
## Summary

- Collect Markdown table headers across every row in first-seen order.
- Preserve cells from ragged rows instead of silently dropping them.
- Add a regression test through `ScrapeResult.to_markdown()`.

Fixes #168

## Validation

- `pytest tests/ -q` — 546 passed, 5 skipped, 19 deselected on Python 3.11
- `pytest tests/ -q` — 547 passed, 4 skipped, 19 deselected on Python 3.13
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m build`
