### PR TITLE
feat: add parquet and excel exporters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,16 @@ dataframe = ["pandas>=1.5"]
 stealth = ["curl_cffi>=0.6"]
 # YAML export for ScrapeResult.to_yaml() / save() to a .yaml/.yml file.
 yaml = ["PyYAML>=6.0"]
+# Parquet export for ScrapeResult.to_parquet() / save() to a .parquet file.
+parquet = [
+    "pandas>=1.5",
+    "pyarrow>=10.0",
+]
+# Excel export for ScrapeResult.to_excel() / save() to a .xlsx file.
+excel = [
+    "pandas>=1.5",
+    "openpyxl>=3.1",
+]
 # The MCP SDK requires Python >=3.10. The core library still supports 3.9, so
 # gate these deps behind a marker: on 3.9 they're skipped, on 3.10+ installed.
 mcp = [
@@ -62,6 +72,8 @@ all = [
     "pandas>=1.5",
     "curl_cffi>=0.6",
     "PyYAML>=6.0",
+    "pyarrow>=10.0",
+    "openpyxl>=3.1",
     "fastmcp>=2.0; python_version >= '3.10'",
     "anyio>=4.0; python_version >= '3.10'",
 ]

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -249,7 +249,13 @@ class ScrapeResult:
 
         p = _Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        self.to_dataframe().to_parquet(path, index=False)
+        try:
+            df = self.to_dataframe()
+        except ImportError:
+            raise ImportError(
+                "pandas is required for to_parquet(). Install it with: pip install 'pyscrappy[parquet]'"
+            ) from None
+        df.to_parquet(path, index=False)
 
     def to_excel(self, path: str) -> None:
         """Write ``data`` to an Excel (.xlsx) file at ``path``.

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -276,11 +276,11 @@ class ScrapeResult:
         p = _Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         try:
-             df = self.to_dataframe()
+            df = self.to_dataframe()
         except ImportError:
-             raise ImportError(
-                 "pandas is required for to_excel(). Install it with: pip install 'pyscrappy[excel]'"
-             ) from None
+            raise ImportError(
+                "pandas is required for to_excel(). Install it with: pip install 'pyscrappy[excel]'"
+            ) from None
         df.to_excel(path, index=False)
 
     def save(self, path: str) -> None:

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -33,7 +33,8 @@ class ScrapeResult:
     ``data`` is always a list of dicts — one dict per scraped item.
     Call ``.to_dataframe()`` for a pandas DataFrame, ``.to_json()`` for
     JSON, ``.to_csv()`` for CSV text, ``.to_ndjson()`` for NDJSON,
-    ``.to_yaml()`` for YAML, ``.to_markdown()`` for clean,
+    ``.to_yaml()`` for YAML, ``.to_parquet(path)`` for Parquet,
+    ``.to_excel(path)`` for Excel, ``.to_markdown()`` for clean,
     LLM-ready Markdown, or ``.save(path)`` to write by file extension.
     """
 
@@ -230,18 +231,66 @@ class ScrapeResult:
             envelope, default_flow_style=False, allow_unicode=True, sort_keys=False
         )
 
+    def to_parquet(self, path: str) -> None:
+        """Write ``data`` to a Parquet file at ``path``.
+
+        Raises:
+            ImportError: If pyarrow is not installed.
+        """
+        from pathlib import Path as _Path
+
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "pyarrow is required for to_parquet(). "
+                "Install it with: pip install 'pyscrappy[parquet]'"
+            ) from None
+
+        p = _Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        self.to_dataframe().to_parquet(path, index=False)
+
+    def to_excel(self, path: str) -> None:
+        """Write ``data`` to an Excel (.xlsx) file at ``path``.
+
+        Raises:
+            ImportError: If openpyxl is not installed.
+        """
+        from pathlib import Path as _Path
+
+        try:
+            import openpyxl  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "openpyxl is required for to_excel(). "
+                "Install it with: pip install 'pyscrappy[excel]'"
+            ) from None
+
+        p = _Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        self.to_dataframe().to_excel(path, index=False)
+
     def save(self, path: str) -> None:
         """Write the result to ``path``, choosing format from the extension.
 
         Supported extensions: ``.json`` → :meth:`to_json`, ``.csv`` →
         :meth:`to_csv`, ``.md`` → :meth:`to_markdown`, ``.ndjson`` /
         ``.jsonl`` → :meth:`to_ndjson`, ``.yaml`` / ``.yml`` →
-        :meth:`to_yaml`.
+        :meth:`to_yaml`, ``.parquet`` → :meth:`to_parquet`, ``.xlsx`` →
+        :meth:`to_excel`.
         """
         from pathlib import Path as _Path
 
         p = _Path(path)
         suffix = p.suffix.lower()
+        if suffix == ".parquet":
+            self.to_parquet(path)
+            return
+        if suffix == ".xlsx":
+            self.to_excel(path)
+            return
+
         if suffix == ".json":
             content = self.to_json()
         elif suffix == ".csv":
