### PR TITLE
docs: changelog + README for exporters and bounded disk cache; bump to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to PyScrappy are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-08-27
+
+### Added
+- **Parquet and Excel exporters.** `ScrapeResult.to_parquet(path)` (pandas + pyarrow) and `ScrapeResult.to_excel(path)` (pandas + openpyxl) write results to those formats, and `save()` dispatches `.parquet` / `.xlsx` by extension. Installed via the new `pyscrappy[parquet]` / `pyscrappy[excel]` extras; a missing dependency raises a clear `ImportError` naming the extra to install (#161).
+
+### Fixed
+- **On-disk response cache is now bounded.** `_DiskCache.put()` prunes after every write — sweeping expired entries (so a key that is never re-requested no longer lingers, unlike `get()`'s lazy expiry) and then trimming the oldest by mtime past `ScraperConfig.cache_dir_max_size` (default 512, mirroring the in-memory `cache_max_size`). Previously a `cache_dir` grew one file per distinct URL forever (#166).
+
 ## [1.6.0] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ pip install 'pyscrappy[mcp]'
 # Stealth (TLS-fingerprint impersonation to bypass anti-bot filters)
 pip install 'pyscrappy[stealth]'
 
+# Parquet / Excel export (ScrapeResult.to_parquet() / .to_excel())
+pip install 'pyscrappy[parquet]'
+pip install 'pyscrappy[excel]'
+
 # Everything
 pip install 'pyscrappy[all]'
 ```
@@ -271,6 +275,10 @@ result = scrape("https://en.wikipedia.org/wiki/Web_scraping")
 
 print(result.to_markdown())   # feed straight to an LLM
 # ...or result.to_json() / result.to_dataframe()
+
+# Write to a file — format inferred from the extension:
+result.save("out.json")       # .json .csv .md .ndjson .yaml .parquet .xlsx
+# (.parquet needs pyscrappy[parquet]; .xlsx needs pyscrappy[excel])
 ```
 
 Prefer raw fields? Every result is a `ScrapeResult` with `.data` (a list of
@@ -425,6 +433,7 @@ config = ScraperConfig(
     render_js="auto",        # auto-detect if JS rendering is needed
     cache_ttl=0,             # response cache TTL in seconds (0 = disabled)
     cache_dir=None,          # also persist the cache to disk (survives restarts)
+    cache_dir_max_size=512,  # max live entries kept on disk before oldest are pruned
     impersonate=None,        # e.g. "chrome" to spoof a browser's TLS fingerprint (see below)
 )
 
@@ -580,6 +589,10 @@ still fronts it for speed; a disk hit is promoted back into memory.
 ```python
 config = ScraperConfig(cache_ttl=3600, cache_dir="~/.cache/pyscrappy")
 ```
+
+The on-disk cache is bounded too: each write prunes expired entries and trims the
+oldest past `cache_dir_max_size` (default `512`), so a `cache_dir` doesn't grow
+one file per distinct URL forever.
 
 `clear_cache()` empties the in-memory cache; the on-disk cache persists by
 design — delete its `cache_dir` to clear it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.6.0"
+version = "1.6.1"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 __all__ = [
     # Core


### PR DESCRIPTION
Two features merged after the 1.6.0 release cut (#174 and #180) had no CHANGELOG entry or version bump. This records them and bumps to **1.6.1**.

## Changelog (1.6.1)
- **Added** — Parquet/Excel exporters: `ScrapeResult.to_parquet()` / `to_excel()`, `save()` extension dispatch, and the `pyscrappy[parquet]` / `pyscrappy[excel]` extras (#161, via #174).
- **Fixed** — the on-disk response cache is now bounded: `put()` sweeps expired entries and trims oldest past `cache_dir_max_size` (default 512), so a `cache_dir` no longer grows one file per URL forever (#166, via #180).

## README
- New `[parquet]` / `[excel]` extras in the install list.
- `result.save("out.parquet"/".xlsx")` shown in the quick start, with the extras each format needs.
- Disk-cache section notes the new `cache_dir_max_size` bound; added the field to the config example.

## Version
Bumped across all four sites (pyproject.toml, `__init__.py`, server.json ×2).

589 passed, ruff clean.