### PR TITLE
fix: normalize multi-valued ::attr() values

### DIFF
--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -26,6 +26,8 @@ from typing import Any
 from bs4 import BeautifulSoup, Tag
 from lxml import etree
 
+from pyscrappy.generic.adaptive import _attr_str
+
 # CSS with a trailing ``::text`` / ``::attr(name)`` pseudo-element, Scrapy-style.
 _PSEUDO = re.compile(r"^(?P<sel>.*?)::(?P<kind>text|attr\((?P<attr>[^)]+)\))$", re.DOTALL)
 
@@ -283,7 +285,7 @@ class SelectorList(list):
         if self._pseudo == "text":
             return [s.text() for s in self]
         if self._pseudo == "attr":
-            return [str(s.attrs[self._attr]) for s in self if self._attr in s.attrs]
+            return [_attr_str(s.attrs[self._attr]) for s in self if self._attr in s.attrs]
         return [s.html() for s in self]
 
     def get(self, default: str | None = None) -> str | None:

--- a/tests/test_generic/test_selector.py
+++ b/tests/test_generic/test_selector.py
@@ -41,6 +41,20 @@ class TestCss:
     def test_css_attr_pseudo(self):
         assert _page().css("a::attr(href)").getall() == ["/a", "/b"]
 
+    def test_css_attr_pseudo_normalizes_class(self):
+        assert Selector('<a class="x y">link</a>').css("a::attr(class)").get() == "x y"
+
+    def test_css_attr_pseudo_normalizes_rel(self):
+        html = '<a rel="nofollow noopener">link</a>'
+        assert Selector(html).css("a::attr(rel)").get() == "nofollow noopener"
+
+    def test_css_attr_pseudo_preserves_scalar_attribute(self):
+        assert Selector('<a href="/p">link</a>').css("a::attr(href)").get() == "/p"
+
+    def test_css_attr_pseudo_getall_normalizes_multi_valued_attributes(self):
+        html = '<a class="x y">one</a><a class="m n">two</a>'
+        assert Selector(html).css("a::attr(class)").getall() == ["x y", "m n"]
+
     def test_css_attr_missing_attribute_uses_default(self):
         assert Selector("<a>x</a>").css("a::attr(href)").get("MISSING") == "MISSING"
 


### PR DESCRIPTION
## Summary

- normalize BeautifulSoup list-valued attributes returned by `::attr()`
- reuse the existing `_attr_str()` normalization helper
- preserve scalar attribute behavior
- add regression coverage for `class`, `rel`, `href`, and `.getall()`

## Problem

BeautifulSoup represents multi-valued attributes such as `class` and `rel` as list-like values.

`SelectorList._values()` previously converted those values directly with `str()`, producing Python-style output such as:

```text
['x', 'y']
```
instead of:
`x y`

## Testing
py -3.13 -m ruff check src/ - passed
py -3.13 -m pytest tests/test_generic/test_selector.py -v - 28 passed
py -3.13 -m pytest tests/ -v - 565 passed, 3 unrelated failures
git diff --check - passed

The 3 full-suite failures are existing environment-specific Windows Application Control failures while importing pandas DLLs in dataframe/CSV tests. They are unrelated to selector behavior.

Closes #167