### PR TITLE
fix(http): bound the on-disk response cache

### DIFF
--- a/src/pyscrappy/core/async_http.py
+++ b/src/pyscrappy/core/async_http.py
@@ -266,7 +266,9 @@ class AsyncHttpClient:
         if self.config.cache_ttl > 0:
             _SHARED_CACHE.put(key, resp, self.config.cache_max_size)
             if self.config.cache_dir:
-                _disk_cache_for(self.config.cache_dir).put(key, resp)
+                _disk_cache_for(self.config.cache_dir).put(
+                    key, resp, self.config.cache_ttl, self.config.cache_dir_max_size
+                )
 
     async def _rate_limit(self, url: str, min_delay: float | None = None) -> None:
         domain = urlparse(url).netloc

--- a/src/pyscrappy/core/config.py
+++ b/src/pyscrappy/core/config.py
@@ -71,6 +71,11 @@ class ScraperConfig:
             hits survive across process restarts and separate runs — the in-memory
             cache still fronts it for speed. ``None`` (the default) keeps caching
             in memory only.
+        cache_dir_max_size: Maximum number of live entries in the on-disk cache,
+            mirroring ``cache_max_size`` for the in-memory tier. A long-running
+            process (or a large crawl reusing one ``cache_dir``) stays within
+            this cap rather than growing one file per distinct URL forever.
+            Defaults to ``512``. Only takes effect when ``cache_dir`` is set.
         impersonate: Impersonate a real browser's TLS/JA3 fingerprint, to get
             past anti-bot filters that block plain clients (e.g. ``"chrome"``,
             ``"chrome124"``, ``"safari"``, ``"firefox"``). Works on both the sync
@@ -98,6 +103,7 @@ class ScraperConfig:
     cache_ttl: float = 0.0
     cache_max_size: int = 512
     cache_dir: str | None = None
+    cache_dir_max_size: int = 512
     impersonate: str | None = None
     retry_jitter: bool = True
 

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -130,11 +130,21 @@ class _DiskCache:
     read against the caller's ``ttl``; an expired file is deleted lazily. All ops
     are best-effort — a caching layer must never break a scrape, so any OS/JSON
     error just behaves as a miss.
