### PR TITLE
fix(core): handle malformed Markdown heading levels

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -83,7 +83,12 @@ class ScrapeResult:
             if title:
                 parts.append(f"# {title}")
             for heading in text.get("headings", []):
-                level = int(heading.get("level", "h2")[1:])
+                raw_level = str(heading.get("level") or "h2")
+                level = (
+                    max(1, min(int(raw_level[1:]), 6))
+                    if raw_level[:1].lower() == "h" and raw_level[1:].isdigit()
+                    else 2
+                )
                 parts.append(f"{'#' * level} {heading['text']}")
             body = text.get("text")
             if body:

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -145,6 +145,32 @@ class TestScrapeResult:
         assert "| Name | Age |" in md
         assert "| Alice | 30 |" in md
 
+    @pytest.mark.parametrize(
+        ("raw_level", "expected_prefix"),
+        [
+            ("h1", "#"),
+            ("H6", "######"),
+            ("h0", "#"),
+            ("h9", "######"),
+            ("title", "##"),
+            ("", "##"),
+            (None, "##"),
+        ],
+    )
+    def test_to_markdown_handles_nonstandard_heading_levels(self, raw_level, expected_prefix):
+        result = ScrapeResult(
+            data=[
+                {
+                    "text": {
+                        "text": "body",
+                        "headings": [{"level": raw_level, "text": "Heading"}],
+                    }
+                }
+            ]
+        )
+
+        assert result.to_markdown().splitlines()[0] == f"{expected_prefix} Heading"
+
     def test_to_markdown_preserves_late_table_columns(self):
         result = ScrapeResult(
             data=[


### PR DESCRIPTION
## Summary
- parse heading levels defensively instead of raising on malformed user data
- preserve valid h1-h6 headings and clamp numeric levels to Markdown's h1-h6 range
- fall back to h2 for missing, empty, None, and non-heading values
- add regression coverage for valid, malformed, and out-of-range levels

## Verification
- `pytest tests/test_core/test_models.py -q` (39 passed, 5 skipped)
- `pytest tests -q` (546 passed, 9 skipped, 19 deselected)
- `ruff check src tests`
- `ruff format --check src tests`

Fixes #176