### PR TITLE
fix(models): don't crash to_markdown() on a malformed heading level

### DIFF
--- a/src/pyscrappy/core/models.py
+++ b/src/pyscrappy/core/models.py
@@ -74,6 +74,20 @@ class ScrapeResult:
         return "\n\n---\n\n".join(b for b in blocks if b)
 
     @staticmethod
+    def _heading_level(raw: Any) -> int:
+        """Parse a heading's ``level`` field, defaulting/clamping to 1-6.
+
+        ``TextExtractor`` only ever emits ``h1``-``h6``, but ``ScrapeResult``
+        also accepts user-supplied ``data``, where a malformed level (e.g.
+        ``"title"``, ``""``, ``None``) must degrade to a sane heading rather
+        than crash the whole ``to_markdown()`` call.
+        """
+        text = str(raw) if raw is not None else ""
+        if text[:1].lower() == "h" and text[1:].isdigit():
+            return max(1, min(int(text[1:]), 6))
+        return 2
+
+    @staticmethod
     def _item_to_markdown(item: dict[str, Any]) -> str:
         text = item.get("text")
         # Rich generic-scraper item: text is a dict with paragraphs/headings.
@@ -83,7 +97,7 @@ class ScrapeResult:
             if title:
                 parts.append(f"# {title}")
             for heading in text.get("headings", []):
-                level = int(heading.get("level", "h2")[1:])
+                level = ScrapeResult._heading_level(heading.get("level"))
                 parts.append(f"{'#' * level} {heading['text']}")
             body = text.get("text")
             if body:

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -145,6 +145,34 @@ class TestScrapeResult:
         assert "| Name | Age |" in md
         assert "| Alice | 30 |" in md
 
+    @pytest.mark.parametrize("bad_level", ["title", "", None, "h9", "h0"])
+    def test_to_markdown_handles_a_malformed_heading_level(self, bad_level):
+        result = ScrapeResult(
+            data=[
+                {
+                    "text": {
+                        "text": "body",
+                        "headings": [{"level": bad_level, "text": "X"}],
+                    }
+                }
+            ]
+        )
+        md = result.to_markdown()
+        assert "X" in md
+        heading_line = next(line for line in md.splitlines() if line.endswith(" X"))
+        assert 1 <= heading_line.count("#") <= 6
+
+    @pytest.mark.parametrize(
+        ("level", "expected_hashes"),
+        [("h1", 1), ("h6", 6), ("h9", 6), ("h0", 1)],
+    )
+    def test_to_markdown_clamps_out_of_range_heading_levels(self, level, expected_hashes):
+        result = ScrapeResult(
+            data=[{"text": {"text": "", "headings": [{"level": level, "text": "X"}]}}]
+        )
+        md = result.to_markdown()
+        assert md.splitlines()[0] == f"{'#' * expected_hashes} X"
+
     def test_to_markdown_escapes_table_cells(self):
         result = ScrapeResult(
             data=[


### PR DESCRIPTION
Fixes #176

## Summary

`ScrapeResult._item_to_markdown()` sliced `heading["level"][1:]` and `int()`'d it unconditionally (`int(heading.get("level", "h2")[1:])`), so any level not shaped like `h1`-`h6` raised `ValueError` (`"title"`, `""`) or `TypeError` (`None`) instead of degrading gracefully. `TextExtractor` only ever emits `h1`-`h6`, but `ScrapeResult` also accepts user-supplied `data` (a documented, supported use), where one malformed heading crashed the entire `to_markdown()` call rather than just that heading.

## Fix

Added `_heading_level()`, which parses the level defensively — falls back to `h2` for anything not shaped `h<digits>`, and clamps in-range-shaped-but-out-of-bounds values (`h9`, `h0`) to 1-6 — and routed the heading loop through it, per the fix sketched in the issue.

## Testing

- `test_to_markdown_handles_a_malformed_heading_level` — parametrized over `"title"`, `""`, `None`, `"h9"`, `"h0"`: each renders without raising, with a heading line carrying 1-6 `#`s.
- `test_to_markdown_clamps_out_of_range_heading_levels` — pins the exact clamped output for `h1`, `h6`, `h9`, `h0`.
- Confirmed both fail against the old code (`git stash` on `models.py`, re-ran): 7 of 9 new cases failed with the exact `ValueError`/`TypeError`/assertion mismatches the issue describes.

```
uv run pytest tests/ -q
# 535 passed, 9 skipped, 19 deselected
uv run ruff check src/pyscrappy/core/models.py tests/test_core/test_models.py
# All checks passed!
```

`mypy src/pyscrappy/core/models.py` reports 4 pre-existing errors (missing `pandas`/`yaml` stubs, two `no-any-return` findings on unrelated lines) — none touch `_heading_level` or the lines I changed; unrelated to this fix.