### PR TITLE
Release 1.6.0: shared attr-normalization refactor + changelog for merged fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to PyScrappy are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-25
+
+### Fixed
+- **`::attr()` normalizes multi-valued attributes.** `css("a::attr(class)")` (and other list-valued attributes like `rel`) now return a space-joined string (`"nav active"`) instead of a Python list repr (`"['nav', 'active']"`); single-valued attributes are unchanged (#167).
+- **`to_markdown()` preserves ragged table cells.** Table columns are now the union of keys across all rows (first-seen order), so surplus cells in ragged tables — which `TableExtractor` keeps under `column_N` keys — are no longer dropped from the rendered Markdown (#168).
+- **`to_markdown()` no longer crashes on a malformed heading level.** A heading whose `level` isn't `h1`-`h6` (e.g. from user-supplied `data`) now falls back to a default and is clamped into range, instead of raising `ValueError` (#176).
+
+### Changed
+- Attribute-normalization helpers moved to a shared `pyscrappy.generic._attrs` module, so the selector no longer imports a private helper out of the adaptive module (internal cleanup; no API change).
+
 ## [1.5.9] - 2026-08-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.5.9"
+version = "1.6.0"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.5.9",
+  "version": "1.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.5.9",
+      "version": "1.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.5.9"
+__version__ = "1.6.0"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/generic/_attrs.py
+++ b/src/pyscrappy/generic/_attrs.py
@@ -1,0 +1,26 @@
+"""Shared normalization for HTML attribute values.
+
+BeautifulSoup represents multi-valued attributes (``class``, ``rel``, ``headers``,
+…) as a *list*, and single-valued ones as a string. Both the adaptive fingerprint
+scorer and the ``::attr()`` selector need the same normalization, so it lives
+here rather than one reaching into the other's internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def attr_to_str(v: Any) -> str:
+    """A multi-valued attribute (a list) as a space-joined string; a scalar as-is.
+
+    ``["nav", "active"]`` -> ``"nav active"``; ``"/page"`` -> ``"/page"``.
+    """
+    return " ".join(v) if isinstance(v, list) else str(v)
+
+
+def attr_to_list(v: Any) -> list[str]:
+    """An attribute value as a list of tokens (empty for a missing value)."""
+    if not v:
+        return []
+    return v if isinstance(v, list) else [v]

--- a/src/pyscrappy/generic/adaptive.py
+++ b/src/pyscrappy/generic/adaptive.py
@@ -34,6 +34,8 @@ from typing import Any
 
 from bs4 import Tag
 
+from pyscrappy.generic._attrs import attr_to_list, attr_to_str
+
 # Text that changes between scrapes shouldn't anchor an element. A cell that is
 # mostly digits / currency / date-like is treated as volatile and down-weighted.
 _VOLATILE = re.compile(
@@ -71,14 +73,14 @@ def _text_is_volatile(text: str | None) -> bool:
 
 def fingerprint(el: Tag) -> dict[str, Any]:
     """Capture the identifying features of ``el`` as a JSON-serializable dict."""
-    attrs = {k: _attr_str(v) for k, v in (el.attrs or {}).items()}
+    attrs = {k: attr_to_str(v) for k, v in (el.attrs or {}).items()}
     text = el.get_text(strip=True) or None
     anchor_tag, anchor_id, anchor_depth = _nearest_stable_anchor(el)
     return {
         "tag": el.name,
         "id": attrs.get("id"),
         "stable_attr": _first_stable_attr(attrs),
-        "classes": sorted(_attr_list(el.get("class"))),
+        "classes": sorted(attr_to_list(el.get("class"))),
         "attrs": {k: v for k, v in attrs.items() if k not in ("id", "class")},
         "text": text,
         "text_volatile": _text_is_volatile(text),
@@ -88,16 +90,6 @@ def fingerprint(el: Tag) -> dict[str, Any]:
         "anchor_depth": anchor_depth,
         "siblings": _sibling_tags(el),
     }
-
-
-def _attr_str(v: Any) -> str:
-    return " ".join(v) if isinstance(v, list) else str(v)
-
-
-def _attr_list(v: Any) -> list[str]:
-    if not v:
-        return []
-    return v if isinstance(v, list) else [v]
 
 
 def _first_stable_attr(attrs: dict[str, str]) -> str | None:

--- a/src/pyscrappy/generic/selector.py
+++ b/src/pyscrappy/generic/selector.py
@@ -26,7 +26,7 @@ from typing import Any
 from bs4 import BeautifulSoup, Tag
 from lxml import etree
 
-from pyscrappy.generic.adaptive import _attr_str
+from pyscrappy.generic._attrs import attr_to_str
 
 # CSS with a trailing ``::text`` / ``::attr(name)`` pseudo-element, Scrapy-style.
 _PSEUDO = re.compile(r"^(?P<sel>.*?)::(?P<kind>text|attr\((?P<attr>[^)]+)\))$", re.DOTALL)
@@ -285,7 +285,7 @@ class SelectorList(list):
         if self._pseudo == "text":
             return [s.text() for s in self]
         if self._pseudo == "attr":
-            return [_attr_str(s.attrs[self._attr]) for s in self if self._attr in s.attrs]
+            return [attr_to_str(s.attrs[self._attr]) for s in self if self._attr in s.attrs]
         return [s.html() for s in self]
 
     def get(self, default: str | None = None) -> str | None:


### PR DESCRIPTION
Cuts the 1.6.0 release. A small internal refactor plus the CHANGELOG for the contributor fixes merged since 1.5.9.

## Refactor
The `::attr()` fix (#167 via #175) left `selector.py` importing `adaptive.py`'s private `_attr_str`, coupling the selector to the adaptive module's internals (a rename there would silently break the selector). Moved the normalization helpers to a shared `pyscrappy.generic._attrs` module (`attr_to_str` / `attr_to_list`); both `adaptive.py` and `selector.py` import from it. No API or behavior change.

## CHANGELOG (1.6.0)
Records the contributor fixes already merged to main since 1.5.9:
- `::attr()` normalizes multi-valued attributes (#167)
- `to_markdown()` preserves ragged table cells (#168)
- `to_markdown()` doesn't crash on a malformed heading level (#176)
- plus the `_attrs` refactor above.

## Version
Bumped to **1.6.0** across all four sites (pyproject, `__init__`, server.json x2). Patch was at `.9`, so this rolls to the next minor.

## Testing
- Full suite: 579 passed, ruff check + format clean.
- Verified the refactor: `::attr(class)` still returns `"x y"`, `adaptive` no longer exposes `_attr_str`, adaptive+selector tests green.