+
+    Bounded like :class:`_ResponseCache`: ``put()`` prunes afterward, sweeping
+    any expired entry (so a key fetched once and never again does not linger
+    forever) and then, if the directory still exceeds ``max_size``, deleting
+    the oldest files by mtime until it does not. Unlike the in-memory LRU, a
+    read does not refresh recency here — mtime is set-on-write, not set-on-hit
+    — so a cold key that keeps getting read but never rewritten ages out under
+    a full cache; that trade is what keeps pruning an O(entries) directory
+    scan instead of a second per-entry access-time write on every hit.
     """
 
-    def __init__(self, cache_dir: str) -> None:
+    def __init__(self, cache_dir: str, max_size: int = _DEFAULT_CACHE_MAX_SIZE) -> None:
         self._dir = Path(cache_dir)
         self._lock = threading.Lock()
+        self._max_size = max_size
 
     def _path(self, key: str) -> Path:
         return self._dir / (hashlib.sha256(key.encode("utf-8")).hexdigest() + ".json")
@@ -168,7 +178,9 @@ class _DiskCache:
         except Exception:  # noqa: BLE001 - a bad cache entry is a miss, not an error
             return None
 
-    def put(self, key: str, resp: httpx.Response) -> None:
+    def put(
+        self, key: str, resp: httpx.Response, ttl: float | None = None, max_size: int | None = None
+    ) -> None:
         tmp = None
         try:
             self._dir.mkdir(parents=True, exist_ok=True)
@@ -206,6 +218,35 @@ class _DiskCache:
                     tmp.unlink(missing_ok=True)
                 except OSError:
                     pass
+        self._prune(ttl, self._max_size if max_size is None else max_size)
+
+    def _prune(self, ttl: float | None, max_size: int) -> None:
+        """Sweep expired entries, then trim to ``max_size`` (oldest mtime first).
+
+        Called after every write so growth stays bounded even for a key that is
+        never re-requested — ``get()``'s lazy expiry only reaps the ones that
+        are. Best-effort like the rest of this class: never raises.
+        """
+        try:
+            with self._lock:
+                now = time.time()
+                live: list[tuple[float, Path]] = []
+                for f in self._dir.glob("*.json"):
+                    try:
+                        if ttl is not None and ttl > 0:
+                            data = json.loads(f.read_text(encoding="utf-8"))
+                            if now - data["ts"] > ttl:
+                                f.unlink(missing_ok=True)
+                                continue
+                        live.append((f.stat().st_mtime, f))
+                    except (OSError, ValueError, KeyError):
+                        continue  # unreadable/malformed entry: not this pass's job
+                if len(live) > max_size:
+                    live.sort(key=lambda entry: entry[0])
+                    for _, f in live[: len(live) - max_size]:
+                        f.unlink(missing_ok=True)
+        except OSError:
+            pass
 
     def clear(self) -> None:
         try:
@@ -504,7 +545,9 @@ class HttpClient:
         if self.config.cache_ttl > 0:
             _SHARED_CACHE.put(key, resp, self.config.cache_max_size)
             if self.config.cache_dir:
-                _disk_cache_for(self.config.cache_dir).put(key, resp)
+                _disk_cache_for(self.config.cache_dir).put(
+                    key, resp, self.config.cache_ttl, self.config.cache_dir_max_size
+                )
 
     @staticmethod
     def clear_cache() -> None:

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -2,6 +2,8 @@
 
 import os
 import random
+import shutil
+import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -727,3 +729,56 @@ class TestHttpClientCaching:
         assert hit is not None
         assert hit.headers.get_list("Set-Cookie") == ["a=1", "b=2"]
         assert hit.headers.get("Content-Type") == "text/html"
+
+    def _disk_resp(self, url):
+        return httpx.Response(200, content=b"x", request=httpx.Request("GET", url))
+
+    def test_disk_cache_evicts_oldest_past_max_size(self, tmp_path):
+        # #166: an unbounded on-disk cache grows one file per distinct URL
+        # forever. put() must cap it, keeping the most recently written entries.
+        import pyscrappy.core.http as http_mod
+
+        dc = http_mod._DiskCache(str(tmp_path / "capped"), max_size=5)
+        for i in range(20):
+            dc.put(f"http://x/{i}", self._disk_resp(f"http://x/{i}"), ttl=100)
+
+        remaining = list((tmp_path / "capped").glob("*.json"))
+        assert len(remaining) == 5
+        # The 5 most recently written keys are the last 5 (0..19 in order).
+        for i in range(15, 20):
+            assert dc.get(f"http://x/{i}", 100) is not None
+        for i in range(0, 15):
+            assert dc.get(f"http://x/{i}", 100) is None
+
+    def test_disk_cache_put_max_size_overrides_the_instance_default(self, tmp_path):
+        import pyscrappy.core.http as http_mod
+
+        dc = http_mod._DiskCache(str(tmp_path / "override"))  # default max_size
+        for i in range(10):
+            dc.put(f"http://x/{i}", self._disk_resp(f"http://x/{i}"), ttl=100, max_size=3)
+        assert len(list((tmp_path / "override").glob("*.json"))) == 3
+
+    def test_disk_cache_sweeps_an_expired_entry_even_if_never_reread(self, tmp_path):
+        # get()'s lazy expiry only catches a key that is re-requested. put()'s
+        # prune must also reap a key that expires and is never asked for again.
+        import pyscrappy.core.http as http_mod
+
+        dc = http_mod._DiskCache(str(tmp_path / "sweep"), max_size=100)
+        dc.put("http://x/expired", self._disk_resp("http://x/expired"), ttl=0.01)
+        time.sleep(0.05)
+        dc.put("http://x/other", self._disk_resp("http://x/other"), ttl=0.01)
+
+        remaining = list((tmp_path / "sweep").glob("*.json"))
+        assert len(remaining) == 1
+        assert dc.get("http://x/other", 0.01) is not None
+
+    def test_disk_cache_prune_failure_does_not_raise(self, tmp_path):
+        # A prune that cannot even list the directory (e.g. removed out from
+        # under the cache) must behave as a no-op, not break the write it follows.
+        import pyscrappy.core.http as http_mod
+
+        cache_dir = tmp_path / "gone"
+        dc = http_mod._DiskCache(str(cache_dir), max_size=1)
+        dc.put("http://x/a", self._disk_resp("http://x/a"), ttl=100)
+        shutil.rmtree(cache_dir)
+        dc.put("http://x/b", self._disk_resp("http://x/b"), ttl=100)  # must not raise


### PR DESCRIPTION
Fixes #166

## Summary

`_DiskCache.put()` only ever wrote a new file — nothing pruned it — so a key fetched once and never again (e.g. a large crawl, or a long-running MCP server with `cache_dir` set) stayed on disk forever. The in-memory `_ResponseCache` already has an LRU cap for exactly this reason (`cache_max_size`); the disk tier had no equivalent.

## Fix

`put()` now prunes after every write:
1. Sweep any expired entry first, so one that is never re-requested doesn't linger — unlike `get()`'s lazy expiry, which only reaps a key that's actually asked for again.
2. If the directory still exceeds `max_size`, delete the oldest files by mtime until it doesn't.

Both `_DiskCache.__init__` and `put()` take the cap, mirroring `_ResponseCache`'s existing `put(key, resp, max_size=None)` per-call-override pattern. Added `ScraperConfig.cache_dir_max_size` (default 512, matching `cache_max_size`) and threaded it through both the sync and async `_cache_put()`, which also now pass `cache_ttl` through so the sweep has something to check against.

## Testing

Four new tests in `TestHttpClientCaching`, covering the issue's own three required cases plus the per-call override:
- `test_disk_cache_evicts_oldest_past_max_size` — put 20, cap 5 → exactly 5 remain, the 5 most recently written.
- `test_disk_cache_sweeps_an_expired_entry_even_if_never_reread` — an entry that expires between two `put()` calls to *different* keys is gone after the second, without ever being `get()`'d.
- `test_disk_cache_prune_failure_does_not_raise` — the cache dir is removed out from under the cache; the following `put()` doesn't raise.
- `test_disk_cache_put_max_size_overrides_the_instance_default` — a per-call `max_size` on `put()` wins over the instance default.

Confirmed all four fail against the pre-fix code (`git stash` on the three source files, re-ran): each raises `TypeError` for the parameter that doesn't exist yet.

```
uv run pytest tests/ -q
# 530 passed, 9 skipped, 19 deselected
uv run ruff check src/pyscrappy/core/http.py src/pyscrappy/core/async_http.py src/pyscrappy/core/config.py tests/test_core/test_http.py
# All checks passed!
```

`mypy` reports 6 pre-existing errors in `http.py`/`async_http.py` about `Response | _StealthResponse` typing at `_cache_put()`'s existing call sites — identical set, same messages, only shifted line numbers, confirmed by running mypy against the unmodified files. Unrelated to this change.