### PR TITLE
fix(http): on_retry reports target URL on 429 under scraper_api (1.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to PyScrappy are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-09-01
+
+### Fixed
+- **`on_retry` reports the target URL on a 429 under `scraper_api`.** The sync client's rate-limit (429) retry branch passed the rewritten provider endpoint (e.g. `api.scraperapi.com`) to the `on_retry` hook instead of the logical target URL, unlike every other hook call and unlike the async client. Retry callbacks/metrics now attribute a rate-limited retry to the site being scraped, consistent with #171.
+
 ## [1.6.1] - 2026-08-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyscrappy"
-version = "1.6.1"
+version = "1.6.2"
 description = "A robust, all-in-one Python web scraping toolkit"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mldsveda/PyScrappy",
     "source": "github"
   },
-  "version": "1.6.1",
+  "version": "1.6.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "pyscrappy",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/pyscrappy/__init__.py
+++ b/src/pyscrappy/__init__.py
@@ -103,7 +103,7 @@ for _cls in (
     register(_cls.name, _cls)
 del _cls
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 __all__ = [
     # Core

--- a/src/pyscrappy/core/http.py
+++ b/src/pyscrappy/core/http.py
@@ -391,7 +391,11 @@ class HttpClient:
                     if attempt < self.config.max_retries:
                         logger.warning("Rate-limited on %s, retrying in %.1fs", url, retry_after)
                         _fire(
-                            self.config.on_retry, url, attempt, retry_after, "429 Too Many Requests"
+                            self.config.on_retry,
+                            target_url,
+                            attempt,
+                            retry_after,
+                            "429 Too Many Requests",
                         )
                         time.sleep(retry_after)
                         continue

--- a/tests/test_core/test_http.py
+++ b/tests/test_core/test_http.py
@@ -888,3 +888,32 @@ class TestObservabilityHooks:
         client.get("https://target.example.com/page")
         assert seen == ["https://target.example.com/page"]  # not api.scraperapi.com
         client.close()
+
+    def test_on_retry_429_reports_target_url_not_scraper_api_endpoint(self):
+        # A 429 retry under scraper_api routing must report the logical target
+        # URL, like every other hook (#171) — the async path already does, the
+        # sync 429 branch previously leaked the provider endpoint.
+        seen = []
+        config = ScraperConfig(
+            rate_limit=0,
+            retry_delay=0,
+            max_retries=3,
+            scraper_api={"provider": "scraperapi", "api_key": "KEY"},
+            on_retry=lambda url, attempt, delay, error: seen.append(url),
+        )
+        client = HttpClient(config)
+
+        rl = MagicMock(spec=httpx.Response)
+        rl.status_code = 429
+        rl.headers = {}
+        ok = MagicMock(spec=httpx.Response)
+        ok.status_code = 200
+        ok.headers = {}
+        ok.raise_for_status = MagicMock()
+        mock = MagicMock()
+        mock.get.side_effect = [rl, ok]  # 429 then success
+        client._client = mock
+
+        client.get("https://target.example.com/page")
+        assert seen == ["https://target.example.com/page"]  # not api.scraperapi.com
+        client.close()


### PR DESCRIPTION
## Bug
The sync HTTP client's **429 (rate-limit) retry** branch passed the rewritten `scraper_api` provider endpoint to the `on_retry` hook instead of the logical target URL.

```python
# http.py, 429 branch (before)
_fire(self.config.on_retry, url, attempt, retry_after, "429 ...")  # url == api.scraperapi.com
```

Every other hook call in the same method already passes `target_url` — `on_request`, and the 5xx and `RequestError` `on_retry` branches — and the **async client's 429 branch does too**. So this was a sync/async divergence: the #171 fix ("hooks report the logical target URL, not the provider endpoint") was applied everywhere except the sync 429 path.

## Impact
With `scraper_api` configured, a rate-limited retry fired `on_retry` with `api.scraperapi.com` instead of the site being scraped, so a user's retry dashboard/metrics misattributed the retry.

## Fix
One line: pass `target_url` in the 429 branch, matching the siblings and the async client.

## Test
Added `test_on_retry_429_reports_target_url_not_scraper_api_endpoint` (mirrors the existing `on_request` scraper_api test). **Regression-proven:** it fails on the old code (hook received the provider endpoint) and passes with the fix.

590 passed, ruff clean. Bumped to 1.6.2 across all four version sites + CHANGELOG.