@@ -255,7 +304,7 @@ class ScrapeResult:
         else:
             raise ValueError(
                 f"Unsupported extension {suffix!r} for save(); "
-                "use .json, .csv, .md, .ndjson, .jsonl, .yaml, or .yml"
+                "use .json, .csv, .md, .ndjson, .jsonl, .yaml, .yml, .parquet, or .xlsx"
             )
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")

--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -275,7 +275,13 @@ class ScrapeResult:
 
         p = _Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        self.to_dataframe().to_excel(path, index=False)
+        try:
+             df = self.to_dataframe()
+        except ImportError:
+             raise ImportError(
+                 "pandas is required for to_excel(). Install it with: pip install 'pyscrappy[excel]'"
+             ) from None
+        df.to_excel(path, index=False)
 
     def save(self, path: str) -> None:
         """Write the result to ``path``, choosing format from the extension.

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -297,6 +297,70 @@ class TestScrapeResult:
         with pytest.raises(ImportError, match="PyYAML is required"):
             result.to_yaml()
 
+    # --- to_parquet -------------------------------------------------------- #
+
+    def test_to_parquet(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        result = ScrapeResult(data=[{"a": 1, "b": "x"}, {"a": 2, "b": "y"}])
+        out_path = tmp_path / "out.parquet"
+        result.to_parquet(str(out_path))
+
+        df = pd.read_parquet(str(out_path))
+        assert len(df) == 2
+        assert list(df.columns) == ["a", "b"]
+        assert df["a"].tolist() == [1, 2]
+        assert df["b"].tolist() == ["x", "y"]
+
+    def test_to_parquet_missing_pyarrow(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "pyarrow":
+                raise ImportError("no pyarrow")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = ScrapeResult(data=[{"a": 1}])
+        with pytest.raises(ImportError, match="pyarrow is required"):
+            result.to_parquet("dummy.parquet")
+
+    # --- to_excel ---------------------------------------------------------- #
+
+    def test_to_excel(self, tmp_path):
+        pytest.importorskip("openpyxl")
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        result = ScrapeResult(data=[{"a": 1, "b": "x"}, {"a": 2, "b": "y"}])
+        out_path = tmp_path / "out.xlsx"
+        result.to_excel(str(out_path))
+
+        df = pd.read_excel(str(out_path))
+        assert len(df) == 2
+        assert list(df.columns) == ["a", "b"]
+        assert df["a"].tolist() == [1, 2]
+        assert df["b"].tolist() == ["x", "y"]
+
+    def test_to_excel_missing_openpyxl(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "openpyxl":
+                raise ImportError("no openpyxl")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = ScrapeResult(data=[{"a": 1}])
+        with pytest.raises(ImportError, match="openpyxl is required"):
+            result.to_excel("dummy.xlsx")
+
     # --- save() extensions ------------------------------------------------- #
 
     def test_save_ndjson_and_jsonl(self, tmp_path):
@@ -323,6 +387,34 @@ class TestScrapeResult:
         for path in (yaml_path, yml_path):
             parsed = yaml.safe_load(path.read_text())
             assert parsed["data"] == [{"a": 1}]
+
+    def test_save_parquet(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        result = ScrapeResult(data=[{"title": "x", "n": 1}])
+        parquet_path = tmp_path / "out.parquet"
+        result.save(str(parquet_path))
+
+        df = pd.read_parquet(str(parquet_path))
+        assert len(df) == 1
+        assert df["title"].iloc[0] == "x"
+        assert df["n"].iloc[0] == 1
+
+    def test_save_excel(self, tmp_path):
+        pytest.importorskip("openpyxl")
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        result = ScrapeResult(data=[{"title": "x", "n": 1}])
+        excel_path = tmp_path / "out.xlsx"
+        result.save(str(excel_path))
+
+        df = pd.read_excel(str(excel_path))
+        assert len(df) == 1
+        assert df["title"].iloc[0] == "x"
+        assert df["n"].iloc[0] == 1
 
     def test_save_ndjson_empty_data(self, tmp_path):
         result = ScrapeResult(data=[])


### PR DESCRIPTION
## Summary

Adds Parquet and Excel exporters to `ScrapeResult`.

### Changes

* Add `ScrapeResult.to_parquet(path)` using pandas and PyArrow.
* Add `ScrapeResult.to_excel(path)` using pandas and openpyxl.
* Add `.parquet` and `.xlsx` extension dispatch to `ScrapeResult.save()`.
* Add optional `parquet` and `excel` dependencies.
* Add clear `ImportError` messages with installation hints.
* Add tests for exporters, dependency handling, and `save()` dispatch.

### Testing

* `tests/test_core/test_models.py`: 42 passed
* Full test suite: 568 passed, 2 skipped, 19 deselected

Closes #161
